### PR TITLE
feat: add nat manager for p2p

### DIFF
--- a/pkg/p2p/node.go
+++ b/pkg/p2p/node.go
@@ -16,6 +16,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoreds"
+	"github.com/libp2p/go-libp2p/p2p/security/noise"
 
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/p2p/types"
@@ -66,6 +67,8 @@ func NewNode(config *NodeConfig, SPAddr string, signer *signerclient.SignerClien
 		// dynamic updates permanent nodes
 		libp2p.Ping(false),
 		libp2p.NATPortMap(),
+		// support noise connections
+		libp2p.Security(noise.ID, noise.New),
 		libp2p.WithDialTimeout(time.Duration(DailTimeout)*time.Second),
 	)
 	if err != nil {

--- a/pkg/p2p/node.go
+++ b/pkg/p2p/node.go
@@ -65,6 +65,7 @@ func NewNode(config *NodeConfig, SPAddr string, signer *signerclient.SignerClien
 		// to the same sp all fail and are replaced, then the sp will be unable to communicate, this requires
 		// dynamic updates permanent nodes
 		libp2p.Ping(false),
+		libp2p.NATPortMap(),
 		libp2p.WithDialTimeout(time.Duration(DailTimeout)*time.Second),
 	)
 	if err != nil {


### PR DESCRIPTION
### Description

Add nat manager for p2p node.

### Rationale

In consideration of network security and deployment efficiency, need to be fixed the public IP and protect private ip. 

### Example

N/A

### Changes

Notable changes: 
N/A

