### PR TITLE
fix: adjust init metrics check condition to avoid panic

### DIFF
--- a/cmd/storage_provider/init.go
+++ b/cmd/storage_provider/init.go
@@ -48,7 +48,7 @@ func initLog(ctx *cli.Context, cfg *config.StorageProviderConfig) error {
 
 // initMetrics initializes global metrics.
 func initMetrics(ctx *cli.Context, cfg *config.StorageProviderConfig) error {
-	if cfg == nil {
+	if cfg.MetricsCfg == nil {
 		cfg.MetricsCfg = config.DefaultMetricsConfig
 	}
 	if ctx.IsSet(utils.MetricsEnabledFlag.Name) {


### PR DESCRIPTION
### Description

adjust check condition to avoid panic

### Rationale

Avoid program panic

### Example

N/A

### Changes

N/A
