### PR TITLE
feat: update schema and order for list deleted objects

### DIFF
--- a/proto/service/metadata/types/metadata.proto
+++ b/proto/service/metadata/types/metadata.proto
@@ -22,6 +22,8 @@ message Object {
   string locked_balance = 2;
   // removed defines the object is deleted or not
   bool removed = 3;
+  // update_at defines the block number when the object updated
+  int64 update_at = 4;
 }
 
 // GetUserBucketsRequest is request type for the GetUserBuckets RPC method.

--- a/service/metadata/service/object.go
+++ b/service/metadata/service/object.go
@@ -40,6 +40,7 @@ func (metadata *Metadata) ListObjectsByBucketName(ctx context.Context, req *meta
 			},
 			LockedBalance: object.LockedBalance.String(),
 			Removed:       object.Removed,
+			UpdateAt:      object.UpdateAt,
 		})
 	}
 
@@ -88,6 +89,7 @@ func (metadata *Metadata) ListDeletedObjectsByBlockNumberRange(ctx context.Conte
 			},
 			LockedBalance: object.LockedBalance.String(),
 			Removed:       object.Removed,
+			UpdateAt:      object.UpdateAt,
 		})
 	}
 

--- a/store/bsdb/object.go
+++ b/store/bsdb/object.go
@@ -27,7 +27,7 @@ func (b *BsDBImpl) ListDeletedObjectsByBlockNumberRange(startBlockNumber int64, 
 			Select("*").
 			Where("update_at >= ? and update_at <= ? and removed = ?", startBlockNumber, endBlockNumber, true).
 			Limit(DeletedObjectsDefaultSize).
-			Order("update_at asc").
+			Order("update_at,object_id asc").
 			Find(&objects).Error
 		return objects, err
 	}
@@ -38,7 +38,7 @@ func (b *BsDBImpl) ListDeletedObjectsByBlockNumberRange(startBlockNumber int64, 
 			"(objects.visibility='VISIBILITY_TYPE_PUBLIC_READ') or (objects.visibility='VISIBILITY_TYPE_INHERIT' and buckets.visibility='VISIBILITY_TYPE_PUBLIC_READ')",
 			startBlockNumber, endBlockNumber, true).
 		Limit(DeletedObjectsDefaultSize).
-		Order("objects.update_at asc").
+		Order("objects.update_at, objects.object_id asc").
 		Find(&objects).Error
 	return objects, err
 }


### PR DESCRIPTION
### Description

An additional response field `update_at` has been added, and data with the same `update_at` object will be sorted by object ID. 

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 
* Update new response field update_at
* Same `update_at` object will be sorted by object ID. 