### PR TITLE
fix: signer adapt to on-chain logic

### DIFF
--- a/service/signer/client/gnfd_sign_client.go
+++ b/service/signer/client/gnfd_sign_client.go
@@ -93,6 +93,15 @@ func NewGreenfieldChainSignClient(
 	}, nil
 }
 
+// GetAddr returns the public address of the private key.
+func (client *GreenfieldChainSignClient) GetAddr(scope SignType) (sdk.AccAddress, error) {
+	km, err := client.greenfieldClients[scope].GetKeyManager()
+	if err != nil {
+		return nil, err
+	}
+	return km.GetAddr(), nil
+}
+
 // Sign returns a msg signature signed by private key.
 func (client *GreenfieldChainSignClient) Sign(scope SignType, msg []byte) ([]byte, error) {
 	km, err := client.greenfieldClients[scope].GetKeyManager()
@@ -103,6 +112,7 @@ func (client *GreenfieldChainSignClient) Sign(scope SignType, msg []byte) ([]byt
 	return km.GetPrivKey().Sign(msg)
 }
 
+// VerifySignature verifies the signature.
 func (client *GreenfieldChainSignClient) VerifySignature(scope SignType, msg, sig []byte) bool {
 	km, err := client.greenfieldClients[scope].GetKeyManager()
 	if err != nil {
@@ -123,7 +133,11 @@ func (client *GreenfieldChainSignClient) SealObject(ctx context.Context, scope S
 	)
 
 	for _, sp := range object.SecondarySps {
-		secondarySPAccs = append(secondarySPAccs, sdk.AccAddress(sp.SpId))
+		opAddr, err := sdk.AccAddressFromHexUnsafe(sp.SpId) // should be 0x...
+		if err != nil {
+			return nil, err
+		}
+		secondarySPAccs = append(secondarySPAccs, opAddr)
 		secondarySPSignatures = append(secondarySPSignatures, sp.Signature)
 	}
 	km, err := client.greenfieldClients[scope].GetKeyManager()

--- a/service/signer/signer_service.go
+++ b/service/signer/signer_service.go
@@ -8,6 +8,7 @@ import (
 	stypes "github.com/bnb-chain/greenfield-storage-provider/service/types/v1"
 	"github.com/bnb-chain/greenfield-storage-provider/util"
 	"github.com/bnb-chain/greenfield-storage-provider/util/hash"
+	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"google.golang.org/grpc"
 )
@@ -81,8 +82,15 @@ func (signer *SignerServer) VerifyObjectApproval(ctx context.Context, req *stype
 // SignIntegrityHash implements v1.SignerServiceServer
 func (signer *SignerServer) SignIntegrityHash(ctx context.Context, req *stypes.SignIntegrityHashRequest) (*stypes.SignIntegrityHashResponse, error) {
 	integrityHash := hash.GenerateIntegrityHash(req.Data)
+	opAddr, err := signer.client.GetAddr(client.SignOperator)
+	if err != nil {
+		return &stypes.SignIntegrityHashResponse{
+			ErrMessage: merrors.MakeErrMsgResponse(merrors.ErrSignMsg),
+		}, nil
+	}
 
-	sig, err := signer.client.Sign(client.SignApproval, integrityHash)
+	msg := storagetypes.NewSecondarySpSignDoc(opAddr, integrityHash).GetSignBytes()
+	sig, err := signer.client.Sign(client.SignApproval, msg)
 	if err != nil {
 		return &stypes.SignIntegrityHashResponse{
 			ErrMessage: merrors.MakeErrMsgResponse(merrors.ErrSignMsg),


### PR DESCRIPTION
### Description

signer adapts to on-chain logic.

### Rationale

refer to: https://github.com/bnb-chain/greenfield/blob/758044d8562de8e8a860c6d4c3935c740967dd16/x/storage/keeper/keeper.go#L305

### Example

N/A

### Changes

Notable changes: 
* signer
