### PR TITLE
refactor(jobdb): add jobdb v2 interface, objectID as primary key

### DIFF
--- a/store/jobdb/job_db.go
+++ b/store/jobdb/job_db.go
@@ -23,6 +23,7 @@ type PieceJob struct {
 	Done            bool
 }
 
+// JobDB use txhash as primary key
 type JobDB interface {
 	CreateUploadPayloadJob(txHash []byte, info *ptypesv1pb.ObjectInfo) (uint64, error)
 	SetObjectCreateHeightAndObjectID(txHash []byte, height uint64, objectID uint64) error
@@ -37,4 +38,22 @@ type JobDB interface {
 	GetSecondaryJob(txHash []byte) ([]*PieceJob, error)
 	SetPrimaryPieceJobDone(txHash []byte, piece *PieceJob) error
 	SetSecondaryPieceJobDone(txHash []byte, piece *PieceJob) error
+}
+
+// JobDBV2 use objectID as primary key
+type JobDBV2 interface {
+	CreateUploadPayloadJobV2(info *ptypesv1pb.ObjectInfo) (uint64, error)
+	// SetObjectCreateHeightAndObjectID maybe useless
+	// SetObjectCreateHeightAndObjectID(txHash []byte, height uint64, objectID uint64) error
+
+	GetObjectInfoV2(objectID uint64) (*ptypesv1pb.ObjectInfo, error)
+	GetJobContextV2(jobId uint64) (*ptypesv1pb.JobContext, error)
+
+	SetUploadPayloadJobStateV2(jobId uint64, state string, timestamp int64) error
+	SetUploadPayloadJobJobErrorV2(jobID uint64, jobState string, jobErr string, timestamp int64) error
+
+	GetPrimaryJobV2(objectID uint64) ([]*PieceJob, error)
+	GetSecondaryJobV2(objectID uint64) ([]*PieceJob, error)
+	SetPrimaryPieceJobDoneV2(objectID uint64, piece *PieceJob) error
+	SetSecondaryPieceJobDoneV2(objectID uint64, piece *PieceJob) error
 }

--- a/store/jobdb/jobsql/job_meta.go
+++ b/store/jobdb/jobsql/job_meta.go
@@ -18,6 +18,7 @@ type JobMetaImpl struct {
 	db *gorm.DB
 }
 
+// NewJobMetaImpl return a database instance
 func NewJobMetaImpl(option *DBOption) (*JobMetaImpl, error) {
 	db, err := InitDB(option)
 	if err != nil {
@@ -25,6 +26,8 @@ func NewJobMetaImpl(option *DBOption) (*JobMetaImpl, error) {
 	}
 	return &JobMetaImpl{db: db}, nil
 }
+
+// v1 interface implement
 
 // CreateUploadPayloadJob create DBJob record and DBObject record, Use JobID field for association.
 func (jmi *JobMetaImpl) CreateUploadPayloadJob(txHash []byte, info *ptypesv1pb.ObjectInfo) (uint64, error) {
@@ -339,4 +342,283 @@ func (jmi *JobMetaImpl) SetObjectCreateHeightAndObjectID(txHash []byte, height u
 		return fmt.Errorf("update object record's height and objectid failed, %s", result.Error)
 	}
 	return nil
+}
+
+// v2 interface implement
+
+// CreateUploadPayloadJobV2 create DBJobV2 record and DBObjectV2 record, Use JobID field for association.
+func (jmi *JobMetaImpl) CreateUploadPayloadJobV2(info *ptypesv1pb.ObjectInfo) (uint64, error) {
+	var (
+		result             *gorm.DB
+		insertJobRecord    *DBJobV2
+		insertObjectRecord *DBObjectV2
+	)
+
+	insertJobRecord = &DBJobV2{
+		JobType:    uint32(ptypesv1pb.JobType_JOB_TYPE_CREATE_OBJECT),
+		JobState:   uint32(ptypesv1pb.JobState_JOB_STATE_CREATE_OBJECT_DONE),
+		CreateTime: time.Now(),
+		ModifyTime: time.Now(),
+	}
+	result = jmi.db.Create(insertJobRecord)
+	if result.Error != nil || result.RowsAffected != 1 {
+		return 0, fmt.Errorf("insert job record failed, %s", result.Error)
+	}
+	insertObjectRecord = &DBObjectV2{
+		ObjectID:       info.ObjectId,
+		JobID:          insertJobRecord.JobID,
+		CreateHash:     hex.EncodeToString(info.TxHash),
+		Height:         info.Height,
+		Owner:          info.Owner,
+		BucketName:     info.BucketName,
+		ObjectName:     info.ObjectName,
+		Size:           info.Size,
+		IsPrivate:      info.IsPrivate,
+		ContentType:    info.ContentType,
+		PrimarySP:      "mock-sp-string", // todo: how to encode sp info?
+		RedundancyType: uint32(info.RedundancyType),
+	}
+	result = jmi.db.Create(insertObjectRecord)
+	if result.Error != nil || result.RowsAffected != 1 {
+		return 0, fmt.Errorf("insert object record failed, %s", result.Error)
+	}
+	return insertJobRecord.JobID, nil
+}
+
+// GetObjectInfoV2 query DBObjectV2 by txHash, and convert to types.ObjectInfo.
+func (jmi *JobMetaImpl) GetObjectInfoV2(objectID uint64) (*ptypesv1pb.ObjectInfo, error) {
+	var (
+		result         *gorm.DB
+		queryCondition *DBObjectV2
+		queryReturn    DBObjectV2
+	)
+
+	// If the primary key is a number, the query will be written as follows:
+	queryCondition = &DBObjectV2{
+		ObjectID: objectID,
+	}
+	result = jmi.db.Model(queryCondition).First(&queryReturn)
+	if result.Error != nil {
+		return nil, fmt.Errorf("select job record's failed, %s", result.Error)
+	}
+	txHash, err := hex.DecodeString(queryReturn.CreateHash)
+	if err != nil {
+		return nil, err
+	}
+	return &ptypesv1pb.ObjectInfo{
+		JobId:          queryReturn.JobID,
+		Owner:          queryReturn.Owner,
+		BucketName:     queryReturn.BucketName,
+		ObjectName:     queryReturn.ObjectName,
+		Size:           queryReturn.Size,
+		Checksum:       []byte(queryReturn.Checksum),
+		IsPrivate:      queryReturn.IsPrivate,
+		ContentType:    queryReturn.ContentType,
+		PrimarySp:      nil, // todo: how to decode sp info
+		Height:         queryReturn.Height,
+		TxHash:         txHash,
+		RedundancyType: ptypesv1pb.RedundancyType(queryReturn.RedundancyType),
+		SecondarySps:   nil, // todo: how to fill
+	}, nil
+}
+
+// GetJobContextV2 query DBJobV2 by jobID, and convert to types.JobContext.
+func (jmi *JobMetaImpl) GetJobContextV2(jobId uint64) (*ptypesv1pb.JobContext, error) {
+	var (
+		result         *gorm.DB
+		queryCondition *DBJobV2
+		queryReturn    DBJobV2
+	)
+
+	// If the primary key is a number, the query will be written as follows:
+	queryCondition = &DBJobV2{
+		JobID: jobId,
+	}
+	result = jmi.db.Model(queryCondition).First(&queryReturn)
+	if result.Error != nil {
+		return nil, fmt.Errorf("select job record's failed, %s", result.Error)
+	}
+	return &ptypesv1pb.JobContext{
+		JobId:      queryReturn.JobID,
+		JobType:    ptypesv1pb.JobType(queryReturn.JobType),
+		JobState:   ptypesv1pb.JobState(queryReturn.JobState),
+		JobErr:     queryReturn.JobErr,
+		CreateTime: queryReturn.CreateTime.Unix(),
+		ModifyTime: queryReturn.ModifyTime.Unix(),
+	}, nil
+}
+
+// SetUploadPayloadJobStateV2 update DBJobV2 record's state.
+func (jmi *JobMetaImpl) SetUploadPayloadJobStateV2(jobId uint64, jobState string, timestampSec int64) error {
+	var (
+		result         *gorm.DB
+		queryCondition *DBJobV2
+		updateFields   *DBJobV2
+	)
+
+	queryCondition = &DBJobV2{
+		JobID: jobId,
+	}
+	updateFields = &DBJobV2{
+		JobState:   uint32(ptypesv1pb.JobState_value[jobState]),
+		ModifyTime: time.Unix(timestampSec, 0),
+	}
+	result = jmi.db.Model(queryCondition).Updates(updateFields)
+	if result.Error != nil || result.RowsAffected != 1 {
+		return fmt.Errorf("update job record's state failed, %s", result.Error)
+	}
+	return nil
+}
+
+// SetUploadPayloadJobJobErrorV2 update DBJobV2 record's state and err.
+func (jmi *JobMetaImpl) SetUploadPayloadJobJobErrorV2(jobID uint64, jobState string, jobErr string, timestampSec int64) error {
+	var (
+		result         *gorm.DB
+		queryCondition *DBJobV2
+		updateFields   *DBJobV2
+	)
+
+	queryCondition = &DBJobV2{
+		JobID: jobID,
+	}
+	updateFields = &DBJobV2{
+		JobState:   uint32(ptypesv1pb.JobState_value[jobState]),
+		ModifyTime: time.Unix(timestampSec, 0),
+		JobErr:     jobErr,
+	}
+	result = jmi.db.Model(queryCondition).Updates(updateFields)
+	if result.Error != nil || result.RowsAffected != 1 {
+		return fmt.Errorf("update job record's state and err failed, %s", result.Error)
+	}
+	return nil
+}
+
+// GetPrimaryJobV2 query DBPieceJobV2 by objectID and primary type, and convert to PieceJob.
+func (jmi *JobMetaImpl) GetPrimaryJobV2(objectId uint64) ([]*jobdb.PieceJob, error) {
+	var (
+		result       *gorm.DB
+		queryReturns []DBPieceJobV2
+		pieceJobs    []*jobdb.PieceJob
+	)
+
+	result = jmi.db.
+		Where("object_id = ? AND piece_type = ?", objectId, ptypesv1pb.JobType_JOB_TYPE_UPLOAD_PRIMARY).
+		Find(&queryReturns)
+	if result.Error != nil {
+		return pieceJobs, fmt.Errorf("select primary piece jobs failed, %s", result.Error)
+	}
+	for _, job := range queryReturns {
+		pieceJobs = append(pieceJobs, &jobdb.PieceJob{
+			PieceId:         job.PieceIdx,
+			Checksum:        [][]byte{[]byte(job.IntegrityHash)},
+			StorageProvider: job.StorageProvider})
+	}
+	return pieceJobs, nil
+}
+
+// SetPrimaryPieceJobDoneV2 create primary DBPieceJobV2 record.
+func (jmi *JobMetaImpl) SetPrimaryPieceJobDoneV2(objectID uint64, pj *jobdb.PieceJob) error {
+	var (
+		result               *gorm.DB
+		insertPieceJobRecord *DBPieceJobV2
+	)
+
+	insertPieceJobRecord = &DBPieceJobV2{
+		ObjectID:        objectID,
+		PieceType:       uint32(ptypesv1pb.JobType_JOB_TYPE_UPLOAD_PRIMARY),
+		PieceIdx:        pj.PieceId,
+		Checksum:        string(pj.Checksum[0]),
+		PieceState:      0, // todo: fill what?
+		StorageProvider: pj.StorageProvider,
+		IntegrityHash:   "",
+		Signature:       "",
+	}
+	result = jmi.db.Create(insertPieceJobRecord)
+	if result.Error != nil || result.RowsAffected != 1 {
+		return fmt.Errorf("insert primary piece job record failed, %s", result.Error)
+	}
+	return nil
+}
+
+// SetSecondaryPieceJobDoneV2 create secondary DBPieceJobV2 record.
+func (jmi *JobMetaImpl) SetSecondaryPieceJobDoneV2(objectID uint64, pj *jobdb.PieceJob) error {
+	var (
+		result               *gorm.DB
+		insertPieceJobRecord *DBPieceJobV2
+	)
+
+	insertPieceJobRecord = &DBPieceJobV2{
+		ObjectID:        objectID,
+		PieceType:       uint32(ptypesv1pb.JobType_JOB_TYPE_UPLOAD_SECONDARY_EC),
+		PieceIdx:        pj.PieceId,
+		Checksum:        string(pj.Checksum[0]),
+		PieceState:      0, // todo: fill what?
+		StorageProvider: pj.StorageProvider,
+		IntegrityHash:   "",
+		Signature:       "",
+	}
+	result = jmi.db.Create(insertPieceJobRecord)
+	if result.Error != nil || result.RowsAffected != 1 {
+		return fmt.Errorf("insert secondary piece job record failed, %s", result.Error)
+	}
+	return nil
+}
+
+// GetSecondaryJobV2 query DBPieceJobV2 by objectID and secondary type, and convert to PieceJob.
+func (jmi *JobMetaImpl) GetSecondaryJobV2(objectID uint64) ([]*jobdb.PieceJob, error) {
+	var (
+		result       *gorm.DB
+		queryReturns []DBPieceJobV2
+		pieceJobs    []*jobdb.PieceJob
+	)
+
+	result = jmi.db.
+		Where("object_id = ? AND piece_type = ?", objectID, ptypesv1pb.JobType_JOB_TYPE_UPLOAD_SECONDARY_EC).
+		Find(&queryReturns)
+	if result.Error != nil {
+		return pieceJobs, fmt.Errorf("select secondary piece jobs failed, %s", result.Error)
+	}
+	for _, job := range queryReturns {
+		pieceJobs = append(pieceJobs, &jobdb.PieceJob{
+			PieceId:         job.PieceIdx,
+			Checksum:        [][]byte{[]byte(job.IntegrityHash)},
+			StorageProvider: job.StorageProvider})
+	}
+	return pieceJobs, nil
+}
+
+// ScanObjectInfoV2 query scan DBObjectV2, and convert to ObjectInfo.
+func (jmi *JobMetaImpl) ScanObjectInfoV2(offset int, limit int) ([]*ptypesv1pb.ObjectInfo, error) {
+	var (
+		result       *gorm.DB
+		queryReturns []DBObjectV2
+		objects      []*ptypesv1pb.ObjectInfo
+	)
+
+	result = jmi.db.Limit(limit).Offset(offset).Find(&queryReturns)
+	if result.Error != nil {
+		return objects, fmt.Errorf("select primary piece jobs failed, %s", result.Error)
+	}
+	for _, object := range queryReturns {
+		txHash, err := hex.DecodeString(object.CreateHash)
+		if err != nil {
+			return objects, err
+		}
+		objects = append(objects, &ptypesv1pb.ObjectInfo{
+			JobId:          object.JobID,
+			Owner:          object.Owner,
+			BucketName:     object.BucketName,
+			ObjectName:     object.ObjectName,
+			Size:           object.Size,
+			Checksum:       []byte(object.Checksum),
+			IsPrivate:      object.IsPrivate,
+			ContentType:    object.ContentType,
+			PrimarySp:      nil, // todo: how to decode sp info
+			Height:         object.Height,
+			TxHash:         txHash,
+			RedundancyType: ptypesv1pb.RedundancyType(object.RedundancyType),
+			SecondarySps:   nil, // todo: how to fill
+		})
+	}
+	return objects, nil
 }


### PR DESCRIPTION
# Description
This pr add jobdb v2 interface, use objectID as primary key. In the future, maybe replace v1 interface(txHash as primary key).
# Rationale
NA
# Example
NA
# Changes
NA

