### PR TITLE
ci: fix release.yml uncorrect env var name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Setup GitHub Token
-        run: git config --global url.https://${{ secrets.GH_ACCESS_SECRET }}@github.com/.insteadOf https://github.com/
+        run: git config --global url.https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
       - name: Checkout code
         uses: actions/checkout@v3
 
@@ -134,7 +134,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_SECRET }} # This token is provided by Actions, you do not need to create your own token
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
           tag_name: ${{ env.RELEASE_VERSION}}
           release_name: ${{ env.RELEASE_VERSION}}


### PR DESCRIPTION
### Description

There is something wrong in release.yml  which should use GH_ACCESS_TOKEN instead of GH_ACCESS_SECRET

### Rationale

N/A

### Example

N/A

### Changes

N/A