### PR TITLE
feat: adds seal object metrics and refine some codes

### DIFF
--- a/pkg/metrics/metric_items.go
+++ b/pkg/metrics/metric_items.go
@@ -7,6 +7,8 @@ import (
 	metricshttp "github.com/bnb-chain/greenfield-storage-provider/pkg/metrics/http"
 )
 
+const serviceLabelName = "service"
+
 // this file is used to write metric items in sp service
 var (
 	// DefaultGRPCServerMetrics create default gRPC server metrics
@@ -16,14 +18,31 @@ var (
 		openmetrics.WithClientStreamSendHistogram(), openmetrics.WithClientStreamRecvHistogram())
 	// DefaultHTTPServerMetrics create default HTTP server metrics
 	DefaultHTTPServerMetrics = metricshttp.NewServerMetrics()
-	// PanicsTotal record the number of rpc panics
+
+	// PanicsTotal records the number of rpc panics
 	PanicsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "grpc_req_panics_recovered_total",
 		Help: "Total number of gRPC requests recovered from internal panic.",
 	}, []string{"grpc_type", "grpc_service", "grpc_method"})
-	// BlockHeightLagGauge record the current block height of block syncer service
+	// BlockHeightLagGauge records the current block height of block syncer service
 	BlockHeightLagGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "block_syncer_height",
 		Help: "Current block number of block syncer progress.",
-	}, []string{"service"})
+	}, []string{serviceLabelName})
+	// SealObjectTimeHistogram records sealing object time of task node service
+	SealObjectTimeHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "task_node_seal_object_time",
+		Help:    "Track task node service the time of sealing object on chain.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{serviceLabelName})
+	// SealObjectTotalCounter records total seal object number
+	SealObjectTotalCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "task_node_seal_object_total",
+		Help: "Track task node service handles total seal object number",
+	}, []string{"success_or_failure"})
+	// ReplicateObjectTaskGauge records total replicate object number
+	ReplicateObjectTaskGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "task_node_replicate_object_task_number",
+		Help: "Track task node service replicate object task",
+	}, []string{serviceLabelName})
 )

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -97,7 +97,8 @@ func (m *Metrics) Enabled() bool {
 
 func (m *Metrics) registerMetricItems() {
 	m.registry.MustRegister(DefaultGRPCServerMetrics, DefaultGRPCClientMetrics, DefaultHTTPServerMetrics,
-		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}), PanicsTotal, BlockHeightLagGauge)
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}), PanicsTotal, BlockHeightLagGauge,
+		SealObjectTimeHistogram, SealObjectTotalCounter, ReplicateObjectTaskGauge)
 }
 
 func (m *Metrics) serve() {

--- a/store/sqldb/traffic.go
+++ b/store/sqldb/traffic.go
@@ -6,10 +6,12 @@ import (
 	"time"
 
 	merrors "github.com/bnb-chain/greenfield-storage-provider/model/errors"
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
 	"gorm.io/gorm"
 )
 
 // CheckQuotaAndAddReadRecord check current quota, and add read record
+// TODO: Traffic statistics may be inaccurate in extreme cases, optimize it in the future
 func (s *SpDBImpl) CheckQuotaAndAddReadRecord(record *ReadRecord, quota *BucketQuota) error {
 	yearMonth := TimeToYearMonth(TimestampUsToTime(record.ReadTimestampUs))
 	bucketTraffic, err := s.GetBucketTraffic(record.BucketID, yearMonth)
@@ -30,6 +32,9 @@ func (s *SpDBImpl) CheckQuotaAndAddReadRecord(record *ReadRecord, quota *BucketQ
 		if result.Error != nil {
 			return fmt.Errorf("failed to insert bucket traffic table: %s", result.Error)
 		}
+		if result.RowsAffected != 1 {
+			log.Infow("insert traffic", "RowsAffected", result.RowsAffected, "record", record, "quota", quota)
+		}
 		bucketTraffic = &BucketTraffic{
 			BucketID:         insertBucketTraffic.BucketID,
 			YearMonth:        insertBucketTraffic.Month,
@@ -49,6 +54,9 @@ func (s *SpDBImpl) CheckQuotaAndAddReadRecord(record *ReadRecord, quota *BucketQ
 		if result.Error != nil {
 			return fmt.Errorf("failed to update bucket traffic table: %s", result.Error)
 		}
+		if result.RowsAffected != 1 {
+			log.Infow("update traffic", "RowsAffected", result.RowsAffected, "record", record, "quota", quota)
+		}
 		bucketTraffic.ReadQuotaSize = quota.ReadQuotaSize
 	}
 
@@ -66,6 +74,9 @@ func (s *SpDBImpl) CheckQuotaAndAddReadRecord(record *ReadRecord, quota *BucketQ
 		})
 	if result.Error != nil {
 		return fmt.Errorf("failed to update bucket traffic table: %s", result.Error)
+	}
+	if result.RowsAffected != 1 {
+		log.Infow("update traffic", "RowsAffected", result.RowsAffected, "record", record, "quota", quota)
 	}
 
 	// add read record


### PR DESCRIPTION
### Description

1. TaskNode service adds seal object metrics.
2. Refine the replicate task and add some DB logs.

### Rationale

N/A

### Example

N/A

### Changes

* TaskNode/SQLDB.
