### PR TITLE
feat: block syncer add permission module

### DIFF
--- a/config/subconfig.go
+++ b/config/subconfig.go
@@ -237,7 +237,8 @@ func (cfg *StorageProviderConfig) MakeBlockSyncerConfig() (*tomlconfig.TomlConfi
 			MaxOpenConnections: 1,
 		},
 		Logging: loggingconfig.Config{
-			Level: "debug",
+			Level:   "debug",
+			RootDir: "./",
 		},
 	}, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,9 @@ replace (
 	cosmossdk.io/math => github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230228075616-68ac309b432c
 	github.com/bnb-chain/greenfield => github.com/bnb-chain/greenfield v0.0.9
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.0.2-0.20230316090342-debd6c0c82a7
-	github.com/forbole/juno/v4 => github.com/bnb-chain/juno/v4 v4.0.0-20230315120403-3093b5ed5267
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.0.11
+	github.com/forbole/juno/v4 => github.com/bnb-chain/juno/v4 v4.0.0-20230323095415-6b0a61c851ae
+
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/tendermint/tendermint => github.com/bnb-chain/gnfd-tendermint v0.0.2
 )
@@ -15,15 +16,13 @@ replace (
 require (
 	cosmossdk.io/math v1.0.0-beta.6
 	github.com/aws/aws-sdk-go v1.44.159
-	github.com/bnb-chain/greenfield v0.0.7
+	github.com/bnb-chain/greenfield v0.0.9
 	github.com/bnb-chain/greenfield-common/go v0.0.0-20230310033112-2d379fdc2987
-	github.com/bnb-chain/greenfield-go-sdk v0.0.0-20230314083410-f0d6dbbec179
+	github.com/bnb-chain/greenfield-go-sdk v0.0.7
 	github.com/bytedance/gopkg v0.0.0-20221122125632-68358b8ecec6
 	github.com/cloudflare/cfssl v1.6.3
-	github.com/cosmos/cosmos-proto v1.0.0-beta.1
 	github.com/cosmos/cosmos-sdk v0.46.7
 	github.com/cosmos/gogoproto v1.4.6
-	github.com/crx666/protobuf-gogofast v1.2.7
 	github.com/ethereum/go-ethereum v1.10.19
 	github.com/forbole/juno/v4 v4.0.0-00010101000000-000000000000
 	github.com/gin-gonic/gin v1.8.2
@@ -58,7 +57,7 @@ require (
 )
 
 require (
-	cosmossdk.io/errors v1.0.0-beta.7 // indirect
+	cosmossdk.io/errors v1.0.0-beta.7
 	filippo.io/edwards25519 v1.0.0-rc.1 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/99designs/keyring v1.2.1 // indirect
@@ -227,7 +226,6 @@ require (
 	github.com/rs/zerolog v1.29.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect
-	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/afero v1.9.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -212,14 +212,14 @@ github.com/bnb-chain/greenfield v0.0.9 h1:nU3TgGloyysyyrbW/t9X2gdEvllxfIBudhuOdZ
 github.com/bnb-chain/greenfield v0.0.9/go.mod h1:uH3iyy7RfTaO+qM34AF1XN4CrCPcoUSTJs3zvaIWIf4=
 github.com/bnb-chain/greenfield-common/go v0.0.0-20230310033112-2d379fdc2987 h1:+SOlI4dfp5y/2srTBdAEOujoJboMx+m22zvj5xuBLgU=
 github.com/bnb-chain/greenfield-common/go v0.0.0-20230310033112-2d379fdc2987/go.mod h1:Nzpqn+BK8P1Ub3Tgn300bHmWMUk9R6cBwvmasVY25J8=
-github.com/bnb-chain/greenfield-cosmos-sdk v0.0.2-0.20230316090342-debd6c0c82a7 h1:CRZHHzInXLUvulik180alYKa2omtu+rCwk2q+J2h02w=
-github.com/bnb-chain/greenfield-cosmos-sdk v0.0.2-0.20230316090342-debd6c0c82a7/go.mod h1:C0poOez5FBpH4Y/oa9jmco2fRojeMsJZGOZEX+GOv8w=
+github.com/bnb-chain/greenfield-cosmos-sdk v0.0.11 h1:8Vb57cJUoMVv9EL5ce43V8ZCPOvjNjrxs9+KyJw6JOg=
+github.com/bnb-chain/greenfield-cosmos-sdk v0.0.11/go.mod h1:C0poOez5FBpH4Y/oa9jmco2fRojeMsJZGOZEX+GOv8w=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230228075616-68ac309b432c h1:BLmdYaj7Dx0YOhfk77+KPPJSMCwpQl6f4Y30+801bf0=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230228075616-68ac309b432c/go.mod h1:u/MXvf8wbUbCsAEyQSSYXXMsczAsFX48e2D6JI86T4o=
-github.com/bnb-chain/greenfield-go-sdk v0.0.0-20230314083410-f0d6dbbec179 h1:9WC+Wl/6BOrhXi9/OxSC7N7R3FLuvLfy9eLkGIo8UGM=
-github.com/bnb-chain/greenfield-go-sdk v0.0.0-20230314083410-f0d6dbbec179/go.mod h1:FwNxlpMZfHvs/oKt4vJttgsEkxSyjou6IUG42Nu/zD0=
-github.com/bnb-chain/juno/v4 v4.0.0-20230315120403-3093b5ed5267 h1:HCDTRmGYyP4Fj5PRjmVwfbw2CXon431D0Tnpl03u23E=
-github.com/bnb-chain/juno/v4 v4.0.0-20230315120403-3093b5ed5267/go.mod h1:oQZkgavrYEz5hPchQg7TO4kK68PhyFIs0F3s5ev60bY=
+github.com/bnb-chain/greenfield-go-sdk v0.0.7 h1:uqsZClp8/CdsWxaTSA9ed0JlfNcwMFUXDdua52ry35w=
+github.com/bnb-chain/greenfield-go-sdk v0.0.7/go.mod h1:0/EP4qwa/8Ok87tHGrk8k/hakxMKsYLA75DD+jd+aTE=
+github.com/bnb-chain/juno/v4 v4.0.0-20230323095415-6b0a61c851ae h1:26GOg5sArORy1viLIWdAElG30S9e+9c3QzKcuZUuhHA=
+github.com/bnb-chain/juno/v4 v4.0.0-20230323095415-6b0a61c851ae/go.mod h1:K7eL/kwPovSav7UYxoP1nWEF6QKabm3DEWneclV5Pf0=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/bradfitz/gomemcache v0.0.0-20170208213004-1952afaa557d/go.mod h1:PmM6Mmwb0LSuEubjR8N7PtNe1KxZLtOUHtbeikc5h60=
@@ -356,8 +356,6 @@ github.com/creachadair/taskgroup v0.3.2/go.mod h1:wieWwecHVzsidg2CsUnFinW1faVN4+
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crx666/protobuf-gogofast v1.2.7 h1:/rglPP6qoMz5A7HI0U3JfbsvIjlWueoLoc9pxqnv02g=
-github.com/crx666/protobuf-gogofast v1.2.7/go.mod h1:wgjYcm8tA5wxXqg2iXkCsdK6kyWTVdQa/XFpLPP0k+w=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
 github.com/d4l3k/messagediff v1.2.1 h1:ZcAIMYsUg0EAp9X+tt8/enBE/Q8Yd5kzPynLyKptt9U=
 github.com/d4l3k/messagediff v1.2.1/go.mod h1:Oozbb1TVXFac9FtSIxHBMnBCq2qeH/2KkEQxENCrlLo=
@@ -951,7 +949,6 @@ github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d/go.mod h1:P2vi
 github.com/karalabe/usb v0.0.0-20211005121534-4c5740d64559/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kevinms/leakybucket-go v0.0.0-20200115003610-082473db97ca/go.mod h1:ph+C5vpnCcQvKBwJwKLTK3JLNGnBXYlG7m7JjoC/zYA=
-github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
@@ -1584,8 +1581,6 @@ github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNX
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible h1:Bn1aCHHRnjv4Bl16T8rcaFjYSrGrIZvpiGO6P3Q4GpU=
 github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
-github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
-github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=
 github.com/shurcooL/events v0.0.0-20181021180414-410e4ca65f48/go.mod h1:5u70Mqkb5O5cxEA8nxTsgrgLehJeAw6Oc4Ab1c/P1HM=
 github.com/shurcooL/github_flavored_markdown v0.0.0-20181002035957-2122de532470/go.mod h1:2dOwnU2uBioM+SGy2aZoq1f/Sd1l9OkAeAUvjSyvgU0=
@@ -2240,7 +2235,6 @@ golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20201208040808-7e3f01d25324/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/service/blocksyncer/block_syncer.go
+++ b/service/blocksyncer/block_syncer.go
@@ -96,6 +96,7 @@ func (s *BlockSyncer) initDB() error {
 		if module, ok := module.(modules.PrepareTablesModule); ok {
 			err = module.PrepareTables()
 			if err != nil {
+				log.Errorf("failed to PrepareTables err: %v", err)
 				return err
 			}
 		}

--- a/service/blocksyncer/block_syncer_indexer.go
+++ b/service/blocksyncer/block_syncer_indexer.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/forbole/juno/v4/common"
+
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/forbole/juno/v4/database"
 	"github.com/forbole/juno/v4/models"
 	"github.com/forbole/juno/v4/modules"
@@ -42,12 +43,13 @@ func (i *Impl) ExportBlock(block *coretypes.ResultBlock, events *coretypes.Resul
 }
 
 // HandleEvent accepts the transaction and handles events contained inside the transaction.
-func (i *Impl) HandleEvent(ctx context.Context, block *coretypes.ResultBlock, index int, event sdk.Event) {
+func (i *Impl) HandleEvent(ctx context.Context, block *coretypes.ResultBlock, event sdk.Event) {
 	for _, module := range i.Modules {
 		if eventModule, ok := module.(modules.EventModule); ok {
-			err := eventModule.HandleEvent(ctx, block, index, event)
+			log.Infof("module name :%s event type: %s, height: %d", module.Name(), event.Type, block.Block.Height)
+			err := eventModule.HandleEvent(ctx, block, event)
 			if err != nil {
-				log.Errorw("failed to handle event", "module", module, "event", event, "error", err)
+				log.Errorw("failed to handle event", "module", module.Name(), "event", event, "error", err)
 			}
 		}
 	}
@@ -89,7 +91,7 @@ func (i *Impl) Process(height uint64) error {
 func (i *Impl) ExportEpoch(block *coretypes.ResultBlock) error {
 	// Save the block
 	err := i.DB.SaveEpoch(context.Background(), &models.Epoch{
-		ID:          1,
+		OneRowId:    true,
 		BlockHeight: block.Block.Height,
 		BlockHash:   common.HexToHash(block.BlockID.Hash.String()),
 		UpdateTime:  block.Block.Time.Unix(),
@@ -104,7 +106,7 @@ func (i *Impl) ExportEpoch(block *coretypes.ResultBlock) error {
 
 // ExportTxs accepts a slice of transactions and persists then inside the database.
 // An error is returned if write fails.
-func (i *Impl) ExportTxs(txs []*types.Tx) error {
+func (i *Impl) ExportTxs(block *coretypes.ResultBlock, txs []*types.Tx) error {
 	return nil
 }
 
@@ -131,10 +133,9 @@ func (i *Impl) ExportEvents(ctx context.Context, block *coretypes.ResultBlock, e
 	// get all events in order from the txs within the block
 	for _, tx := range events.TxsResults {
 		// handle all events contained inside the transaction
-		events := filterEventsByType(tx)
 		// call the event handlers
-		for idx, event := range events {
-			i.HandleEvent(ctx, block, idx, event)
+		for _, event := range tx.Events {
+			i.HandleEvent(ctx, block, sdk.Event(event))
 		}
 	}
 	return nil
@@ -165,4 +166,15 @@ func (i *Impl) HandleTx(tx *types.Tx) {
 // HandleMessage accepts the transaction and handles messages contained inside the transaction.
 func (i *Impl) HandleMessage(index int, msg sdk.Msg, tx *types.Tx) {
 	log.Infof("HandleMessage")
+}
+
+// Processed tells whether the current Indexer has already processed the given height of Block
+// An error is returned if the operation fails.
+func (i *Impl) Processed(ctx context.Context, height uint64) (bool, error) {
+	ep, err := i.DB.GetEpoch(context.Background())
+	if err != nil {
+		return false, err
+	}
+	log.Infof("epoch height:%d, cur height: %d", ep.BlockHeight, height)
+	return ep.BlockHeight > int64(height), nil
 }

--- a/service/blocksyncer/block_syncer_service.go
+++ b/service/blocksyncer/block_syncer_service.go
@@ -8,14 +8,9 @@ import (
 
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/forbole/juno/v4/parser"
 	"github.com/forbole/juno/v4/types"
 	"github.com/forbole/juno/v4/types/config"
-	eventutil "github.com/forbole/juno/v4/types/event"
-
-	abci "github.com/tendermint/tendermint/abci/types"
 )
 
 // enqueueMissingBlocks enqueues jobs (block heights) for missed blocks starting
@@ -70,16 +65,4 @@ func mustGetLatestHeight(ctx *parser.Context) uint64 {
 	}
 
 	return 0
-}
-
-// filterEventsByType filter the event by types we are interested in.
-// Current we handle storage/payment/permission related events.
-func filterEventsByType(tx *abci.ResponseDeliverTx) []sdk.Event {
-	filteredEvents := make([]sdk.Event, 0)
-	for _, event := range tx.Events {
-		if _, ok := eventutil.EventProcessedMap[event.Type]; ok {
-			filteredEvents = append(filteredEvents, sdk.Event(event))
-		}
-	}
-	return filteredEvents
 }


### PR DESCRIPTION
### Description

block syncer add permission module

### Rationale

block syncer need to store data related to permission on the greenfield chain

### Example

nothing

### Changes

Notable changes: 
* bnb-chain/juno version is changed
