### PR TITLE
chore: skip merge word check in commit lint ci action

### DIFF
--- a/.github/commitlint.config.js
+++ b/.github/commitlint.config.js
@@ -1,5 +1,5 @@
 const validateTypeNums = (parsedCommit) => {
-    const mergePrefix = "Merge pull request"
+    const mergePrefix = "Merge"
     if (parsedCommit.raw.startsWith(mergePrefix)) {
         console.log('this is a merge commit:' + parsedCommit.raw)
         return [true,'']


### PR DESCRIPTION
### Description

skip 'merge' word check in commit lint action 

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 
N/A
