### PR TITLE
feat: support dns for p2p node

### DIFF
--- a/pkg/p2p/node_config.go
+++ b/pkg/p2p/node_config.go
@@ -130,7 +130,8 @@ func MakeBootstrapMultiaddr(bootstrap []string) (peersID []peer.ID, addrs []ma.M
 			}
 			// addr corresponds to node id one by one, only use the first
 			for _, h := range hosts {
-				if net.ParseIP(h) == nil {
+				// TODO:: support IPv6
+				if strings.Contains(h, ":") {
 					continue
 				}
 				host = h

--- a/pkg/p2p/node_config.go
+++ b/pkg/p2p/node_config.go
@@ -121,11 +121,11 @@ func MakeBootstrapMultiaddr(bootstrap []string) (peersID []peer.ID, addrs []ma.M
 		if net.ParseIP(host) == nil {
 			hosts, err := net.LookupHost(host)
 			if err != nil {
-				err = fmt.Errorf("failed to parser bootstrap '%s' domain", boot)
+				err = fmt.Errorf("failed to parse bootstrap '%s' domain", boot)
 				return peersID, addrs, err
 			}
 			if len(hosts) == 0 {
-				err = fmt.Errorf("failed to parser bootstrap '%s' domain, the empty ip list", boot)
+				err = fmt.Errorf("failed to parse bootstrap '%s' domain, the empty ip list", boot)
 				return peersID, addrs, err
 			}
 			// addr corresponds to node id one by one, only use the first
@@ -138,7 +138,7 @@ func MakeBootstrapMultiaddr(bootstrap []string) (peersID []peer.ID, addrs []ma.M
 				break
 			}
 			if net.ParseIP(host) == nil {
-				err = fmt.Errorf("failed to parser bootstrap '%s' domain, no usable ip", boot)
+				err = fmt.Errorf("failed to parse bootstrap '%s' domain, no usable ip", boot)
 				return peersID, addrs, err
 			}
 		}

--- a/pkg/p2p/node_config.go
+++ b/pkg/p2p/node_config.go
@@ -129,7 +129,17 @@ func MakeBootstrapMultiaddr(bootstrap []string) (peersID []peer.ID, addrs []ma.M
 				return peersID, addrs, err
 			}
 			// addr corresponds to node id one by one, only use the first
-			host = hosts[0]
+			for _, h := range hosts {
+				if net.ParseIP(h) == nil {
+					continue
+				}
+				host = h
+				break
+			}
+			if net.ParseIP(host) == nil {
+				err = fmt.Errorf("failed to parser bootstrap '%s' domain, no usable ip", boot)
+				return peersID, addrs, err
+			}
 		}
 		port, err := strconv.Atoi(strings.TrimSpace(addrInfo[1]))
 		if err != nil {

--- a/pkg/p2p/node_config.go
+++ b/pkg/p2p/node_config.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"encoding/hex"
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -117,6 +118,19 @@ func MakeBootstrapMultiaddr(bootstrap []string) (peersID []peer.ID, addrs []ma.M
 			return peersID, addrs, err
 		}
 		host := strings.TrimSpace(addrInfo[0])
+		if net.ParseIP(host) == nil {
+			hosts, err := net.LookupHost(host)
+			if err != nil {
+				err = fmt.Errorf("failed to parser bootstrap '%s' domain", boot)
+				return peersID, addrs, err
+			}
+			if len(hosts) == 0 {
+				err = fmt.Errorf("failed to parser bootstrap '%s' domain, the empty ip list", boot)
+				return peersID, addrs, err
+			}
+			// addr corresponds to node id one by one, only use the first
+			host = hosts[0]
+		}
 		port, err := strconv.Atoi(strings.TrimSpace(addrInfo[1]))
 		if err != nil {
 			return peersID, addrs, err

--- a/pkg/p2p/node_config_test.go
+++ b/pkg/p2p/node_config_test.go
@@ -1,0 +1,54 @@
+package p2p
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDNSParser(t *testing.T) {
+	dns := "localhost"
+	hosts, err := net.LookupHost(dns)
+	require.NoError(t, err)
+	for _, host := range hosts {
+		fmt.Println(host)
+	}
+}
+
+func TestBootstrapParser(t *testing.T) {
+	testCases := []struct {
+		name      string
+		bootstrap []string
+	}{
+		{
+			name: "domain",
+			bootstrap: []string{
+				"16Uiu2HAmBzdPttaxicSDEf5Kq1XBnoH97wRFA8aiWEnYc2hp2ZHW@localhost:9933",
+			},
+		},
+		{
+			name: "ip",
+			bootstrap: []string{
+				"16Uiu2HAmBzdPttaxicSDEf5Kq1XBnoH97wRFA8aiWEnYc2hp2ZHW@0.0.0.0:9933",
+			},
+		},
+		{
+			name: "domain and ip mix",
+			bootstrap: []string{
+				"16Uiu2HAmBzdPttaxicSDEf5Kq1XBnoH97wRFA8aiWEnYc2hp2ZHW@localhost:9933",
+				"16Uiu2HAmBzdPttaxicSDEf5Kq1XBnoH97wRFA8aiWEnYc2hp2ZHW@0.0.0.0:9933",
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			peersIDs, addrs, err := MakeBootstrapMultiaddr(testCase.bootstrap)
+			require.NoError(t, err)
+			for i, addr := range addrs {
+				fmt.Println("peerID: " + peersIDs[i].String() + ", addr" + addr.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description

Support DNS for p2p bootstrap node

### Rationale

Use for k8s ALB and NLB

### Example

N/A

### Changes

Notable changes: 

N/A
