### PR TITLE
chore: add setup-test-env tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# GreenField-storage-provider
+# Greenfield-storage-provider
 
-GreenField-Storage-Providers storage service infrastructures provided by either organizations or individuals. They use GreenField-Storage-Chain as the ledger and the golden data source of meta. Each SP can and will respond to users’ requests to write (upload) and read (download) data, and be the gatekeeper for user rights and authentications.
+Greenfield-Storage-Providers storage service infrastructures provided by either organizations or individuals. They use GreenField-Storage-Chain as the ledger and the golden data source of meta. Each SP can and will respond to users’ requests to write (upload) and read (download) data, and be the gatekeeper for user rights and authentications.
 
 # Service
 ## Install-Tools
@@ -14,10 +14,12 @@ bash build.sh
 ## Quick Deploy
 ```shell
 cd build
-# Print Version
-./storage_provider -v
-# Run Services
-./storage_provider -config ./config.toml
-# Run Cases
-./test-storage-provider
+# print version
+./gnfd-sp --version
+# setup secondary sps in the test-env directory(syncer)
+./setup-test-env
+# run primary sp(gateway/uploader/downloader/stonehub/stonenode/syncer)
+./gnfd-sp -config ./config.toml
+# run cases, request to primary sp
+./test-gnfd-sp
 ```

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ go build -ldflags "\
   -X 'main.CommitID=${CommitID}' \
   -X 'main.BranchName=${BranchName}' \
   -X 'main.BuildTime=${BuildTime}'" \
