### PR TITLE
fix: fix put object verify permission bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,8 @@ require (
 	cosmossdk.io/math v1.0.0-beta.6
 	github.com/aws/aws-sdk-go v1.44.159
 	github.com/bnb-chain/greenfield v0.0.10
-	github.com/bnb-chain/greenfield-common/go v0.0.0-20230310033112-2d379fdc2987
-	github.com/bnb-chain/greenfield-go-sdk v0.0.7
+	github.com/bnb-chain/greenfield-common/go v0.0.0-20230327055559-264d5271f271
+	github.com/bnb-chain/greenfield-go-sdk v0.0.8
 	github.com/bytedance/gopkg v0.0.0-20221122125632-68358b8ecec6
 	github.com/cloudflare/cfssl v1.6.3
 	github.com/cosmos/cosmos-sdk v0.46.7
@@ -231,7 +231,6 @@ require (
 	github.com/rs/zerolog v1.29.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect
-	github.com/shopspring/decimal v1.3.1
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/afero v1.9.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -210,14 +210,14 @@ github.com/bnb-chain/gnfd-tendermint v0.0.3 h1:RjEBQZJW7krM4DFxZbIasNNO7K2uohcmL
 github.com/bnb-chain/gnfd-tendermint v0.0.3/go.mod h1:/v9z9F6cq0+f7EGG92lYSLBcPYQDILoK91X8YM28hWo=
 github.com/bnb-chain/greenfield v0.0.10 h1:WACUvR977jK4jDm0LTcYl7gomXtn5mUXXAPoGo9s+dI=
 github.com/bnb-chain/greenfield v0.0.10/go.mod h1:UDWHU9XiyTbbpZsktn1bMab4MVAY4dhWEf/mhMuOQgQ=
-github.com/bnb-chain/greenfield-common/go v0.0.0-20230310033112-2d379fdc2987 h1:+SOlI4dfp5y/2srTBdAEOujoJboMx+m22zvj5xuBLgU=
-github.com/bnb-chain/greenfield-common/go v0.0.0-20230310033112-2d379fdc2987/go.mod h1:Nzpqn+BK8P1Ub3Tgn300bHmWMUk9R6cBwvmasVY25J8=
+github.com/bnb-chain/greenfield-common/go v0.0.0-20230327055559-264d5271f271 h1:KcI/UzJe+/79pSyISTpT5iHXgQga7kRZl+aNSLfNWBk=
+github.com/bnb-chain/greenfield-common/go v0.0.0-20230327055559-264d5271f271/go.mod h1:gGaPRDSjK1QH/lMjZ5wfhbP4SfrUUKX6Q72x/8uehxo=
 github.com/bnb-chain/greenfield-cosmos-sdk v0.0.13 h1:xm9qqrOjrGfX4imXxxruHIpuUUUAFbdtM/TXPXRc5zo=
 github.com/bnb-chain/greenfield-cosmos-sdk v0.0.13/go.mod h1:rvAY7ga/AakZWyYkA1zAsNtvKpdoyRFZTqF4MhFYzZ8=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230228075616-68ac309b432c h1:BLmdYaj7Dx0YOhfk77+KPPJSMCwpQl6f4Y30+801bf0=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230228075616-68ac309b432c/go.mod h1:u/MXvf8wbUbCsAEyQSSYXXMsczAsFX48e2D6JI86T4o=
-github.com/bnb-chain/greenfield-go-sdk v0.0.7 h1:uqsZClp8/CdsWxaTSA9ed0JlfNcwMFUXDdua52ry35w=
-github.com/bnb-chain/greenfield-go-sdk v0.0.7/go.mod h1:0/EP4qwa/8Ok87tHGrk8k/hakxMKsYLA75DD+jd+aTE=
+github.com/bnb-chain/greenfield-go-sdk v0.0.8 h1:eBhhdek0o9NnRVAeDOVJVyP3y3a/ym5ZuZWEbV5Nrco=
+github.com/bnb-chain/greenfield-go-sdk v0.0.8/go.mod h1:J2zKMxU4th2PxADbcKhI7m9jOrIpuwoqE6LvZFG6tMo=
 github.com/bnb-chain/juno/v4 v4.0.0-20230327035319-0492d012fa17 h1:6bT6hfSU+sI6nNrUrnf7bBskCvgT26qCT+O+wvUN7lg=
 github.com/bnb-chain/juno/v4 v4.0.0-20230327035319-0492d012fa17/go.mod h1:I+J7Cdpzc7U+0ULxIDZw5zzsDAX8352JN5vtuEz1dg4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
@@ -1587,8 +1587,6 @@ github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNX
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible h1:Bn1aCHHRnjv4Bl16T8rcaFjYSrGrIZvpiGO6P3Q4GpU=
 github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
-github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
-github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=
 github.com/shurcooL/events v0.0.0-20181021180414-410e4ca65f48/go.mod h1:5u70Mqkb5O5cxEA8nxTsgrgLehJeAw6Oc4Ab1c/P1HM=
 github.com/shurcooL/github_flavored_markdown v0.0.0-20181002035957-2122de532470/go.mod h1:2dOwnU2uBioM+SGy2aZoq1f/Sd1l9OkAeAUvjSyvgU0=

--- a/pkg/greenfield/query_service.go
+++ b/pkg/greenfield/query_service.go
@@ -168,11 +168,13 @@ func (greenfield *Greenfield) VerifyGetObjectPermission(ctx context.Context, acc
 
 // VerifyPutObjectPermission verify put object permission.
 func (greenfield *Greenfield) VerifyPutObjectPermission(ctx context.Context, account, bucket, object string) (bool, error) {
+	_ = object
 	client := greenfield.getCurrentClient().GnfdCompositeClient()
 	resp, err := client.VerifyPermission(ctx, &storagetypes.QueryVerifyPermissionRequest{
 		Operator:   account,
 		BucketName: bucket,
-		ObjectName: object,
+		// TODO: Polish the function interface according to the semantics
+		// ObjectName: object,
 		ActionType: permissiontypes.ACTION_CREATE_OBJECT,
 	})
 	if err != nil {


### PR DESCRIPTION
### Description

1.  Fix the put object verify permission bug.
2. Update the greenfield-common version.
3. Update the greenfield-go-sdk version.

### Rationale

N/A.

### Example

N/A.

### Changes

Notable changes: 
* go.mod.
* pkg/greenfield.
