### PR TITLE
fix: upgrade juno version for a property length fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace (
 	github.com/bnb-chain/greenfield => github.com/bnb-chain/greenfield v0.0.10
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.0.13
-	github.com/forbole/juno/v4 => github.com/bnb-chain/juno/v4 v4.0.0-20230327035319-0492d012fa17
+	github.com/forbole/juno/v4 => github.com/bnb-chain/juno/v4 v4.0.0-20230331063806-f6cddda3e3fc
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/tendermint/tendermint => github.com/bnb-chain/gnfd-tendermint v0.0.3
 )

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230228075616-68ac309b43
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230228075616-68ac309b432c/go.mod h1:u/MXvf8wbUbCsAEyQSSYXXMsczAsFX48e2D6JI86T4o=
 github.com/bnb-chain/greenfield-go-sdk v0.0.8 h1:eBhhdek0o9NnRVAeDOVJVyP3y3a/ym5ZuZWEbV5Nrco=
 github.com/bnb-chain/greenfield-go-sdk v0.0.8/go.mod h1:J2zKMxU4th2PxADbcKhI7m9jOrIpuwoqE6LvZFG6tMo=
-github.com/bnb-chain/juno/v4 v4.0.0-20230327035319-0492d012fa17 h1:6bT6hfSU+sI6nNrUrnf7bBskCvgT26qCT+O+wvUN7lg=
-github.com/bnb-chain/juno/v4 v4.0.0-20230327035319-0492d012fa17/go.mod h1:I+J7Cdpzc7U+0ULxIDZw5zzsDAX8352JN5vtuEz1dg4=
+github.com/bnb-chain/juno/v4 v4.0.0-20230331063806-f6cddda3e3fc h1:rvFmks+xFSvysY1Tm91FX64bYAQ9ebusa2/4RmSlqTE=
+github.com/bnb-chain/juno/v4 v4.0.0-20230331063806-f6cddda3e3fc/go.mod h1:I+J7Cdpzc7U+0ULxIDZw5zzsDAX8352JN5vtuEz1dg4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/bradfitz/gomemcache v0.0.0-20170208213004-1952afaa557d/go.mod h1:PmM6Mmwb0LSuEubjR8N7PtNe1KxZLtOUHtbeikc5h60=


### PR DESCRIPTION
### Description

upgrade juno version for a fix. It expands the length of property 'ObjectName'

### Rationale

It's a requirement from front-end, we need to give 'Object' a finer-grained distinction, so we may add timestamp or other info as a suffix of 'ObjectName'. So we need to add length of this property. We did this in juno and this PR is to upgrade juno version.

### Example

N/A

### Changes

Notable changes: 
* add length of 'ObjectName'