--o ./build/storage_provider cmd/storage_provider/*.go
+-o ./build/gnfd-sp cmd/storage_provider/*.go
 
 if [ $? -ne 0 ]; then
     echo "build failed Ooh!!!"
@@ -26,9 +26,14 @@ else
     echo "build succeed!"
 fi
 
-go build -o ./build/test-storage-provider test/e2e/services/case_driver.go
+go build -o ./build/test-gnfd-sp test/e2e/services/case_driver.go
 if [ $? -ne 0 ]; then
     echo "build test-storage-provider failed Ooh!!!"
+fi
+
+go build -o ./build/setup-test-env test/e2e/onebox/setup_onebox.go
+if [ $? -ne 0 ]; then
+    echo "build setup-test-env failed Ooh!!!"
 fi
 
 cp config/config.toml ./build/

--- a/cmd/storage_provider/version.go
+++ b/cmd/storage_provider/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	StorageProviderLogo = `Green Field Storage Provider
+	StorageProviderLogo = `Greenfield Storage Provider
          __                                                       _     __         
    _____/ /_____  _________ _____ ____     ____  _________ _   __(_)___/ /__  _____
   / ___/ __/ __ \/ ___/ __  / __  / _ \   / __ \/ ___/ __ \ | / / / __  / _ \/ ___/

--- a/config/config.toml
+++ b/config/config.toml
@@ -68,7 +68,7 @@ Service = [
     StorageProvider = "bnb-sp"
     Address = "127.0.0.1:9433"
     StoneHubServiceAddress = "127.0.0.1:9333"
-    SyncerServiceAddress = ["127.0.0.1:9533", "127.0.0.1:9543", "127.0.0.1:9553", "127.0.0.1:9563", "127.0.0.1:9573", "127.0.0.1:9583"]
+    SyncerServiceAddress = ["127.0.0.1:9593", "127.0.0.1:9543", "127.0.0.1:9553", "127.0.0.1:9563", "127.0.0.1:9573", "127.0.0.1:9583"]
     StoneJobLimit = 64
     [StoneNodeCfg.PieceConfig]
         Shards = 0

--- a/test/e2e/onebox/setup_onebox.go
+++ b/test/e2e/onebox/setup_onebox.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bnb-chain/greenfield-storage-provider/config"
+	"github.com/bnb-chain/greenfield-storage-provider/model"
+	"github.com/bnb-chain/greenfield-storage-provider/service/challenge"
+	"github.com/bnb-chain/greenfield-storage-provider/service/gateway"
+	"github.com/bnb-chain/greenfield-storage-provider/service/stonehub"
+	"github.com/bnb-chain/greenfield-storage-provider/service/stonenode"
+	"github.com/bnb-chain/greenfield-storage-provider/service/uploader"
+	"github.com/bnb-chain/greenfield-storage-provider/store/metadb/metalevel"
+	"github.com/bnb-chain/greenfield-storage-provider/store/metadb/metasql"
+	"github.com/bnb-chain/greenfield-storage-provider/store/piecestore/storage"
+	"github.com/bnb-chain/greenfield-storage-provider/util"
+	"github.com/bnb-chain/greenfield-storage-provider/util/log"
+)
+
+var (
+	configFile = flag.String("config", "./config.toml", "config file path")
+	binaryFile = flag.String("binary", "./gnfd-sp", "binary file path")
+	cfg        *config.StorageProviderConfig
+)
+
+const (
+	oneboxDir  = "./test-env"
+	destBinary = "onebox-gnfd-sp"
+	destConfig = "config.toml"
+)
+
+func initConfig() {
+	cfg.Service = []string{model.SyncerService}
+	cfg.GatewayCfg = gateway.DefaultGatewayConfig
+	cfg.UploaderCfg = uploader.DefaultUploaderConfig
+	cfg.StoneHubCfg = stonehub.DefaultStoneHubConfig
+	cfg.ChallengeCfg = challenge.DefaultChallengeConfig
+	cfg.StoneNodeCfg = stonenode.DefaultStoneNodeConfig
+	if cfg.SyncerCfg.MetaSqlDBConfig == nil {
+		cfg.SyncerCfg.MetaSqlDBConfig = metasql.DefaultMetaSqlDBConfig
+	}
+	if cfg.SyncerCfg.MetaLevelDBConfig == nil {
+		cfg.SyncerCfg.MetaLevelDBConfig = metalevel.DefaultMetaLevelDBConfig
+	}
+	if cfg.SyncerCfg.PieceConfig == nil {
+		cfg.SyncerCfg.PieceConfig = storage.DefaultPieceStoreConfig
+	}
+}
+
+func runShell(cmdStr string) (string, error) {
+	var (
+		outMsg bytes.Buffer
+		errMsg bytes.Buffer
+		err    error
+	)
+	cmd := exec.Command("/bin/sh", "-c", cmdStr)
+	cmd.Stdout = &outMsg
+	cmd.Stderr = &errMsg
+	if err = cmd.Run(); err != nil {
+		log.Errorw("failed to run cmd", "cmd", cmd, "error", err, "stderr", errMsg, "stdout", outMsg)
+		return outMsg.String(), err
+	}
+	return outMsg.String(), nil
+}
+
+func getProcessNum() (int, error) {
+	time.Sleep(10 * time.Second)
+	getProcessNumCMD := fmt.Sprintf("ps axu|grep %s | grep -v \"grep\" |wc -l", destBinary)
+	processNumStr, err := runShell(getProcessNumCMD)
+	if err != nil {
+		return 0, err
+	}
+	processNumStr = strings.ReplaceAll(processNumStr, " ", "")
+	processNumStr = strings.ReplaceAll(processNumStr, "\n", "")
+	processNum, err := strconv.Atoi(processNumStr)
+	if err != nil {
+		log.Errorw("failed to get process num", "error", err)
+		return 0, err
+	}
+	return processNum, nil
+}
+
+func main() {
+	log.Info("begin setup onebox, deploy secondary syncers")
+
+	cfg = config.LoadConfig(*configFile)
+	addrList := cfg.StoneNodeCfg.SyncerServiceAddress
+	initConfig()
+
+	// clear
+	// todo: polish not clear data
+	os.RemoveAll(oneboxDir)
+	pkillCMD := fmt.Sprintf("kill -9 $(pgrep -f %s)", destBinary)
+	runShell(pkillCMD)
+	if processNum, err := getProcessNum(); err != nil || processNum != 0 {
+		log.Errorw("failed to pkill", "error", err)
+		os.Exit(1)
+		return
+	}
+
+	// setup
+	if err := os.Mkdir(oneboxDir, 0777); err != nil {
+		log.Errorw("failed to mkdir onebox directory", "error", err)
+		os.Exit(1)
+		return
+	}
+
+	for index, addr := range addrList {
+		spDir := oneboxDir + "/sp" + strconv.Itoa(index)
+		if err := os.Mkdir(spDir, 0777); err != nil {
+			log.Errorw("failed to mkdir onebox sp directory", "error", err)
+			os.Exit(1)
+			return
+		}
+		cpCMD := fmt.Sprintf("cp %s %s", *binaryFile, spDir+"/"+destBinary)
+		if _, err := runShell(cpCMD); err != nil {
+			log.Errorw("failed to cp binary", "error", err)
+			os.Exit(1)
+			return
+		}
+		f, err := os.Create(spDir + "/" + destConfig)
+		if err != nil {
+			log.Errorw("failed to create config", "error", err)
+			os.Exit(1)
+			return
+		}
+		cfg.SyncerCfg.Address = addr
+		cfg.SyncerCfg.StorageProvider = spDir
+		cfg.SyncerCfg.MetaLevelDBConfig.Path = spDir + "/leveldb"
+		cfg.SyncerCfg.PieceConfig.Store.BucketURL = spDir + "/piece_store"
+		if err = util.TomlSettings.NewEncoder(f).Encode(cfg); err != nil {
+			log.Errorw("failed to encode config", "error", err)
+			os.Exit(1)
+			return
+		}
+		if err = f.Close(); err != nil {
+			log.Errorw("failed to close config", "error", err)
+			os.Exit(1)
+			return
+		}
+		nohupStartCMD := fmt.Sprintf("nohup %s/%s -config %s/%s </dev/null >%s/log.txt 2>&1&",
+			spDir, destBinary, spDir, destConfig, spDir)
+		if _, err = runShell(nohupStartCMD); err != nil {
+			log.Errorw("failed to start syncer", "error", err)
+			os.Exit(1)
+			return
+		}
+		log.Infow("succeed to setup syncer", "dir", spDir)
+	}
+
+	// check
+	if processNum, err := getProcessNum(); err != nil || processNum != len(addrList) {
+		log.Errorw("failed to setup onebox, syncer maybe down and please check log in ./onebox/sp*/log.txt",
+			"expect", len(addrList), "actual", processNum)
+		os.Exit(1)
+		return
+	}
+	log.Info("succeed to setup onebox")
+}


### PR DESCRIPTION
### Description
This pr setup secondary sps env, currently only includes Syncer. The tool is used in the quick deploy(in readme).

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 
N/A