### PR TITLE
feat: add task scheduler

### DIFF
--- a/cmd/storage_provider/main.go
+++ b/cmd/storage_provider/main.go
@@ -151,9 +151,10 @@ func storageProvider(ctx *cli.Context) error {
 		service, err := initService(serviceName, cfg)
 		if err != nil {
 			log.Errorw("failed to init service", "service", serviceName, "error", err)
+			fmt.Println("failed to init service", "service", serviceName, "error", err)
 			os.Exit(1)
 		}
-		log.Debugw("succeed to init service ", "service", serviceName)
+		log.Debugw("succeed to init service", "service", serviceName)
 		// register service to lifecycle.
 		slc.RegisterServices(service)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 
+	"github.com/bnb-chain/greenfield-storage-provider/service/manager"
 	"github.com/naoina/toml"
 
 	"github.com/bnb-chain/greenfield-storage-provider/model"
@@ -36,6 +37,7 @@ type StorageProviderConfig struct {
 	LogCfg            *LogConfig
 	MetricsCfg        *metrics.MetricsConfig
 	RateLimiter       *localhttp.RateLimiterConfig
+	ManagerCfg        *manager.ManagerConfig
 }
 
 // JSONMarshal marshal the StorageProviderConfig to json format
@@ -74,6 +76,7 @@ var DefaultStorageProviderConfig = &StorageProviderConfig{
 		model.MetadataService:   model.MetadataGRPCAddress,
 		model.P2PService:        model.P2PGRPCAddress,
 		model.AuthService:       model.AuthGRPCAddress,
+		model.ManagerService:    model.ManagerGRPCAddress,
 	},
 	Endpoint: map[string]string{
 		model.GatewayService:    "gnfd.test-sp.com",
@@ -86,6 +89,7 @@ var DefaultStorageProviderConfig = &StorageProviderConfig{
 		model.MetadataService:   model.MetadataGRPCAddress,
 		model.P2PService:        model.P2PGRPCAddress,
 		model.AuthService:       model.AuthGRPCAddress,
+		model.ManagerService:    model.ManagerGRPCAddress,
 	},
 	SpOperatorAddress: hex.EncodeToString([]byte(model.SpOperatorAddress)),
 	SpDBConfig:        DefaultSQLDBConfig,
@@ -97,6 +101,7 @@ var DefaultStorageProviderConfig = &StorageProviderConfig{
 	LogCfg:            DefaultLogConfig,
 	MetricsCfg:        DefaultMetricsConfig,
 	RateLimiter:       DefaultRateLimiterConfig,
+	ManagerCfg:        manager.DefaultManagerConfig,
 }
 
 // DefaultSQLDBConfig defines the default configuration of SQL DB

--- a/config/subconfig.go
+++ b/config/subconfig.go
@@ -220,6 +220,11 @@ func (cfg *StorageProviderConfig) MakeTaskNodeConfig() (*tasknode.TaskNodeConfig
 	} else {
 		return nil, fmt.Errorf("missing p2p server gRPC address configuration for task node service")
 	}
+	if _, ok := cfg.Endpoint[model.ManagerService]; ok {
+		snCfg.ManagerGrpcAddress = cfg.Endpoint[model.ManagerService]
+	} else {
+		return nil, fmt.Errorf("missing manager server gRPC address configuration for task node service")
+	}
 	return snCfg, nil
 }
 

--- a/config/subconfig.go
+++ b/config/subconfig.go
@@ -130,6 +130,11 @@ func (cfg *StorageProviderConfig) MakeUploaderConfig() (*uploader.UploaderConfig
 	} else {
 		return nil, fmt.Errorf("missing task node gRPC address configuration for uploader service")
 	}
+	if _, ok := cfg.Endpoint[model.ManagerService]; ok {
+		uCfg.ManagerGrpcAddress = cfg.Endpoint[model.ManagerService]
+	} else {
+		return nil, fmt.Errorf("missing manager gRPC address configuration for uploader service")
+	}
 	return uCfg, nil
 }
 
@@ -232,11 +237,16 @@ func (cfg *StorageProviderConfig) MakeMetadataServiceConfig() (*metadata.Metadat
 }
 
 // MakeManagerServiceConfig make manager service config from StorageProviderConfig
+// TODO: refine it
 func (cfg *StorageProviderConfig) MakeManagerServiceConfig() (*manager.ManagerConfig, error) {
-	managerConfig := &manager.ManagerConfig{
-		SpOperatorAddress: cfg.SpOperatorAddress,
-		ChainConfig:       cfg.ChainConfig,
-		SpDBConfig:        cfg.SpDBConfig,
+	managerConfig := manager.DefaultManagerConfig
+	managerConfig.SpOperatorAddress = cfg.SpOperatorAddress
+	managerConfig.ChainConfig = cfg.ChainConfig
+	managerConfig.SpDBConfig = cfg.SpDBConfig
+	if _, ok := cfg.ListenAddress[model.ManagerService]; ok {
+		managerConfig.GRPCAddress = cfg.ListenAddress[model.ManagerService]
+	} else {
+		return nil, fmt.Errorf("missing manager gRPC address configuration for manager service")
 	}
 	return managerConfig, nil
 }

--- a/deployment/localup/localup.sh
+++ b/deployment/localup/localup.sh
@@ -83,8 +83,9 @@ make_config() {
         sed -i -e "s/9733/$(($cur_port+733))/g" config.toml
         sed -i -e "s/9833/$(($cur_port+833))/g" config.toml
         sed -i -e "s/9933/$(($cur_port+933))/g" config.toml
+        sed -i -e "s/9934/$(($cur_port+934))/g" config.toml
+        sed -i -e "s/9935/$(($cur_port+935))/g" config.toml
         sed -i -e "s/24036/$(($cur_port+4036))/g" config.toml
-        sed -i -e "s/8933/$(($cur_port+33))/g" config.toml
         sed -i -e "s/SpOperatorAddress = \".*\"/SpOperatorAddress = \"${OPERATOR_ADDRESS}\"/g" config.toml
         sed -i -e "s/OperatorPrivateKey = \".*\"/OperatorPrivateKey = \"${OPERATOR_PRIVATE_KEY}\"/g" config.toml
         sed -i -e "s/FundingPrivateKey = \".*\"/FundingPrivateKey = \"${FUNDING_PRIVATE_KEY}\"/g" config.toml

--- a/model/const.go
+++ b/model/const.go
@@ -72,7 +72,9 @@ const (
 	// P2PListenAddress default p2p protocol listen address of p2p node
 	P2PListenAddress = "127.0.0.1:9933"
 	// AuthGRPCAddress default gRPC address of auth service
-	AuthGRPCAddress = "localhost:8933"
+	AuthGRPCAddress = "localhost:9934"
+	// ManagerGRPCAddress default gRPC address of manager
+	ManagerGRPCAddress = "localhost:9935"
 )
 
 // define greenfield chain default address

--- a/model/errors/rpc_error.go
+++ b/model/errors/rpc_error.go
@@ -108,6 +108,22 @@ var (
 	ErrExhaustedSP = errors.New("backup storage providers exhausted")
 )
 
+// manager service error
+var (
+	// ErrUnsupportedTaskType defines the unsupported task type error
+	ErrUnsupportedTaskType = errors.New("task type unsupported")
+	// ErrDanglingTaskPointer defines the task pointer dangling error
+	ErrDanglingTaskPointer = errors.New("task pointer dangling")
+	// ErrUnsupportedDispatchTaskType defines the unsupported dispatch task type error
+	ErrUnsupportedDispatchTaskType = errors.New("task type unsupported dispatch")
+	//ErrRepeatedTask defines task repeated error
+	ErrRepeatedTask = errors.New("task repeated")
+	//ErrExceedUploadParallel defines upload object parallel number exceed error
+	ErrExceedUploadParallel = errors.New("upload object parallel number exceed")
+	// ErrTaskCanceled defines the task has been canceled error
+	ErrTaskCanceled = errors.New("task has been canceled")
+)
+
 // uploader service error
 var (
 	// ErrMismatchIntegrityHash defines integrity hash mismatch error

--- a/model/errors/rpc_error.go
+++ b/model/errors/rpc_error.go
@@ -116,9 +116,9 @@ var (
 	ErrDanglingTaskPointer = errors.New("task pointer dangling")
 	// ErrUnsupportedDispatchTaskType defines the unsupported dispatch task type error
 	ErrUnsupportedDispatchTaskType = errors.New("task type unsupported dispatch")
-	//ErrRepeatedTask defines task repeated error
+	// ErrRepeatedTask defines task repeated error
 	ErrRepeatedTask = errors.New("task repeated")
-	//ErrExceedUploadParallel defines upload object parallel number exceed error
+	// ErrExceedUploadParallel defines upload object parallel number exceed error
 	ErrExceedUploadParallel = errors.New("upload object parallel number exceed")
 	// ErrTaskCanceled defines the task has been canceled error
 	ErrTaskCanceled = errors.New("task has been canceled")

--- a/pkg/p2p/node.go
+++ b/pkg/p2p/node.go
@@ -42,7 +42,7 @@ func NewNode(config *NodeConfig, SPAddr string, signer *signerclient.SignerClien
 	if config.PingPeriod < PingPeriodMin {
 		config.PingPeriod = PingPeriodMin
 	}
-	privKey, localAddr, bootstrapIDs, bootstrapAddrs, err := config.ParseConfing()
+	privKey, localAddr, bootstrapIDs, bootstrapAddrs, err := config.ParseConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +222,7 @@ func (n *Node) sendToPeer(peerID peer.ID, pc protocol.ID, data proto.Message) er
 		n.peers.DeletePeer(peerID)
 		return err
 	}
-	// log.Debugw("success to send msg", "peer_id", peerID, "protocol", pc, "msg", data.String())
+	// log.Debugw("succeed to send msg", "peer_id", peerID, "protocol", pc, "msg", data.String())
 	s.Close()
 	return err
 }

--- a/pkg/p2p/node.go
+++ b/pkg/p2p/node.go
@@ -197,7 +197,7 @@ func (n *Node) eventLoop() {
 // broadcast sends request to all p2p nodes
 func (n *Node) broadcast(pc protocol.ID, data proto.Message) {
 	for _, peerID := range n.node.Peerstore().PeersWithAddrs() {
-		log.Debugw("broadcast msg to peer", "peer_id", peerID, "protocol", pc)
+		// log.Debugw("broadcast msg to peer", "peer_id", peerID, "protocol", pc)
 		if strings.Compare(n.node.ID().String(), peerID.String()) == 0 {
 			continue
 		}
@@ -222,7 +222,7 @@ func (n *Node) sendToPeer(peerID peer.ID, pc protocol.ID, data proto.Message) er
 		n.peers.DeletePeer(peerID)
 		return err
 	}
-	log.Debugw("success to send msg", "peer_id", peerID, "protocol", pc, "msg", data.String())
+	// log.Debugw("success to send msg", "peer_id", peerID, "protocol", pc, "msg", data.String())
 	s.Close()
 	return err
 }

--- a/pkg/p2p/node_config.go
+++ b/pkg/p2p/node_config.go
@@ -29,7 +29,7 @@ const (
 
 // NodeConfig defines the p2p node config
 type NodeConfig struct {
-	// ListenAddress defines the p2p listen address, used to make multiaddr
+	// ListenAddress defines the p2p listen address, used to make multi-addr
 	ListenAddress string
 	// P2PPrivateKey defines the p2p node private key, only support Secp256k1
 	// if default value, creates random private-public key pairs
@@ -49,8 +49,8 @@ func (cfg *NodeConfig) overrideConfigFromEnv() {
 	}
 }
 
-// ParseConfing parsers the configuration into a format that go-libp2p can use
-func (cfg *NodeConfig) ParseConfing() (privKey crypto.PrivKey, hostAddr ma.Multiaddr, bootstrapIDs []peer.ID, bootstrapAddrs []ma.Multiaddr, err error) {
+// ParseConfig parsers the configuration into a format that go-libp2p can use
+func (cfg *NodeConfig) ParseConfig() (privKey crypto.PrivKey, hostAddr ma.Multiaddr, bootstrapIDs []peer.ID, bootstrapAddrs []ma.Multiaddr, err error) {
 	cfg.overrideConfigFromEnv()
 	if len(cfg.P2PPrivateKey) > 0 {
 		priKeyBytes, err := hex.DecodeString(cfg.P2PPrivateKey)
@@ -83,7 +83,7 @@ func (cfg *NodeConfig) ParseConfing() (privKey crypto.PrivKey, hostAddr ma.Multi
 	}
 	hostAddr, err = MakeMultiaddr(host, port)
 	if err != nil {
-		log.Errorw("failed to make local mulit addr", "address", cfg.ListenAddress, "error", err)
+		log.Errorw("failed to make local multi addr", "address", cfg.ListenAddress, "error", err)
 		return privKey, hostAddr, bootstrapIDs, bootstrapAddrs, err
 	}
 	bootstrapIDs, bootstrapAddrs, err = MakeBootstrapMultiaddr(cfg.Bootstrap)

--- a/pkg/p2p/ping.go
+++ b/pkg/p2p/ping.go
@@ -31,7 +31,7 @@ func (n *Node) onPing(s network.Stream) {
 			log.Warnw("failed to response ping", "peer_id", peerID, "error", err)
 			return
 		}
-		log.Debugw("success to response ping", "peer_id", peerID)
+		// log.Debugw("succeed to response ping", "peer_id", peerID)
 	}()
 	ping := &types.Ping{}
 	buf, err := io.ReadAll(s)
@@ -46,7 +46,7 @@ func (n *Node) onPing(s network.Stream) {
 		log.Errorw("failed to unmarshal ping msg", "error", err)
 		return
 	}
-	log.Debugf("%s received ping request from %s. Message: %s", s.Conn().LocalPeer(), s.Conn().RemotePeer(), ping.String())
+	// log.Debugf("%s received ping request from %s. Message: %s", s.Conn().LocalPeer(), s.Conn().RemotePeer(), ping.String())
 
 	err = types.VerifySignature(ping.GetSpOperatorAddress(), ping.GetSignBytes(), ping.GetSignature())
 	if err != nil {
@@ -66,7 +66,7 @@ func (n *Node) onPing(s network.Stream) {
 			nodeInfo.MultiAddr = append(nodeInfo.MultiAddr, addr.String())
 		}
 		pong.Nodes = append(pong.Nodes, nodeInfo)
-		log.Debugw("send node to remote", "node_id", pID.String(), "remote_node", s.Conn().RemotePeer())
+		// log.Debugw("send node to remote", "node_id", pID.String(), "remote_node", s.Conn().RemotePeer())
 	}
 	pong.SpOperatorAddress = n.SpOperatorAddress
 	pong, err = n.signer.SignPongMsg(context.Background(), pong)
@@ -89,7 +89,7 @@ func (n *Node) onPong(s network.Stream) {
 			log.Warnw("failed to receive pong", "peer_id", peerID, "error", err)
 			return
 		}
-		log.Debugw("success to receive pong", "peer_id", peerID)
+		// log.Debugw("succeed to receive pong", "peer_id", peerID)
 	}()
 	pong := &types.Pong{}
 	buf, err := io.ReadAll(s)
@@ -104,7 +104,7 @@ func (n *Node) onPong(s network.Stream) {
 		log.Errorw("failed to unmarshal ping msg", "error", err)
 		return
 	}
-	log.Debugf("%s received pong request from %s.", s.Conn().LocalPeer(), s.Conn().RemotePeer())
+	// log.Debugf("%s received pong request from %s.", s.Conn().LocalPeer(), s.Conn().RemotePeer())
 
 	err = types.VerifySignature(pong.GetSpOperatorAddress(), pong.GetSignBytes(), pong.GetSignature())
 	if err != nil {
@@ -127,6 +127,6 @@ func (n *Node) onPong(s network.Stream) {
 			addrs = append(addrs, addr)
 		}
 		n.node.Peerstore().AddAddrs(pID, addrs, peerstore.PermanentAddrTTL)
-		log.Debugw("receive node from remote and permanent", "remote_node", s.Conn().RemotePeer(), "node_id", pID)
+		// log.Debugw("receive node from remote and permanent", "remote_node", s.Conn().RemotePeer(), "node_id", pID)
 	}
 }

--- a/pkg/rcmgr/error.go
+++ b/pkg/rcmgr/error.go
@@ -66,3 +66,31 @@ func logValuesConnLimit(scope, edge string, dir Direction, stat ScopeStat, err e
 	}
 	return append(logValues, "stat", stat, "error", err)
 }
+
+type ErrTaskLimitExceeded struct {
+	priority                  ReserveTaskPriority
+	current, attempted, limit int
+	err                       error
+}
+
+func (e *ErrTaskLimitExceeded) Error() string { return e.err.Error() }
+func (e *ErrTaskLimitExceeded) Unwrap() error { return e.err }
+
+// edge may be empty if this is not an edge error
+func logValuesTaskLimit(scope, edge string, stat ScopeStat, err error) []interface{} {
+	logValues := make([]interface{}, 0, 2*8)
+	logValues = append(logValues, "scope", scope)
+	if edge != "" {
+		logValues = append(logValues, "edge", edge)
+	}
+	var e *ErrTaskLimitExceeded
+	if errors.As(err, &e) {
+		logValues = append(logValues,
+			"priority", e.priority,
+			"current", e.current,
+			"attempted", e.attempted,
+			"limit", e.limit,
+		)
+	}
+	return append(logValues, "stat", stat, "error", err)
+}

--- a/pkg/rcmgr/limit.go
+++ b/pkg/rcmgr/limit.go
@@ -18,17 +18,17 @@ type Limit interface {
 	GetFDLimit() int
 	// GetConnLimit returns the connection limit, for inbound or outbound connections.
 	GetConnLimit(Direction) int
-	// GetConnTotalLimit returns the total connection limit
+	// GetConnTotalLimit returns the total connection limit.
 	GetConnTotalLimit() int
 	// GetTaskLimit returns the task limit, for high, medium and low priority tasks.
 	GetTaskLimit(ReserveTaskPriority) int
-	// GetTaskTotalLimit returns the total task limit
+	// GetTaskTotalLimit returns the total task limit.
 	GetTaskTotalLimit() int
-	// Greater returns an indicator whether cover the param limit
+	// Greater returns an indicator whether cover the param limit.
 	Greater(Limit) bool
-	// Equal returns an indicator whether equal the param limit
+	// Equal returns an indicator whether equal the param limit.
 	Equal(Limit) bool
-	// String returns the Limit state string
+	// String returns the Limit state string.
 	String() string
 }
 
@@ -44,6 +44,8 @@ var _ Limit = &BaseLimit{}
 
 // BaseLimit is a mixin type for basic resource limits.
 type BaseLimit struct {
+	Memory              int64 `json:",omitempty"`
+	FD                  int   `json:",omitempty"`
 	Conns               int   `json:",omitempty"`
 	ConnsInbound        int   `json:",omitempty"`
 	ConnsOutbound       int   `json:",omitempty"`
@@ -51,8 +53,6 @@ type BaseLimit struct {
 	TasksHighPriority   int   `json:",omitempty"`
 	TasksMediumPriority int   `json:",omitempty"`
 	TasksLowPriority    int   `json:",omitempty"`
-	FD                  int   `json:",omitempty"`
-	Memory              int64 `json:",omitempty"`
 }
 
 // GetMemoryLimit returns the (current) memory limit.
@@ -73,12 +73,12 @@ func (limit *BaseLimit) GetConnLimit(direction Direction) int {
 	return limit.ConnsOutbound
 }
 
-// GetConnTotalLimit returns the total connection limit
+// GetConnTotalLimit returns the total connection limit.
 func (limit *BaseLimit) GetConnTotalLimit() int {
 	return limit.Conns
 }
 
-// GetTaskTotalLimit returns the total task limit
+// GetTaskTotalLimit returns the total task limit.
 func (limit *BaseLimit) GetTaskTotalLimit() int {
 	return limit.Tasks
 }
@@ -97,15 +97,15 @@ func (limit *BaseLimit) GetTaskLimit(priority ReserveTaskPriority) int {
 	}
 }
 
-// Greater returns an indicator whether cover the param limit
+// Greater returns an indicator whether cover the param limit.
 func (limit *BaseLimit) Greater(x Limit) bool {
 	if x == nil {
 		return true
 	}
-	if limit.FD < x.GetFDLimit() {
+	if limit.Memory < x.GetMemoryLimit() {
 		return false
 	}
-	if limit.Memory < x.GetMemoryLimit() {
+	if limit.FD < x.GetFDLimit() {
 		return false
 	}
 	if limit.Conns < x.GetConnTotalLimit() {
@@ -132,14 +132,15 @@ func (limit *BaseLimit) Greater(x Limit) bool {
 	return true
 }
 
+// Equal returns true iff limit is the same with x.
 func (limit *BaseLimit) Equal(x Limit) bool {
 	if x == nil {
 		return false
 	}
-	if limit.FD != x.GetFDLimit() {
+	if limit.Memory != x.GetMemoryLimit() {
 		return false
 	}
-	if limit.Memory != x.GetMemoryLimit() {
+	if limit.FD != x.GetFDLimit() {
 		return false
 	}
 	if limit.Conns != x.GetConnTotalLimit() {
@@ -166,7 +167,7 @@ func (limit *BaseLimit) Equal(x Limit) bool {
 	return true
 }
 
-// String returns the Limit state string
+// String returns the Limit state string.
 // TODO:: supports connection and fd field
 func (limit *BaseLimit) String() string {
 	return fmt.Sprintf("memory limits %d, task limits [h: %d, m: %d, l: %d]",
@@ -178,14 +179,14 @@ func (limit *BaseLimit) String() string {
 func InfiniteLimit() Limit {
 	return &BaseLimit{
 		Memory:              MaxLimitInt64,
+		FD:                  MaxLimitInt,
+		Conns:               MaxLimitInt,
+		ConnsInbound:        MaxLimitInt,
+		ConnsOutbound:       MaxLimitInt,
 		Tasks:               MaxLimitInt,
 		TasksHighPriority:   MaxLimitInt,
 		TasksMediumPriority: MaxLimitInt,
 		TasksLowPriority:    MaxLimitInt,
-		Conns:               MaxLimitInt,
-		ConnsInbound:        MaxLimitInt,
-		ConnsOutbound:       MaxLimitInt,
-		FD:                  MaxLimitInt,
 	}
 }
 

--- a/pkg/rcmgr/limit_conf.go
+++ b/pkg/rcmgr/limit_conf.go
@@ -19,7 +19,7 @@ type LimitConfig struct {
 }
 
 var DefaultLimitConfig = &LimitConfig{
-	SystemLimit: &InfiniteBaseLimit,
+	SystemLimit: InfiniteLimit().(*BaseLimit),
 	Service:     make(map[string]*BaseLimit),
 }
 

--- a/pkg/rcmgr/resoruce.go
+++ b/pkg/rcmgr/resoruce.go
@@ -10,11 +10,14 @@ import (
 
 // resources tracks the current state of resource consumption
 type resources struct {
-	limit     Limit
-	nconnsIn  int
-	nconnsOut int
-	nfd       int
-	memory    int64
+	limit        Limit
+	nconnsIn     int
+	nconnsOut    int
+	nfd          int
+	ntasksHigh   int
+	ntasksMedium int
+	ntasksLow    int
+	memory       int64
 }
 
 func addInt64WithOverflow(a int64, b int64) (c int64, ok bool) {
@@ -88,6 +91,84 @@ func (rc *resources) releaseMemory(size int64) {
 	if rc.memory < 0 {
 		log.Warn("BUG: too much memory released")
 		rc.memory = 0
+	}
+}
+
+func (rc *resources) addTask(num int, prio ReserveTaskPriority) error {
+	if prio == ReserveTaskPriorityHigh {
+		return rc.addTasks(num, 0, 0)
+	} else if prio == ReserveTaskPriorityMedium {
+		return rc.addTasks(0, num, 0)
+	} else {
+		return rc.addTasks(0, 0, num)
+	}
+}
+
+func (rc *resources) addTasks(high, medium, low int) error {
+	if rc.ntasksHigh+rc.ntasksMedium+rc.ntasksLow+high+medium+low > rc.limit.GetTaskTotalLimit() {
+		return &ErrTaskLimitExceeded{
+			current:   rc.ntasksHigh + rc.ntasksMedium + rc.ntasksLow,
+			attempted: high + medium + low,
+			limit:     rc.limit.GetTaskTotalLimit(),
+			err:       fmt.Errorf("total task limit exceeded: %w", ErrResourceLimitExceeded),
+		}
+	}
+	if high+rc.ntasksHigh > rc.limit.GetTaskLimit(ReserveTaskPriorityHigh) {
+		return &ErrTaskLimitExceeded{
+			current:   rc.ntasksHigh,
+			attempted: high,
+			limit:     rc.limit.GetTaskLimit(ReserveTaskPriorityHigh),
+			err:       fmt.Errorf("high priority task limit exceeded: %w", ErrResourceLimitExceeded),
+		}
+	}
+	if medium+rc.ntasksMedium > rc.limit.GetTaskLimit(ReserveTaskPriorityMedium) {
+		return &ErrTaskLimitExceeded{
+			current:   rc.ntasksMedium,
+			attempted: medium,
+			limit:     rc.limit.GetTaskLimit(ReserveTaskPriorityMedium),
+			err:       fmt.Errorf("medium priority task limit exceeded: %w", ErrResourceLimitExceeded),
+		}
+	}
+	if low+rc.ntasksLow > rc.limit.GetTaskLimit(ReserveTaskPriorityLow) {
+		return &ErrTaskLimitExceeded{
+			current:   rc.ntasksLow,
+			attempted: low,
+			limit:     rc.limit.GetTaskLimit(ReserveTaskPriorityLow),
+			err:       fmt.Errorf("low priority task limit exceeded: %w", ErrResourceLimitExceeded),
+		}
+	}
+	rc.ntasksHigh += high
+	rc.ntasksMedium += medium
+	rc.ntasksLow += low
+	return nil
+}
+
+func (rc *resources) removeTask(num int, prio ReserveTaskPriority) {
+	if prio == ReserveTaskPriorityHigh {
+		rc.removeTasks(num, 0, 0)
+	} else if prio == ReserveTaskPriorityMedium {
+		rc.removeTasks(0, num, 0)
+	} else if prio == ReserveTaskPriorityLow {
+		rc.removeTasks(0, 0, num)
+	}
+}
+
+func (rc *resources) removeTasks(high, medium, low int) {
+	rc.ntasksHigh -= high
+	rc.ntasksMedium -= medium
+	rc.ntasksLow -= low
+
+	if rc.ntasksHigh < 0 {
+		log.Error("BUG: too many high priority task released")
+		rc.ntasksHigh = 0
+	}
+	if rc.ntasksMedium < 0 {
+		log.Error("BUG: too many medium priority task released")
+		rc.ntasksMedium = 0
+	}
+	if rc.ntasksLow < 0 {
+		log.Error("BUG:  too many low priority task released")
+		rc.ntasksLow = 0
 	}
 }
 
@@ -176,6 +257,9 @@ func (rc *resources) removeConns(incount, outcount, fdcount int) {
 func (rc *resources) stat() ScopeStat {
 	return ScopeStat{
 		Memory:           rc.memory,
+		NumTasksHigh:     rc.ntasksHigh,
+		NumTasksMedium:   rc.ntasksMedium,
+		NumTasksLow:      rc.ntasksLow,
 		NumConnsInbound:  rc.nconnsIn,
 		NumConnsOutbound: rc.nconnsOut,
 		NumFD:            rc.nfd,

--- a/pkg/taskqueue/queue/errors.go
+++ b/pkg/taskqueue/queue/errors.go
@@ -1,0 +1,11 @@
+package queue
+
+import (
+	"errors"
+)
+
+var (
+	ErrQueueExceeded   = errors.New("task queue exceed")
+	ErrTaskRepeated    = errors.New("task repeated")
+	ErrUnsupportedTask = errors.New("task priority unsupported among queue")
+)

--- a/pkg/taskqueue/queue/priority_queue.go
+++ b/pkg/taskqueue/queue/priority_queue.go
@@ -1,0 +1,240 @@
+package queue
+
+import (
+	"sync"
+
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/rcmgr"
+	tqueue "github.com/bnb-chain/greenfield-storage-provider/pkg/taskqueue"
+)
+
+var _ tqueue.TPriorityQueueWithLimit = &TaskPriorityQueue{}
+
+type TaskPriorityQueue struct {
+	name         string
+	pqueue       map[tqueue.TPriority]tqueue.TQueueWithLimit
+	strategy     tqueue.TQueueStrategy
+	supportLimit bool
+	mux          sync.RWMutex
+}
+
+func NewTaskPriorityQueue(
+	name string,
+	pqueue map[tqueue.TPriority]tqueue.TQueueWithLimit,
+	strategy tqueue.TQueueStrategy,
+	limit bool) tqueue.TPriorityQueueWithLimit {
+	return &TaskPriorityQueue{
+		name:         name,
+		pqueue:       pqueue,
+		strategy:     strategy,
+		supportLimit: limit,
+	}
+}
+
+func (p *TaskPriorityQueue) SetStrategy(strategy tqueue.TQueueStrategy) {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+	p.strategy = strategy
+}
+
+func (p *TaskPriorityQueue) Len() int {
+	p.mux.RLock()
+	defer p.mux.RUnlock()
+	var length int
+	for _, queue := range p.pqueue {
+		length += queue.Len()
+	}
+	return length
+}
+
+func (p *TaskPriorityQueue) Cap() int {
+	p.mux.RLock()
+	defer p.mux.RUnlock()
+	var capacity int
+	for _, queue := range p.pqueue {
+		capacity += queue.Cap()
+	}
+	return capacity
+}
+
+func (p *TaskPriorityQueue) Top() tqueue.Task {
+	p.mux.RLock()
+	defer p.mux.RUnlock()
+	if len(p.pqueue) == 0 {
+		return nil
+	}
+	queue, ok := p.pqueue[p.getMaxPriority()]
+	if !ok {
+		log.Errorf("BUG: [%s] max priority out of bound", p.name)
+		return nil
+	}
+	return queue.Top()
+}
+
+func (p *TaskPriorityQueue) Pop() tqueue.Task {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+	if len(p.pqueue) == 0 {
+		return nil
+	}
+	queue, ok := p.pqueue[p.getMaxPriority()]
+	if !ok {
+		log.Errorf("BUG: [%s] max priority out of bound", p.name)
+		return nil
+	}
+	return queue.Pop()
+}
+
+func (p *TaskPriorityQueue) Push(task tqueue.Task) error {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+	prio := task.GetPriority()
+	if _, ok := p.pqueue[prio]; !ok {
+		log.Errorw("task priority unsupported", "queue", p.name, "priority", prio)
+		return ErrUnsupportedTask
+	}
+	queue := p.pqueue[prio]
+	return queue.Push(task)
+}
+
+func (p *TaskPriorityQueue) PopPush(task tqueue.Task) error {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+	prio := task.GetPriority()
+	if _, ok := p.pqueue[prio]; !ok {
+		log.Errorw("task priority unsupported", "queue", p.name, "priority", prio)
+		return ErrUnsupportedTask
+	}
+	queue := p.pqueue[prio]
+	return queue.PopPush(task)
+}
+
+func (p *TaskPriorityQueue) Has(key tqueue.TKey) bool {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+	for _, queue := range p.pqueue {
+		if queue.Has(key) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *TaskPriorityQueue) PopByKey(key tqueue.TKey) tqueue.Task {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+	for _, queue := range p.pqueue {
+		if task := queue.PopByKey(key); task != nil {
+			return task
+		}
+	}
+	return nil
+}
+
+func (p *TaskPriorityQueue) GetPriorities() []tqueue.TPriority {
+	p.mux.RLock()
+	defer p.mux.RUnlock()
+	var prios []tqueue.TPriority
+	for prio, _ := range p.pqueue {
+		prios = append(prios, prio)
+	}
+	return prios
+}
+
+func (p *TaskPriorityQueue) SetPriorityQueue(prio tqueue.TPriority, queue tqueue.TQueueWithLimit) error {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+	if _, ok := p.pqueue[prio]; ok {
+		return nil
+	}
+	p.pqueue[prio] = queue
+	return nil
+}
+
+func (p *TaskPriorityQueue) PopByLimit(limit rcmgr.Limit) tqueue.Task {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+	var tasks []tqueue.Task
+	for _, queue := range p.pqueue {
+		if !queue.GetSupportPickUpByLimit() {
+			continue
+		}
+		task := queue.PopByLimit(limit)
+		if task == nil {
+			continue
+		}
+		tasks = append(tasks, task)
+	}
+	task := p.strategy.RunPickUpStrategy(tasks)
+	for _, t := range tasks {
+		if task.GetPriority() == t.GetPriority() {
+			continue
+		}
+		queue := p.pqueue[t.GetPriority()]
+		queue.Push(t)
+	}
+	return task
+}
+
+func (p *TaskPriorityQueue) Expired(key tqueue.TKey) bool {
+	p.mux.RLock()
+	defer p.mux.RUnlock()
+	for _, queue := range p.pqueue {
+		if queue.Expired(key) {
+			return true
+		}
+	}
+	return false
+}
+
+func (q *TaskPriorityQueue) IsActiveTask(key tqueue.TKey) bool {
+	q.mux.RLock()
+	defer q.mux.RUnlock()
+	for _, queue := range q.pqueue {
+		if queue.IsActiveTask(key) {
+			return true
+		}
+	}
+	return false
+}
+
+func (q *TaskPriorityQueue) GetSupportPickUpByLimit() bool {
+	q.mux.RLock()
+	defer q.mux.RUnlock()
+	return q.supportLimit
+}
+
+func (q *TaskPriorityQueue) SetSupportPickUpByLimit(support bool) {
+	q.mux.Lock()
+	defer q.mux.Unlock()
+	q.supportLimit = support
+}
+
+func (p *TaskPriorityQueue) SubQueueLen(prio tqueue.TPriority) int {
+	p.mux.RLock()
+	defer p.mux.RUnlock()
+	return p.pqueue[prio].Len()
+}
+
+func (p *TaskPriorityQueue) RunCollection() {
+	p.mux.RLock()
+	defer p.mux.RUnlock()
+	for _, queue := range p.pqueue {
+		// performance should be better, otherwise it will block the write operation
+		queue.RunCollection()
+	}
+}
+
+func (p *TaskPriorityQueue) getMaxPriority() tqueue.TPriority {
+	var maxPrio tqueue.TPriority
+	for prio, queue := range p.pqueue {
+		if queue.Len() == 0 {
+			continue
+		}
+		if prio > maxPrio {
+			maxPrio = prio
+		}
+	}
+	log.Debugf("[%s] max priority [%d]", p.name, maxPrio)
+	return maxPrio
+}

--- a/pkg/taskqueue/queue/queue.go
+++ b/pkg/taskqueue/queue/queue.go
@@ -1,0 +1,208 @@
+package queue
+
+import (
+	"sync"
+
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/rcmgr"
+	tqueue "github.com/bnb-chain/greenfield-storage-provider/pkg/taskqueue"
+)
+
+var _ tqueue.TQueue = &TaskQueue{}
+var _ tqueue.TQueueWithLimit = &TaskQueue{}
+
+type TaskQueue struct {
+	name         string
+	tasks        []tqueue.Task
+	indexer      map[tqueue.TKey]int
+	cap          int
+	strategy     tqueue.TQueueStrategy
+	supportLimit bool
+	mux          sync.RWMutex
+}
+
+func NewTaskQueue(name string, cap int, strategy tqueue.TQueueStrategy, limit bool) tqueue.TQueueWithLimit {
+	queue := &TaskQueue{
+		name:         name,
+		tasks:        make([]tqueue.Task, 0),
+		indexer:      make(map[tqueue.TKey]int),
+		cap:          cap,
+		strategy:     strategy,
+		supportLimit: limit,
+	}
+	return queue
+}
+
+func (q *TaskQueue) Len() int {
+	q.mux.RLock()
+	defer q.mux.RUnlock()
+	return len(q.tasks)
+}
+
+func (q *TaskQueue) Cap() int {
+	q.mux.RLock()
+	defer q.mux.RUnlock()
+	return q.cap
+}
+
+func (q *TaskQueue) Top() tqueue.Task {
+	q.mux.RLock()
+	defer q.mux.RUnlock()
+	if len(q.tasks) == 0 {
+		return nil
+	}
+	return q.tasks[len(q.tasks)-1]
+}
+
+func (q *TaskQueue) Pop() tqueue.Task {
+	q.mux.Lock()
+	defer q.mux.Unlock()
+	if len(q.tasks) == 0 {
+		return nil
+	}
+	task := q.tasks[len(q.tasks)-1]
+	q.tasks = q.tasks[0 : len(q.tasks)-1]
+	delete(q.indexer, task.Key())
+	return task
+}
+
+func (q *TaskQueue) Push(task tqueue.Task) error {
+	q.mux.Lock()
+	defer q.mux.Unlock()
+	if _, ok := q.indexer[task.Key()]; ok {
+		log.Warnf("[%s] task has repeated", task.Key())
+		return ErrTaskRepeated
+	}
+	if len(q.tasks)+1 > q.cap {
+		log.Warnf("[%s] queue has exceeded, cap [%d]", q.name, q.cap)
+		return ErrQueueExceeded
+	}
+	q.tasks = append(q.tasks, task)
+	q.indexer[task.Key()] = len(q.tasks) - 1
+	return nil
+}
+
+func (q *TaskQueue) PopPush(task tqueue.Task) error {
+	q.mux.Lock()
+	defer q.mux.Unlock()
+	idx, ok := q.indexer[task.Key()]
+	if !ok {
+		q.tasks = append(q.tasks, task)
+		q.indexer[task.Key()] = len(q.tasks) - 1
+		return nil
+	}
+	if idx >= len(q.tasks) {
+		log.Errorf("BUG: [%s] indexer out of bounds, idx [%d], len [%d]", q.name, idx, len(q.tasks))
+		return nil
+	}
+	q.tasks[idx] = task
+	return nil
+}
+
+func (q *TaskQueue) Has(key tqueue.TKey) bool {
+	q.mux.RLock()
+	defer q.mux.RUnlock()
+	_, ok := q.indexer[key]
+	return ok
+}
+
+func (q *TaskQueue) PopByKey(key tqueue.TKey) tqueue.Task {
+	q.mux.Lock()
+	defer q.mux.Unlock()
+	if _, ok := q.indexer[key]; !ok {
+		return nil
+	}
+	idx := q.indexer[key]
+	if idx >= len(q.tasks) {
+		log.Errorf("BUG: [%s] indexer out of bounds, idx [%d], len [%d]", q.name, idx, len(q.tasks))
+		return nil
+	}
+	task := q.tasks[idx]
+	q.tasks = append(q.tasks[0:idx], q.tasks[idx+1:]...)
+	delete(q.indexer, key)
+	return task
+}
+
+func (q *TaskQueue) PopByLimit(limit rcmgr.Limit) tqueue.Task {
+	q.mux.Lock()
+	defer q.mux.Unlock()
+	index := -1
+	for idx := len(q.tasks) - 1; idx >= 0; idx-- {
+		task := q.tasks[idx]
+		if !q.strategy.RunPickUpFilterStrategy(task) {
+			continue
+		}
+		if task.LimitEstimate().Greater(limit) {
+			index = idx
+			break
+		}
+	}
+	if index == -1 {
+		log.Debugw("not found match task", "queue", q.name, "limit", limit.String())
+		return nil
+	}
+	task := q.tasks[index]
+	q.tasks = append(q.tasks[0:index], q.tasks[index+1:]...)
+	delete(q.indexer, task.Key())
+	log.Debugw("found match task", "queue", q.name, "limit", limit.String(),
+		"task_limit", task.LimitEstimate().String())
+	return task
+}
+
+func (q *TaskQueue) IsActiveTask(key tqueue.TKey) bool {
+	q.mux.RLock()
+	defer q.mux.RUnlock()
+	if _, ok := q.indexer[key]; !ok {
+		return false
+	}
+	idx := q.indexer[key]
+	if idx >= len(q.tasks) {
+		log.Errorf("BUG: [%s] indexer out of bounds, idx [%d], len [%d]", q.name, idx, len(q.tasks))
+		return false
+	}
+	task := q.tasks[idx]
+	return task.RetryExceed() && task.Expired()
+}
+
+func (q *TaskQueue) Expired(key tqueue.TKey) bool {
+	q.mux.RLock()
+	defer q.mux.RUnlock()
+	if _, ok := q.indexer[key]; !ok {
+		return false
+	}
+	idx := q.indexer[key]
+	if idx >= len(q.tasks) {
+		log.Errorf("BUG: [%s] indexer out of bounds, idx [%d], len [%d]", q.name, idx, len(q.tasks))
+		return false
+	}
+	task := q.tasks[idx]
+	return task.Expired()
+}
+
+func (q *TaskQueue) GetSupportPickUpByLimit() bool {
+	q.mux.RLock()
+	defer q.mux.RUnlock()
+	return q.supportLimit
+}
+
+func (q *TaskQueue) SetSupportPickUpByLimit(support bool) {
+	q.mux.Lock()
+	defer q.mux.Unlock()
+	q.supportLimit = support
+}
+
+func (q *TaskQueue) RunCollection() {
+	q.mux.RLock()
+	var keys []tqueue.TKey
+	for key, _ := range q.indexer {
+		keys = append(keys, key)
+	}
+	q.mux.RUnlock()
+	go q.strategy.RunCollectionStrategy(q, keys)
+}
+
+func (q *TaskQueue) SetStrategy(strategy tqueue.TQueueStrategy) {
+	q.mux.Lock()
+	defer q.mux.Unlock()
+	q.strategy = strategy
+}

--- a/pkg/taskqueue/queue/strategy.go
+++ b/pkg/taskqueue/queue/strategy.go
@@ -1,0 +1,131 @@
+package queue
+
+import (
+	"math/rand"
+	"sort"
+	"sync"
+	"time"
+
+	tqueue "github.com/bnb-chain/greenfield-storage-provider/pkg/taskqueue"
+)
+
+var _ tqueue.TQueueStrategy = &Strategy{}
+
+type Strategy struct {
+	pick       func([]tqueue.Task) tqueue.Task
+	gc         func(tqueue.TQueueOnStrategy, []tqueue.TKey)
+	pickFilter func(tqueue.Task) bool
+	mux        sync.RWMutex
+}
+
+func NewStrategy() tqueue.TQueueStrategy {
+	return &Strategy{
+		pick: nil,
+		gc:   nil,
+	}
+}
+
+func (s *Strategy) SetPickUpCallback(pick func([]tqueue.Task) tqueue.Task) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	s.pick = pick
+}
+
+func (s *Strategy) SetCollectionCallback(gc func(queue tqueue.TQueueOnStrategy, keys []tqueue.TKey)) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	s.gc = gc
+}
+
+func (s *Strategy) RunPickUpStrategy(tasks []tqueue.Task) tqueue.Task {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
+	if s.pick == nil {
+		return nil
+	}
+	return s.pick(tasks)
+}
+
+func (s *Strategy) RunCollectionStrategy(queue tqueue.TQueueOnStrategy, keys []tqueue.TKey) {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
+	if s.gc == nil {
+		return
+	}
+	s.gc(queue, keys)
+}
+
+// SetPickUpFilterCallback sets the callback func for picking up filter task.
+func (s *Strategy) SetPickUpFilterCallback(filter func(tqueue.Task) bool) {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
+	s.pickFilter = filter
+}
+
+// RunPickUpFilterStrategy calls the pick up filter callback to pick up filter task.
+func (s *Strategy) RunPickUpFilterStrategy(task tqueue.Task) bool {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
+	if s.gc == nil {
+		return true
+	}
+	return s.pickFilter(task)
+}
+
+func DefaultPickUpFilterTaskByRetry(task tqueue.Task) bool {
+	if task.RetryExceed() {
+		return false
+	}
+	if task.Expired() {
+		return true
+	}
+	return false
+}
+
+func DefaultPickUpFilterTaskByTimeout(task tqueue.Task) bool {
+	return task.Expired()
+}
+
+func DefaultGCTasksByRetry(queue tqueue.TQueueOnStrategy, keys []tqueue.TKey) {
+	for _, key := range keys {
+		if queue.IsActiveTask(key) {
+			queue.PopByKey(key)
+		}
+	}
+}
+
+func DefaultGCTasksByTimeout(queue tqueue.TQueueOnStrategy, keys []tqueue.TKey) {
+	for _, key := range keys {
+		if queue.Expired(key) {
+			queue.PopByKey(key)
+		}
+	}
+}
+
+func DefaultPickUpTaskByPriority(tasks []tqueue.Task) tqueue.Task {
+	if len(tasks) == 0 {
+		return nil
+	}
+	if len(tasks) == 1 {
+		return tasks[0]
+	}
+	sort.Slice(tasks, func(i, j int) bool {
+		return tasks[i].GetPriority() < tasks[j].GetPriority()
+	})
+	var totalPrio int
+	for _, task := range tasks {
+		totalPrio += int(task.GetPriority())
+	}
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var task tqueue.Task
+	randPrio := r.Intn(totalPrio)
+	for _, t := range tasks {
+		totalPrio += int(t.GetPriority())
+		if totalPrio >= randPrio {
+			task = t
+			break
+		}
+	}
+	return task
+}

--- a/pkg/taskqueue/queue/strategy.go
+++ b/pkg/taskqueue/queue/strategy.go
@@ -19,10 +19,7 @@ type Strategy struct {
 }
 
 func NewStrategy() tqueue.TQueueStrategy {
-	return &Strategy{
-		pick: nil,
-		gc:   nil,
-	}
+	return &Strategy{}
 }
 
 func (s *Strategy) SetPickUpCallback(pick func([]tqueue.Task) tqueue.Task) {
@@ -77,9 +74,9 @@ func DefaultPickUpFilterTaskByRetry(task tqueue.Task) bool {
 		return false
 	}
 	if task.Expired() {
-		return true
+		return false
 	}
-	return false
+	return true
 }
 
 func DefaultPickUpFilterTaskByTimeout(task tqueue.Task) bool {
@@ -88,7 +85,7 @@ func DefaultPickUpFilterTaskByTimeout(task tqueue.Task) bool {
 
 func DefaultGCTasksByRetry(queue tqueue.TQueueOnStrategy, keys []tqueue.TKey) {
 	for _, key := range keys {
-		if queue.IsActiveTask(key) {
+		if !queue.IsActiveTask(key) {
 			queue.PopByKey(key)
 		}
 	}

--- a/pkg/taskqueue/queue/strategy.go
+++ b/pkg/taskqueue/queue/strategy.go
@@ -59,11 +59,14 @@ func (s *Strategy) SetPickUpFilterCallback(filter func(tqueue.Task) bool) {
 	s.pickFilter = filter
 }
 
-// RunPickUpFilterStrategy calls the pick up filter callback to pick up filter task.
+// RunPickUpFilterStrategy calls the pickup filter callback to pick up filter task.
 func (s *Strategy) RunPickUpFilterStrategy(task tqueue.Task) bool {
 	s.mux.RLock()
 	defer s.mux.RUnlock()
 	if s.gc == nil {
+		return true
+	}
+	if s.pickFilter == nil {
 		return true
 	}
 	return s.pickFilter(task)

--- a/pkg/taskqueue/task_queue.go
+++ b/pkg/taskqueue/task_queue.go
@@ -21,7 +21,7 @@ import (
 type Task interface {
 	// Key returns the uniquely identify of task.
 	Key() TKey
-	// Type returns the type of task, such as TypeTaskUpload etc.
+	// Type returns the type of task, such as TypeTaskUploadObject etc.
 	Type() TType
 	// GetCreateTime returns the creation time of task.
 	GetCreateTime() int64
@@ -31,8 +31,8 @@ type Task interface {
 	GetUpdateTime() int64
 	// SetUpdateTime sets last updated time of task.
 	SetUpdateTime(int64)
-	// GetTimeout returns the timeout of task
-	// notice: the timeout is a duration, not the end timestamp .
+	// GetTimeout returns the timeout of task.
+	// notice: the timeout is a duration, not the end timestamp.
 	GetTimeout() int64
 	// SetTimeout sets timeout duration of task.
 	SetTimeout(int64)
@@ -69,8 +69,8 @@ type TType int32
 const (
 	// TypeTaskUnknown defines the default task type.
 	TypeTaskUnknown TType = iota
-	// TypeTaskUpload defines the type of uploading object to primary SP task.
-	TypeTaskUpload
+	// TypeTaskUploadObject defines the type of uploading object to primary SP task.
+	TypeTaskUploadObject
 	// TypeTaskReplicatePiece defines the type of replicating pieces to secondary SPs task.
 	TypeTaskReplicatePiece
 	// TypeTaskSealObject defines the type of sealing object to the chain task.
@@ -116,7 +116,7 @@ const (
 //			[TasksHighPriority: 10, TasksMediumPriority: 20, TasksLowPriority: 2]
 //		the executor of the task can run 10 high level task at the same time that the
 //			task priority >= DefaultLargerTaskPriority
-//	 the executor of the task can run 20 medium level task at the same time that the
+//	    the executor of the task can run 20 medium level task at the same time that the
 //			task priority between (DefaultLargerTaskPriority, DefaultSmallerPriority]
 //		the executor of the task can run 2 medium level task at the same time that the
 //			task priority < DefaultSmallerPriority
@@ -162,6 +162,7 @@ type ReceivePieceTask interface {
 }
 
 // DownloadObjectTask defines the task that download object.
+// TODO: refine interface.
 type DownloadObjectTask interface {
 	ObjectTask
 	// GetNeedIntegrity returns an indicator whether needs integrity information.
@@ -195,12 +196,12 @@ type GCObjectTask interface {
 	SetEndBlockNumber(uint64)
 	// GetEndBlockNumber returns end block number.
 	GetEndBlockNumber() uint64
-	// GetGCObjectProcess returns the process of collection object.
+	// GetGCObjectProgress returns the process of collection object.
 	// returns the deleting block number and the last deleted object id.
-	GetGCObjectProcess() (uint64, uint64)
-	// SetGCObjectProcess sets the process of collection object.
+	GetGCObjectProgress() (uint64, uint64)
+	// SetGCObjectProgress sets the process of collection object.
 	// params stand the deleting block number and the last deleted object id.
-	SetGCObjectProcess(uint64, uint64)
+	SetGCObjectProgress(uint64, uint64)
 }
 
 // GCZombiePieceTask defines the collection of zombie piece data task.
@@ -255,7 +256,7 @@ type TTaskPriority interface {
 type TQueueStrategy interface {
 	// SetPickUpCallback sets the callback func for picking up task.
 	SetPickUpCallback(func([]Task) Task)
-	// RunPickUpStrategy calls the pick up callback to pick up task on backup task.
+	// RunPickUpStrategy calls the pickup callback to pick up task on backup task.
 	RunPickUpStrategy([]Task) Task
 	// SetCollectionCallback sets the callback func for gc task.
 	SetCollectionCallback(func(TQueueOnStrategy, []TKey))
@@ -263,13 +264,13 @@ type TQueueStrategy interface {
 	RunCollectionStrategy(TQueueOnStrategy, []TKey)
 	// SetPickUpFilterCallback sets the callback func for picking up filter task.
 	SetPickUpFilterCallback(func(Task) bool)
-	// RunPickUpFilterStrategy calls the pick up filter callback to pick up filter task.
+	// RunPickUpFilterStrategy calls the pickup filter callback to pick up filter task.
 	RunPickUpFilterStrategy(Task) bool
 }
 
 // TQueue defines the task queue operator.
 type TQueue interface {
-	// Top return the top task in queue.
+	// Top returns the top task in queue.
 	Top() Task
 	// Pop pops the top task in queue.
 	Pop() Task

--- a/pkg/taskqueue/task_queue.go
+++ b/pkg/taskqueue/task_queue.go
@@ -133,8 +133,8 @@ const (
 // records the information of different stages of the object.
 type ObjectTask interface {
 	Task
-	// GetObject returns the associated object.
-	GetObject() *storagetypes.ObjectInfo
+	// GetObjectInfo returns the associated object.
+	GetObjectInfo() *storagetypes.ObjectInfo
 }
 
 // UploadObjectTask defines the task that uploads object payload data to primary SP.

--- a/pkg/taskqueue/task_queue.go
+++ b/pkg/taskqueue/task_queue.go
@@ -1,0 +1,324 @@
+package task
+
+import (
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/rcmgr"
+	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
+)
+
+// Task defines the smallest unit of SP background service interaction.
+// there are two types of task, ObjectTask and GCTask.
+//
+// The ObjectTask include: UploadObjectTask, ReplicatePieceTask, SealObjectTask,
+// DownloadObjectTask and ReceiveTask.These tasks associated with an object, and
+// records the information of different stages of the object.
+//
+// The GCTask include: GCObjectTask, GCZombiePieceTask and GCStoreTask.
+// The GCObjectTask collects the piece store space by deleting object payload data
+// that the object has been deleted on the chain.
+// The GCZombiePieceTask collects the piece store space by deleting zombie pieces
+// data that dues to any exception, the piece data meta is not on chain.
+// The GCStoreTask collects the SP meta store space by deleting the expired data.
+type Task interface {
+	// Key returns the uniquely identify of task.
+	Key() TKey
+	// Type returns the type of task, such as TypeTaskUpload etc.
+	Type() TType
+	// GetCreateTime returns the creation time of task.
+	GetCreateTime() int64
+	// SetCreateTime sets the creation time of task.
+	SetCreateTime(int64)
+	// GetUpdateTime returns the last updated time of task.
+	GetUpdateTime() int64
+	// SetUpdateTime sets last updated time of task.
+	SetUpdateTime(int64)
+	// GetTimeout returns the timeout of task
+	// notice: the timeout is a duration, not the end timestamp .
+	GetTimeout() int64
+	// SetTimeout sets timeout duration of task.
+	SetTimeout(int64)
+	// Expired returns an indicator whether timeout.
+	Expired() bool
+	// GetPriority returns the priority of task.
+	GetPriority() TPriority
+	// SetPriority sets the priority of task.
+	SetPriority(TPriority)
+	// IncRetry increases the retry counter of task.
+	IncRetry() bool
+	// RetryExceed returns an indicator whether retry max times.
+	RetryExceed() bool
+	// GetRetry returns the retry counter of task.
+	GetRetry() int64
+	// GetRetryLimit returns the limit of retry counter.
+	GetRetryLimit() int64
+	// SetRetryLimit sets the limit of retry counter.
+	SetRetryLimit(int64)
+	// LimitEstimate returns estimated resource limit.
+	LimitEstimate() rcmgr.Limit
+	// Error returns the task error.
+	Error() error
+	// SetError sets the error to task.
+	SetError(err error)
+}
+
+// TKey defines the type of task key that is the uniquely identify.
+type TKey string
+
+// TType is enum type, it defines the type of task.
+type TType int32
+
+const (
+	// TypeTaskUnknown defines the default task type.
+	TypeTaskUnknown TType = iota
+	// TypeTaskUpload defines the type of uploading object to primary SP task.
+	TypeTaskUpload
+	// TypeTaskReplicatePiece defines the type of replicating pieces to secondary SPs task.
+	TypeTaskReplicatePiece
+	// TypeTaskSealObject defines the type of sealing object to the chain task.
+	TypeTaskSealObject
+	// TypeTaskReceivePiece defines the type of receiving pieces for secondary SP task.
+	TypeTaskReceivePiece
+	// TypeTaskDownloadObject defines the type of downloading object task.
+	TypeTaskDownloadObject
+	// TypeTaskGCObject defines the type of collecting object payload data task.
+	TypeTaskGCObject
+	// TypeTaskGCZombiePiece defines the type of collecting zombie piece task.
+	TypeTaskGCZombiePiece
+	// TypeTaskGCStore defines the type of collecting SP metadata task.
+	TypeTaskGCStore
+)
+
+// TPriority defines the type of task priority, the task priority can use for picking up
+// task from priority queue, it can be used as an auxiliary data for the TQueueStrategy
+// to pick up the task.
+type TPriority uint8
+
+const (
+	// UnKnownTaskPriority defines the default task priority.
+	UnKnownTaskPriority = 0
+	// UnSchedulingPriority defines the task priority that should be never scheduled.
+	UnSchedulingPriority = 0
+	// MaxTaskPriority defines the max task priority.
+	MaxTaskPriority = 255
+	// DefaultLargerTaskPriority defines the larger task priority.
+	DefaultLargerTaskPriority = 170
+	// DefaultSmallerPriority defines the smaller task priority.
+	DefaultSmallerPriority = 85
+)
+
+// TPriorityLevel defines the type of task priority level. The executor of the task
+// will reserve the resources from the resource manager(rcmgr) before execution, and
+// the rcmgr can limit the execution of concurrent tasks number according to the task
+// priority level.
+//
+// Example:
+//
+//		the configuration the rcmgr:
+//			[TasksHighPriority: 10, TasksMediumPriority: 20, TasksLowPriority: 2]
+//		the executor of the task can run 10 high level task at the same time that the
+//			task priority >= DefaultLargerTaskPriority
+//	 the executor of the task can run 20 medium level task at the same time that the
+//			task priority between (DefaultLargerTaskPriority, DefaultSmallerPriority]
+//		the executor of the task can run 2 medium level task at the same time that the
+//			task priority < DefaultSmallerPriority
+type TPriorityLevel int32
+
+const (
+	// TLowPriorityLevel defines the low task priority level.
+	TLowPriorityLevel TPriorityLevel = iota
+	// THighPriorityLevel defines the high task priority level.
+	THighPriorityLevel
+)
+
+// ObjectTask defines the task that is associated with an object, and
+// records the information of different stages of the object.
+type ObjectTask interface {
+	Task
+	// GetObject returns the associated object.
+	GetObject() *storagetypes.ObjectInfo
+}
+
+// UploadObjectTask defines the task that uploads object payload data to primary SP.
+type UploadObjectTask interface {
+	ObjectTask
+}
+
+// ReplicatePieceTask defines the task that replicates pieces of object to secondary SPs.
+type ReplicatePieceTask interface {
+	ObjectTask
+}
+
+// SealObjectTask defines the task that seals object to the chain.
+type SealObjectTask interface {
+	ObjectTask
+}
+
+// ReceivePieceTask defines the task that receives pieces data, only belong to secondary SP.
+type ReceivePieceTask interface {
+	ObjectTask
+	// GetReplicateIdx returns the replicate index.
+	GetReplicateIdx() uint32
+	// SetReplicateIdx sets the replicate index by the executor of the task.
+	SetReplicateIdx(uint32)
+}
+
+// DownloadObjectTask defines the task that download object.
+type DownloadObjectTask interface {
+	ObjectTask
+	// GetNeedIntegrity returns an indicator whether needs integrity information.
+	// when get challenge info, in addition to piece data, also need integrity.
+	GetNeedIntegrity() bool
+	// GetSize returns the download payload data size, high - low + 1.
+	GetSize() uint64
+	// SetLow sets the start offset of download payload data.
+	SetLow(uint64)
+	// GetLow returns the start offset of download payload data.
+	GetLow() uint64
+	// SetHigh sets the end offset of download payload data.
+	SetHigh(uint64)
+	// GetHigh returns the end offset of download payload data.
+	GetHigh() uint64
+}
+
+// GCTask defines gc task that collects the resources that no longer use.
+type GCTask interface {
+	Task
+}
+
+// GCObjectTask defines the collection of object task.
+type GCObjectTask interface {
+	GCTask
+	// SetStartBlockNumber sets start block number.
+	SetStartBlockNumber(uint64)
+	// GetStartBlockNumber returns start block number.
+	GetStartBlockNumber() uint64
+	// SetEndBlockNumber sets end block number.
+	SetEndBlockNumber(uint64)
+	// GetEndBlockNumber returns end block number.
+	GetEndBlockNumber() uint64
+	// GetGCObjectProcess returns the process of collection object.
+	// returns the deleting block number and the last deleted object id.
+	GetGCObjectProcess() (uint64, uint64)
+	// SetGCObjectProcess sets the process of collection object.
+	// params stand the deleting block number and the last deleted object id.
+	SetGCObjectProcess(uint64, uint64)
+}
+
+// GCZombiePieceTask defines the collection of zombie piece data task.
+type GCZombiePieceTask interface {
+	GCTask
+	// GetGCZombiePieceStatus returns the status of collecting zombie pieces.
+	// returns the number that has been deleted.
+	GetGCZombiePieceStatus() uint64
+	// SetGCZombiePieceStatus sets the status of collecting zombie pieces.
+	// param stands the has been deleted pieces number.
+	SetGCZombiePieceStatus(uint64)
+}
+
+// GCStoreTask defines the collection of SP metadata task.
+type GCStoreTask interface {
+	GCTask
+	// GetGCStoreStatus returns the status of collecting metadata.
+	// returns the number that has been deleted.
+	GetGCStoreStatus() (uint64, uint64)
+	// SetGCStoreStatus sets the status of collecting metadata.
+	// parma stands the number that has been deleted.
+	SetGCStoreStatus(uint64, uint64)
+}
+
+// TTaskPriority defines the all supported tasks type and its priorities.
+type TTaskPriority interface {
+	// GetPriority returns the special task type's priority
+	GetPriority(TType) TPriority
+	// SetPriority sets the special task type's priority
+	SetPriority(TType, TPriority)
+	// GetAllPriorities returns all supported tasks type and its priorities.
+	GetAllPriorities() map[TType]TPriority
+	// SetAllPriorities sets all supported tasks type and its priorities.
+	SetAllPriorities(map[TType]TPriority)
+	// GetLowLevelPriority returns the low level priority's watermark.
+	GetLowLevelPriority() TPriority
+	// SetLowLevelPriority sets the low level priority's watermark.
+	SetLowLevelPriority(TPriority) error
+	// GetHighLevelPriority returns the high level priority's watermark.
+	GetHighLevelPriority() TPriority
+	// SetHighLevelPriority sets the high level priority's watermark.
+	SetHighLevelPriority(TPriority) error
+	// HighLevelPriority returns an indicator whether high level priority.
+	HighLevelPriority(TPriority) bool
+	// LowLevelPriority returns an indicator whether low level priority.
+	LowLevelPriority(TPriority) bool
+	// SupportTask returns an indicator whether support type of task.
+	SupportTask(TType) bool
+}
+
+// TQueueStrategy defines the strategy operator on queue.
+type TQueueStrategy interface {
+	// SetPickUpCallback sets the callback func for picking up task.
+	SetPickUpCallback(func([]Task) Task)
+	// RunPickUpStrategy calls the pick up callback to pick up task on backup task.
+	RunPickUpStrategy([]Task) Task
+	// SetCollectionCallback sets the callback func for gc task.
+	SetCollectionCallback(func(TQueueOnStrategy, []TKey))
+	// RunCollectionStrategy calls collection callback func for gc task on queue.
+	RunCollectionStrategy(TQueueOnStrategy, []TKey)
+	// SetPickUpFilterCallback sets the callback func for picking up filter task.
+	SetPickUpFilterCallback(func(Task) bool)
+	// RunPickUpFilterStrategy calls the pick up filter callback to pick up filter task.
+	RunPickUpFilterStrategy(Task) bool
+}
+
+// TQueue defines the task queue operator.
+type TQueue interface {
+	// Top return the top task in queue.
+	Top() Task
+	// Pop pops the top task in queue.
+	Pop() Task
+	// PopByKey pops the task by task key.
+	PopByKey(TKey) Task
+	// Has returns an indicator whether the task in queue.
+	Has(TKey) bool
+	// Push pushes the task in queue.
+	Push(Task) error
+	// PopPush pops task by task key, and pushes task again
+	PopPush(Task) error
+	// Len returns the length of queue.
+	Len() int
+	// Cap returns the capacity of queue.
+	Cap() int
+}
+
+// TQueueOnStrategy defines queue operator that supports TQueueStrategy.
+type TQueueOnStrategy interface {
+	TQueue
+	// SetStrategy sets TQueueStrategy on the queue.
+	SetStrategy(TQueueStrategy)
+	// Expired returns an indicator whether the task is timeout.
+	Expired(TKey) bool
+	// IsActiveTask returns an indicator whether active task.
+	IsActiveTask(TKey) bool
+	// RunCollection calls TQueueStrategy's callback to collect tasks.
+	RunCollection()
+}
+
+// TQueueWithLimit defines the operator of queue that supports resource limits.
+type TQueueWithLimit interface {
+	TQueueOnStrategy
+	// PopByLimit returns the task that consumes less resources than the param.
+	PopByLimit(rcmgr.Limit) Task
+	// GetSupportPickUpByLimit returns an indicator whether supports resource limits.
+	GetSupportPickUpByLimit() bool
+	// SetSupportPickUpByLimit set whether supports resource limits.
+	// if false, PopWithLimit equal Pop
+	SetSupportPickUpByLimit(bool)
+}
+
+// TPriorityQueueWithLimit defines the priority queue, its sub queue supports TQueueWithLimit.
+type TPriorityQueueWithLimit interface {
+	TQueueWithLimit
+	// SubQueueLen returns the length of sub queue.
+	SubQueueLen(TPriority) int
+	// GetPriorities returns all supports priorities.
+	GetPriorities() []TPriority
+	//SetPriorityQueue sets the sub queue with priority.
+	SetPriorityQueue(TPriority, TQueueWithLimit) error
+}

--- a/pkg/taskqueue/types/download_task.go
+++ b/pkg/taskqueue/types/download_task.go
@@ -1,0 +1,231 @@
+package types
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/rcmgr"
+	tqueue "github.com/bnb-chain/greenfield-storage-provider/pkg/taskqueue"
+	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
+)
+
+var _ tqueue.DownloadObjectTask = &DownloadObjectTask{}
+
+func NewDownloadObjectTask(object *storagetypes.ObjectInfo) (*DownloadObjectTask, error) {
+	if object == nil {
+		return nil, ErrObjectDangling
+	}
+	task := &Task{
+		CreateTime:   time.Now().Unix(),
+		UpdateTime:   time.Now().Unix(),
+		TaskPriority: int32(GetTaskPriorityMap().GetPriority(tqueue.TypeTaskDownloadObject)),
+	}
+	return &DownloadObjectTask{
+		Object: object,
+		Task:   task,
+	}, nil
+}
+
+func (m *DownloadObjectTask) Key() tqueue.TKey {
+	if m == nil {
+		return ""
+	}
+	if m.GetObject() == nil {
+		return ""
+	}
+	return tqueue.TKey("DownloadObject" + m.GetObject().Id.String() +
+		"-" + strconv.FormatUint(m.GetLow(), 10) +
+		"-" + strconv.FormatUint(m.GetHigh(), 10))
+}
+
+func (m *DownloadObjectTask) Type() tqueue.TType {
+	return tqueue.TypeTaskDownloadObject
+}
+
+func (m *DownloadObjectTask) LimitEstimate() rcmgr.Limit {
+	return rcmgr.InfiniteLimit()
+}
+
+func (m *DownloadObjectTask) GetCreateTime() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetCreateTime()
+}
+
+func (m *DownloadObjectTask) SetCreateTime(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetCreateTime(time)
+}
+
+func (m *DownloadObjectTask) GetUpdateTime() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetUpdateTime()
+}
+
+func (m *DownloadObjectTask) SetUpdateTime(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetUpdateTime(time)
+}
+
+func (m *DownloadObjectTask) GetTimeout() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetTimeout()
+}
+
+func (m *DownloadObjectTask) SetTimeout(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetTimeout(time)
+}
+
+func (m *DownloadObjectTask) GetPriority() tqueue.TPriority {
+	if m == nil {
+		return tqueue.TPriority(0)
+	}
+	if m.GetTask() == nil {
+		return tqueue.TPriority(0)
+	}
+	return m.GetTask().GetPriority()
+}
+
+func (m *DownloadObjectTask) SetPriority(prio tqueue.TPriority) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetPriority(prio)
+}
+
+func (m *DownloadObjectTask) IncRetry() bool {
+	if m == nil {
+		return false
+	}
+	if m.GetTask() == nil {
+		return false
+	}
+	return m.GetTask().GetRetry() <= m.GetTask().GetRetryLimit()
+}
+
+func (m *DownloadObjectTask) GetRetry() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetRetry()
+}
+
+func (m *DownloadObjectTask) Expired() bool {
+	if m == nil {
+		return true
+	}
+	if m.GetTask() == nil {
+		return true
+	}
+	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() < time.Now().Unix()
+}
+
+func (m *DownloadObjectTask) GetRetryLimit() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetRetryLimit()
+}
+
+func (m *DownloadObjectTask) SetRetryLimit(limit int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetRetryLimit(limit)
+}
+
+func (m *DownloadObjectTask) RetryExceed() bool {
+	if m == nil {
+		return true
+	}
+	if m.GetTask() == nil {
+		return true
+	}
+	return m.GetTask().GetRetry() > m.GetTask().GetRetryLimit()
+}
+
+func (m *DownloadObjectTask) Error() error {
+	if m == nil {
+		return nil
+	}
+	if m.GetTask() == nil {
+		return nil
+	}
+	return m.GetTask().Error()
+}
+
+func (m *DownloadObjectTask) SetError(err error) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetError(err)
+}
+
+func (m *DownloadObjectTask) GetSize() uint64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetHigh() < m.GetLow() {
+		return 0
+	}
+	return m.GetHigh() - m.GetLow()
+}
+
+func (m *DownloadObjectTask) SetLow(low uint64) {
+	if m == nil {
+		return
+	}
+	m.Low = low
+}
+
+func (m *DownloadObjectTask) SetHigh(high uint64) {
+	if m == nil {
+		return
+	}
+	m.High = high
+}

--- a/pkg/taskqueue/types/download_task.go
+++ b/pkg/taskqueue/types/download_task.go
@@ -133,7 +133,7 @@ func (m *DownloadObjectTask) IncRetry() bool {
 	if m.GetTask() == nil {
 		return false
 	}
-	return m.GetTask().GetRetry() <= m.GetTask().GetRetryLimit()
+	return m.GetTask().IncRetry()
 }
 
 func (m *DownloadObjectTask) GetRetry() int64 {
@@ -153,7 +153,7 @@ func (m *DownloadObjectTask) Expired() bool {
 	if m.GetTask() == nil {
 		return true
 	}
-	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() < time.Now().Unix()
+	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() > time.Now().Unix()
 }
 
 func (m *DownloadObjectTask) GetRetryLimit() int64 {

--- a/pkg/taskqueue/types/download_task.go
+++ b/pkg/taskqueue/types/download_task.go
@@ -11,8 +11,8 @@ import (
 
 var _ tqueue.DownloadObjectTask = &DownloadObjectTask{}
 
-func NewDownloadObjectTask(object *storagetypes.ObjectInfo) (*DownloadObjectTask, error) {
-	if object == nil {
+func NewDownloadObjectTask(objectInfo *storagetypes.ObjectInfo) (*DownloadObjectTask, error) {
+	if objectInfo == nil {
 		return nil, ErrObjectDangling
 	}
 	task := &Task{
@@ -21,8 +21,8 @@ func NewDownloadObjectTask(object *storagetypes.ObjectInfo) (*DownloadObjectTask
 		TaskPriority: int32(GetTaskPriorityMap().GetPriority(tqueue.TypeTaskDownloadObject)),
 	}
 	return &DownloadObjectTask{
-		Object: object,
-		Task:   task,
+		ObjectInfo: objectInfo,
+		Task:       task,
 	}, nil
 }
 
@@ -30,10 +30,10 @@ func (m *DownloadObjectTask) Key() tqueue.TKey {
 	if m == nil {
 		return ""
 	}
-	if m.GetObject() == nil {
+	if m.GetObjectInfo() == nil {
 		return ""
 	}
-	return tqueue.TKey("DownloadObject" + m.GetObject().Id.String() +
+	return tqueue.TKey("DownloadObject" + m.GetObjectInfo().Id.String() +
 		"-" + strconv.FormatUint(m.GetLow(), 10) +
 		"-" + strconv.FormatUint(m.GetHigh(), 10))
 }

--- a/pkg/taskqueue/types/gc_object.go
+++ b/pkg/taskqueue/types/gc_object.go
@@ -138,7 +138,7 @@ func (m *GCObjectTask) IncRetry() bool {
 	if m.GetTask() == nil {
 		return false
 	}
-	return m.GetTask().GetRetry() <= m.GetTask().GetRetryLimit()
+	return m.GetTask().IncRetry()
 }
 
 func (m *GCObjectTask) GetRetry() int64 {
@@ -158,7 +158,7 @@ func (m *GCObjectTask) Expired() bool {
 	if m.GetTask() == nil {
 		return true
 	}
-	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() < time.Now().Unix()
+	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() > time.Now().Unix()
 }
 
 func (m *GCObjectTask) GetRetryLimit() int64 {
@@ -225,14 +225,14 @@ func (m *GCObjectTask) SetEndBlockNumber(num uint64) {
 	m.EndBlockNumber = num
 }
 
-func (m *GCObjectTask) GetGCObjectProcess() (uint64, uint64) {
+func (m *GCObjectTask) GetGCObjectProgress() (uint64, uint64) {
 	if m == nil {
 		return 0, 0
 	}
 	return m.GetCurrentBlockNumber(), m.GetObjectId()
 }
 
-func (m *GCObjectTask) SetGCObjectProcess(block, object uint64) {
+func (m *GCObjectTask) SetGCObjectProgress(block, object uint64) {
 	if m == nil {
 		return
 	}

--- a/pkg/taskqueue/types/gc_object.go
+++ b/pkg/taskqueue/types/gc_object.go
@@ -1,0 +1,241 @@
+package types
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/rcmgr"
+	tqueue "github.com/bnb-chain/greenfield-storage-provider/pkg/taskqueue"
+)
+
+var _ tqueue.GCObjectTask = &GCObjectTask{}
+
+func NewGCObjectTask(low, high uint64) (*GCObjectTask, error) {
+	task := &Task{
+		CreateTime:   time.Now().Unix(),
+		UpdateTime:   time.Now().Unix(),
+		RetryLimit:   DefaultGCObjectTaskRetryLimit,
+		Timeout:      DefaultGCObjectTimeout,
+		TaskPriority: int32(GetTaskPriorityMap().GetPriority(tqueue.TypeTaskGCObject)),
+	}
+	return &GCObjectTask{
+		Task:             task,
+		StartBlockNumber: low,
+		EndBlockNumber:   high,
+	}, nil
+}
+
+func (m *GCObjectTask) Key() tqueue.TKey {
+	if m == nil {
+		return ""
+	}
+	return tqueue.TKey("GCObject-" + strconv.FormatInt(m.GetCreateTime(), 10) +
+		"-" + strconv.FormatUint(m.GetStartBlockNumber(), 10) +
+		"-" + strconv.FormatUint(m.GetEndBlockNumber(), 10))
+}
+
+func (m *GCObjectTask) Type() tqueue.TType {
+	return tqueue.TypeTaskGCObject
+}
+
+func (m *GCObjectTask) LimitEstimate() rcmgr.Limit {
+	limit := &rcmgr.BaseLimit{}
+	prio := m.GetPriority()
+	if GetTaskPriorityMap().HighLevelPriority(prio) {
+		limit.TasksHighPriority = 1
+	} else if GetTaskPriorityMap().LowLevelPriority(prio) {
+		limit.TasksLowPriority = 1
+	} else {
+		limit.TasksMediumPriority = 1
+	}
+	return limit
+}
+
+func (m *GCObjectTask) GetCreateTime() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetCreateTime()
+}
+
+func (m *GCObjectTask) SetCreateTime(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetCreateTime(time)
+}
+
+func (m *GCObjectTask) GetUpdateTime() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetUpdateTime()
+}
+
+func (m *GCObjectTask) SetUpdateTime(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetUpdateTime(time)
+}
+
+func (m *GCObjectTask) GetTimeout() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetTimeout()
+}
+
+func (m *GCObjectTask) SetTimeout(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetTimeout(time)
+}
+
+func (m *GCObjectTask) GetPriority() tqueue.TPriority {
+	if m == nil {
+		return tqueue.TPriority(0)
+	}
+	if m.GetTask() == nil {
+		return tqueue.TPriority(0)
+	}
+	return m.GetTask().GetPriority()
+}
+
+func (m *GCObjectTask) SetPriority(prio tqueue.TPriority) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetPriority(prio)
+}
+
+func (m *GCObjectTask) IncRetry() bool {
+	if m == nil {
+		return false
+	}
+	if m.GetTask() == nil {
+		return false
+	}
+	return m.GetTask().GetRetry() <= m.GetTask().GetRetryLimit()
+}
+
+func (m *GCObjectTask) GetRetry() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetRetry()
+}
+
+func (m *GCObjectTask) Expired() bool {
+	if m == nil {
+		return true
+	}
+	if m.GetTask() == nil {
+		return true
+	}
+	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() < time.Now().Unix()
+}
+
+func (m *GCObjectTask) GetRetryLimit() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetRetryLimit()
+}
+
+func (m *GCObjectTask) SetRetryLimit(limit int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetRetryLimit(limit)
+}
+
+func (m *GCObjectTask) RetryExceed() bool {
+	if m == nil {
+		return true
+	}
+	if m.GetTask() == nil {
+		return true
+	}
+	return m.GetTask().GetRetry() > m.GetTask().GetRetryLimit()
+}
+
+func (m *GCObjectTask) Error() error {
+	if m == nil {
+		return nil
+	}
+	if m.GetTask() == nil {
+		return nil
+	}
+	return m.GetTask().Error()
+}
+
+func (m *GCObjectTask) SetError(err error) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetError(err)
+}
+
+func (m *GCObjectTask) SetStartBlockNumber(num uint64) {
+	if m == nil {
+		return
+	}
+	m.StartBlockNumber = num
+}
+
+func (m *GCObjectTask) SetEndBlockNumber(num uint64) {
+	if m == nil {
+		return
+	}
+	m.EndBlockNumber = num
+}
+
+func (m *GCObjectTask) GetGCObjectProcess() (uint64, uint64) {
+	if m == nil {
+		return 0, 0
+	}
+	return m.GetCurrentBlockNumber(), m.GetObjectId()
+}
+
+func (m *GCObjectTask) SetGCObjectProcess(block, object uint64) {
+	if m == nil {
+		return
+	}
+	m.CurrentBlockNumber = block
+	m.ObjectId = object
+}

--- a/pkg/taskqueue/types/gc_store.go
+++ b/pkg/taskqueue/types/gc_store.go
@@ -1,0 +1,229 @@
+package types
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/rcmgr"
+	tqueue "github.com/bnb-chain/greenfield-storage-provider/pkg/taskqueue"
+)
+
+var _ tqueue.GCStoreTask = &GCStoreTask{}
+
+func NewGCStoreTask() (*GCStoreTask, error) {
+	task := &Task{
+		CreateTime:   time.Now().Unix(),
+		UpdateTime:   time.Now().Unix(),
+		RetryLimit:   DefaultGCStoreTaskRetryLimit,
+		Timeout:      DefaultGCStoreTimeout,
+		TaskPriority: int32(GetTaskPriorityMap().GetPriority(tqueue.TypeTaskGCStore)),
+	}
+	return &GCStoreTask{
+		Task: task,
+	}, nil
+}
+
+func (m *GCStoreTask) Key() tqueue.TKey {
+	if m == nil {
+		return ""
+	}
+	return tqueue.TKey("GCStore" + "-" + strconv.FormatInt(m.GetCreateTime(), 10))
+}
+
+func (m *GCStoreTask) Type() tqueue.TType {
+	return tqueue.TypeTaskGCStore
+}
+
+func (m *GCStoreTask) LimitEstimate() rcmgr.Limit {
+	limit := &rcmgr.BaseLimit{}
+	prio := m.GetPriority()
+	if GetTaskPriorityMap().HighLevelPriority(prio) {
+		limit.TasksHighPriority = 1
+	} else if GetTaskPriorityMap().LowLevelPriority(prio) {
+		limit.TasksLowPriority = 1
+	} else {
+		limit.TasksMediumPriority = 1
+	}
+	return limit
+}
+
+func (m *GCStoreTask) GetCreateTime() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetCreateTime()
+}
+
+func (m *GCStoreTask) SetCreateTime(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetCreateTime(time)
+}
+
+func (m *GCStoreTask) GetUpdateTime() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetUpdateTime()
+}
+
+func (m *GCStoreTask) SetUpdateTime(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetUpdateTime(time)
+}
+
+func (m *GCStoreTask) GetTimeout() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetTimeout()
+}
+
+func (m *GCStoreTask) SetTimeout(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetTimeout(time)
+}
+
+func (m *GCStoreTask) GetPriority() tqueue.TPriority {
+	if m == nil {
+		return tqueue.TPriority(0)
+	}
+	if m.GetTask() == nil {
+		return tqueue.TPriority(0)
+	}
+	return m.GetTask().GetPriority()
+}
+
+func (m *GCStoreTask) SetPriority(prio tqueue.TPriority) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetPriority(prio)
+}
+
+func (m *GCStoreTask) IncRetry() bool {
+	if m == nil {
+		return false
+	}
+	if m.GetTask() == nil {
+		return false
+	}
+	return m.GetTask().GetRetry() <= m.GetTask().GetRetryLimit()
+}
+
+func (m *GCStoreTask) GetRetry() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetRetry()
+}
+
+func (m *GCStoreTask) Expired() bool {
+	if m == nil {
+		return true
+	}
+	if m.GetTask() == nil {
+		return true
+	}
+	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() < time.Now().Unix()
+}
+
+func (m *GCStoreTask) GetRetryLimit() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetRetryLimit()
+}
+
+func (m *GCStoreTask) SetRetryLimit(limit int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetRetryLimit(limit)
+}
+
+func (m *GCStoreTask) RetryExceed() bool {
+	if m == nil {
+		return true
+	}
+	if m.GetTask() == nil {
+		return true
+	}
+	return m.GetTask().GetRetry() > m.GetTask().GetRetryLimit()
+}
+
+func (m *GCStoreTask) Error() error {
+	if m == nil {
+		return nil
+	}
+	if m.GetTask() == nil {
+		return nil
+	}
+	return m.GetTask().Error()
+}
+
+func (m *GCStoreTask) SetError(err error) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetError(err)
+}
+
+func (m *GCStoreTask) GetGCStoreStatus() (uint64, uint64) {
+	if m == nil {
+		return 0, 0
+	}
+	return m.GetCurrentIdx(), m.GetDeleteCount()
+}
+
+func (m *GCStoreTask) SetGCStoreStatus(current uint64, delete uint64) {
+	if m == nil {
+		return
+	}
+	if m.GetCurrentIdx() > current {
+		return
+	}
+	m.CurrentIdx = current
+	if m.GetDeleteCount() < delete {
+		return
+	}
+	m.DeleteCount = delete
+}

--- a/pkg/taskqueue/types/gc_store.go
+++ b/pkg/taskqueue/types/gc_store.go
@@ -134,7 +134,7 @@ func (m *GCStoreTask) IncRetry() bool {
 	if m.GetTask() == nil {
 		return false
 	}
-	return m.GetTask().GetRetry() <= m.GetTask().GetRetryLimit()
+	return m.GetTask().IncRetry()
 }
 
 func (m *GCStoreTask) GetRetry() int64 {
@@ -154,7 +154,7 @@ func (m *GCStoreTask) Expired() bool {
 	if m.GetTask() == nil {
 		return true
 	}
-	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() < time.Now().Unix()
+	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() > time.Now().Unix()
 }
 
 func (m *GCStoreTask) GetRetryLimit() int64 {

--- a/pkg/taskqueue/types/gc_zombie.go
+++ b/pkg/taskqueue/types/gc_zombie.go
@@ -124,7 +124,7 @@ func (m *GCZombiePieceTask) IncRetry() bool {
 	if m.GetTask() == nil {
 		return false
 	}
-	return m.GetTask().GetRetry() <= m.GetTask().GetRetryLimit()
+	return m.GetTask().IncRetry()
 }
 
 func (m *GCZombiePieceTask) SetPriority(prio tqueue.TPriority) {
@@ -154,7 +154,7 @@ func (m *GCZombiePieceTask) Expired() bool {
 	if m.GetTask() == nil {
 		return true
 	}
-	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() < time.Now().Unix()
+	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() > time.Now().Unix()
 }
 
 func (m *GCZombiePieceTask) GetRetryLimit() int64 {

--- a/pkg/taskqueue/types/gc_zombie.go
+++ b/pkg/taskqueue/types/gc_zombie.go
@@ -1,0 +1,222 @@
+package types
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/rcmgr"
+	tqueue "github.com/bnb-chain/greenfield-storage-provider/pkg/taskqueue"
+)
+
+var _ tqueue.GCZombiePieceTask = &GCZombiePieceTask{}
+
+func NewGCZombiePieceTask() (*GCZombiePieceTask, error) {
+	task := &Task{
+		CreateTime:   time.Now().Unix(),
+		UpdateTime:   time.Now().Unix(),
+		RetryLimit:   DefaultGCZombiePieceTaskRetryLimit,
+		Timeout:      DefaultGCZombiePieceTimeout,
+		TaskPriority: int32(GetTaskPriorityMap().GetPriority(tqueue.TypeTaskGCZombiePiece)),
+	}
+	return &GCZombiePieceTask{
+		Task: task,
+	}, nil
+}
+
+func (m *GCZombiePieceTask) Key() tqueue.TKey {
+	if m == nil {
+		return ""
+	}
+	return tqueue.TKey("GCZombie" + "-" + strconv.FormatInt(m.GetCreateTime(), 10))
+}
+
+func (m *GCZombiePieceTask) Type() tqueue.TType {
+	return tqueue.TypeTaskGCZombiePiece
+}
+
+func (m *GCZombiePieceTask) LimitEstimate() rcmgr.Limit {
+	limit := &rcmgr.BaseLimit{}
+	prio := m.GetPriority()
+	if GetTaskPriorityMap().HighLevelPriority(prio) {
+		limit.TasksHighPriority = 1
+	} else if GetTaskPriorityMap().LowLevelPriority(prio) {
+		limit.TasksLowPriority = 1
+	} else {
+		limit.TasksMediumPriority = 1
+	}
+	return limit
+}
+
+func (m *GCZombiePieceTask) GetCreateTime() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetCreateTime()
+}
+
+func (m *GCZombiePieceTask) SetCreateTime(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetCreateTime(time)
+}
+
+func (m *GCZombiePieceTask) GetUpdateTime() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetUpdateTime()
+}
+
+func (m *GCZombiePieceTask) SetUpdateTime(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetUpdateTime(time)
+}
+
+func (m *GCZombiePieceTask) GetTimeout() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetTimeout()
+}
+
+func (m *GCZombiePieceTask) SetTimeout(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetTimeout(time)
+}
+
+func (m *GCZombiePieceTask) GetPriority() tqueue.TPriority {
+	if m == nil {
+		return tqueue.TPriority(0)
+	}
+	if m.GetTask() == nil {
+		return tqueue.TPriority(0)
+	}
+	return m.GetTask().GetPriority()
+}
+
+func (m *GCZombiePieceTask) IncRetry() bool {
+	if m == nil {
+		return false
+	}
+	if m.GetTask() == nil {
+		return false
+	}
+	return m.GetTask().GetRetry() <= m.GetTask().GetRetryLimit()
+}
+
+func (m *GCZombiePieceTask) SetPriority(prio tqueue.TPriority) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetPriority(prio)
+}
+
+func (m *GCZombiePieceTask) GetRetry() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetRetry()
+}
+
+func (m *GCZombiePieceTask) Expired() bool {
+	if m == nil {
+		return true
+	}
+	if m.GetTask() == nil {
+		return true
+	}
+	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() < time.Now().Unix()
+}
+
+func (m *GCZombiePieceTask) GetRetryLimit() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetRetryLimit()
+}
+
+func (m *GCZombiePieceTask) SetRetryLimit(limit int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetRetryLimit(limit)
+}
+
+func (m *GCZombiePieceTask) RetryExceed() bool {
+	if m == nil {
+		return true
+	}
+	if m.GetTask() == nil {
+		return true
+	}
+	return m.GetTask().GetRetry() > m.GetTask().GetRetryLimit()
+}
+
+func (m *GCZombiePieceTask) Error() error {
+	if m == nil {
+		return nil
+	}
+	if m.GetTask() == nil {
+		return nil
+	}
+	return m.GetTask().Error()
+}
+
+func (m *GCZombiePieceTask) SetError(err error) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetError(err)
+}
+
+func (m *GCZombiePieceTask) GetGCZombiePieceStatus() uint64 {
+	if m == nil {
+		return 0
+	}
+	return m.GetDeleteCount()
+}
+
+func (m *GCZombiePieceTask) SetGCZombiePieceStatus(del uint64) {
+	if m == nil {
+		return
+	}
+	m.DeleteCount = del
+}

--- a/pkg/taskqueue/types/model.go
+++ b/pkg/taskqueue/types/model.go
@@ -7,6 +7,7 @@ var (
 	ErrObjectDangling = errors.New("object pointer dangling")
 )
 
+// defines the task retry limits
 const (
 	DefaultReplicatePieceTaskRetryLimit  int64 = 3
 	DefaultReplicatePieceTaskMemoryLimit int64 = 40 * 1024 * 1024
@@ -18,18 +19,21 @@ const (
 )
 
 const (
-	DefaultUploadObjectRate = 200
+	// DefaultUploadObjectRate defines default upload object speed(MB/s)
+	DefaultUploadObjectRate = 50
 )
 
+// defines the task timeout
 const (
 	DefaultUploadMinTimeout     = 2
-	DefaultUploadMaxTimeout     = 10
+	DefaultUploadMaxTimeout     = 30
 	DefaultSealObjectTimeout    = 20
 	DefaultGCObjectTimeout      = 60
 	DefaultGCZombiePieceTimeout = 60
 	DefaultGCStoreTimeout       = 60
 )
 
+// ComputeTransferDataTime computes the upload object timeout.
 func ComputeTransferDataTime(size uint64) int64 {
 	mSize := size / 1024
 	timeout := int64(mSize / uint64(DefaultUploadObjectRate))

--- a/pkg/taskqueue/types/model.go
+++ b/pkg/taskqueue/types/model.go
@@ -1,0 +1,43 @@
+package types
+
+import "errors"
+
+var (
+	// ErrObjectDangling defines the object pointer nil error
+	ErrObjectDangling = errors.New("object pointer dangling")
+)
+
+const (
+	DefaultReplicatePieceTaskRetryLimit  int64 = 3
+	DefaultReplicatePieceTaskMemoryLimit int64 = 40 * 1024 * 1024
+	DefaultSealObjectTaskRetryLimit      int64 = 10
+	DefaultDownloadObjectTaskRetryLimit  int64 = 3
+	DefaultGCObjectTaskRetryLimit        int64 = 3
+	DefaultGCZombiePieceTaskRetryLimit   int64 = 3
+	DefaultGCStoreTaskRetryLimit         int64 = 3
+)
+
+const (
+	DefaultUploadObjectRate = 200
+)
+
+const (
+	DefaultUploadMinTimeout     = 2
+	DefaultUploadMaxTimeout     = 10
+	DefaultSealObjectTimeout    = 20
+	DefaultGCObjectTimeout      = 60
+	DefaultGCZombiePieceTimeout = 60
+	DefaultGCStoreTimeout       = 60
+)
+
+func ComputeTransferDataTime(size uint64) int64 {
+	mSize := size / 1024
+	timeout := int64(mSize / uint64(DefaultUploadObjectRate))
+	if timeout < DefaultUploadMinTimeout {
+		return DefaultUploadMinTimeout
+	}
+	if timeout > DefaultUploadMaxTimeout {
+		return DefaultUploadMaxTimeout
+	}
+	return timeout
+}

--- a/pkg/taskqueue/types/receive_task.go
+++ b/pkg/taskqueue/types/receive_task.go
@@ -10,8 +10,8 @@ import (
 
 var _ tqueue.ReceivePieceTask = &ReceivePieceTask{}
 
-func NewReceivePieceTask(object *storagetypes.ObjectInfo) (*ReceivePieceTask, error) {
-	if object == nil {
+func NewReceivePieceTask(objectInfo *storagetypes.ObjectInfo) (*ReceivePieceTask, error) {
+	if objectInfo == nil {
 		return nil, ErrObjectDangling
 	}
 	task := &Task{
@@ -22,8 +22,8 @@ func NewReceivePieceTask(object *storagetypes.ObjectInfo) (*ReceivePieceTask, er
 		TaskPriority: int32(GetTaskPriorityMap().GetPriority(tqueue.TypeTaskReceivePiece)),
 	}
 	return &ReceivePieceTask{
-		Object: object,
-		Task:   task,
+		ObjectInfo: objectInfo,
+		Task:       task,
 	}, nil
 }
 
@@ -31,10 +31,10 @@ func (m *ReceivePieceTask) Key() tqueue.TKey {
 	if m == nil {
 		return ""
 	}
-	if m.GetObject() == nil {
+	if m.GetObjectInfo() == nil {
 		return ""
 	}
-	return tqueue.TKey(m.GetObject().Id.String())
+	return tqueue.TKey(m.GetObjectInfo().Id.String())
 }
 
 func (m *ReceivePieceTask) Type() tqueue.TType {

--- a/pkg/taskqueue/types/receive_task.go
+++ b/pkg/taskqueue/types/receive_task.go
@@ -1,0 +1,210 @@
+package types
+
+import (
+	"time"
+
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/rcmgr"
+	tqueue "github.com/bnb-chain/greenfield-storage-provider/pkg/taskqueue"
+	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
+)
+
+var _ tqueue.ReceivePieceTask = &ReceivePieceTask{}
+
+func NewReceivePieceTask(object *storagetypes.ObjectInfo) (*ReceivePieceTask, error) {
+	if object == nil {
+		return nil, ErrObjectDangling
+	}
+	task := &Task{
+		CreateTime:   time.Now().Unix(),
+		UpdateTime:   time.Now().Unix(),
+		RetryLimit:   DefaultReplicatePieceTaskRetryLimit,
+		Timeout:      DefaultUploadMaxTimeout,
+		TaskPriority: int32(GetTaskPriorityMap().GetPriority(tqueue.TypeTaskReceivePiece)),
+	}
+	return &ReceivePieceTask{
+		Object: object,
+		Task:   task,
+	}, nil
+}
+
+func (m *ReceivePieceTask) Key() tqueue.TKey {
+	if m == nil {
+		return ""
+	}
+	if m.GetObject() == nil {
+		return ""
+	}
+	return tqueue.TKey(m.GetObject().Id.String())
+}
+
+func (m *ReceivePieceTask) Type() tqueue.TType {
+	return tqueue.TypeTaskReceivePiece
+}
+
+func (m *ReceivePieceTask) LimitEstimate() rcmgr.Limit {
+	return rcmgr.InfiniteLimit()
+}
+
+func (m *ReceivePieceTask) GetCreateTime() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetCreateTime()
+}
+
+func (m *ReceivePieceTask) SetCreateTime(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetCreateTime(time)
+}
+
+func (m *ReceivePieceTask) GetUpdateTime() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetUpdateTime()
+}
+
+func (m *ReceivePieceTask) SetUpdateTime(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetUpdateTime(time)
+}
+
+func (m *ReceivePieceTask) GetTimeout() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetTimeout()
+}
+
+func (m *ReceivePieceTask) SetTimeout(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetTimeout(time)
+}
+
+func (m *ReceivePieceTask) GetPriority() tqueue.TPriority {
+	if m == nil {
+		return tqueue.TPriority(0)
+	}
+	if m.GetTask() == nil {
+		return tqueue.TPriority(0)
+	}
+	return m.GetTask().GetPriority()
+}
+
+func (m *ReceivePieceTask) SetPriority(prio tqueue.TPriority) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetPriority(prio)
+}
+
+func (m *ReceivePieceTask) IncRetry() bool {
+	if m == nil {
+		return false
+	}
+	if m.GetTask() == nil {
+		return false
+	}
+	return m.GetTask().GetRetry() <= m.GetTask().GetRetryLimit()
+}
+
+func (m *ReceivePieceTask) GetRetry() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetRetry()
+}
+
+func (m *ReceivePieceTask) Expired() bool {
+	if m == nil {
+		return true
+	}
+	if m.GetTask() == nil {
+		return true
+	}
+	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() < time.Now().Unix()
+}
+
+func (m *ReceivePieceTask) GetRetryLimit() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetRetryLimit()
+}
+
+func (m *ReceivePieceTask) SetRetryLimit(limit int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetRetryLimit(limit)
+}
+
+func (m *ReceivePieceTask) RetryExceed() bool {
+	if m == nil {
+		return true
+	}
+	if m.GetTask() == nil {
+		return true
+	}
+	return m.GetTask().GetRetry() > m.GetTask().GetRetryLimit()
+}
+
+func (m *ReceivePieceTask) Error() error {
+	if m == nil {
+		return nil
+	}
+	if m.GetTask() == nil {
+		return nil
+	}
+	return m.GetTask().Error()
+}
+
+func (m *ReceivePieceTask) SetError(err error) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetError(err)
+}
+
+func (m *ReceivePieceTask) SetReplicateIdx(rIdx uint32) {
+	m.ReplicateIdx = rIdx
+}

--- a/pkg/taskqueue/types/receive_task.go
+++ b/pkg/taskqueue/types/receive_task.go
@@ -132,7 +132,7 @@ func (m *ReceivePieceTask) IncRetry() bool {
 	if m.GetTask() == nil {
 		return false
 	}
-	return m.GetTask().GetRetry() <= m.GetTask().GetRetryLimit()
+	return m.GetTask().IncRetry()
 }
 
 func (m *ReceivePieceTask) GetRetry() int64 {
@@ -152,7 +152,7 @@ func (m *ReceivePieceTask) Expired() bool {
 	if m.GetTask() == nil {
 		return true
 	}
-	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() < time.Now().Unix()
+	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() > time.Now().Unix()
 }
 
 func (m *ReceivePieceTask) GetRetryLimit() int64 {

--- a/pkg/taskqueue/types/replicate_task.go
+++ b/pkg/taskqueue/types/replicate_task.go
@@ -142,7 +142,7 @@ func (m *ReplicatePieceTask) IncRetry() bool {
 	if m.GetTask() == nil {
 		return false
 	}
-	return m.GetTask().GetRetry() <= m.GetTask().GetRetryLimit()
+	return m.GetTask().IncRetry()
 }
 
 func (m *ReplicatePieceTask) GetRetry() int64 {
@@ -162,7 +162,7 @@ func (m *ReplicatePieceTask) Expired() bool {
 	if m.GetTask() == nil {
 		return true
 	}
-	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() < time.Now().Unix()
+	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() > time.Now().Unix()
 }
 
 func (m *ReplicatePieceTask) GetRetryLimit() int64 {

--- a/pkg/taskqueue/types/replicate_task.go
+++ b/pkg/taskqueue/types/replicate_task.go
@@ -10,20 +10,20 @@ import (
 
 var _ tqueue.ReplicatePieceTask = &ReplicatePieceTask{}
 
-func NewReplicatePieceTask(object *storagetypes.ObjectInfo) (*ReplicatePieceTask, error) {
-	if object == nil {
+func NewReplicatePieceTask(objectInfo *storagetypes.ObjectInfo) (*ReplicatePieceTask, error) {
+	if objectInfo == nil {
 		return nil, ErrObjectDangling
 	}
 	task := &Task{
 		CreateTime:   time.Now().Unix(),
 		UpdateTime:   time.Now().Unix(),
 		RetryLimit:   DefaultReplicatePieceTaskRetryLimit,
-		Timeout:      ComputeTransferDataTime(object.GetPayloadSize()) * 3,
+		Timeout:      ComputeTransferDataTime(objectInfo.GetPayloadSize()) * 3,
 		TaskPriority: int32(GetTaskPriorityMap().GetPriority(tqueue.TypeTaskReplicatePiece)),
 	}
 	return &ReplicatePieceTask{
-		Object: object,
-		Task:   task,
+		ObjectInfo: objectInfo,
+		Task:       task,
 	}, nil
 }
 
@@ -31,10 +31,10 @@ func (m *ReplicatePieceTask) Key() tqueue.TKey {
 	if m == nil {
 		return ""
 	}
-	if m.GetObject() == nil {
+	if m.GetObjectInfo() == nil {
 		return ""
 	}
-	return tqueue.TKey(m.GetObject().Id.String())
+	return tqueue.TKey(m.GetObjectInfo().Id.String())
 }
 
 func (m *ReplicatePieceTask) Type() tqueue.TType {

--- a/pkg/taskqueue/types/replicate_task.go
+++ b/pkg/taskqueue/types/replicate_task.go
@@ -1,0 +1,216 @@
+package types
+
+import (
+	"time"
+
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/rcmgr"
+	tqueue "github.com/bnb-chain/greenfield-storage-provider/pkg/taskqueue"
+	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
+)
+
+var _ tqueue.ReplicatePieceTask = &ReplicatePieceTask{}
+
+func NewReplicatePieceTask(object *storagetypes.ObjectInfo) (*ReplicatePieceTask, error) {
+	if object == nil {
+		return nil, ErrObjectDangling
+	}
+	task := &Task{
+		CreateTime:   time.Now().Unix(),
+		UpdateTime:   time.Now().Unix(),
+		RetryLimit:   DefaultReplicatePieceTaskRetryLimit,
+		Timeout:      ComputeTransferDataTime(object.GetPayloadSize()) * 3,
+		TaskPriority: int32(GetTaskPriorityMap().GetPriority(tqueue.TypeTaskReplicatePiece)),
+	}
+	return &ReplicatePieceTask{
+		Object: object,
+		Task:   task,
+	}, nil
+}
+
+func (m *ReplicatePieceTask) Key() tqueue.TKey {
+	if m == nil {
+		return ""
+	}
+	if m.GetObject() == nil {
+		return ""
+	}
+	return tqueue.TKey(m.GetObject().Id.String())
+}
+
+func (m *ReplicatePieceTask) Type() tqueue.TType {
+	return tqueue.TypeTaskReplicatePiece
+}
+
+func (m *ReplicatePieceTask) LimitEstimate() rcmgr.Limit {
+	limit := &rcmgr.BaseLimit{}
+	prio := m.GetPriority()
+	if GetTaskPriorityMap().HighLevelPriority(prio) {
+		limit.TasksHighPriority = 1
+	} else if GetTaskPriorityMap().LowLevelPriority(prio) {
+		limit.TasksLowPriority = 1
+	} else {
+		limit.TasksMediumPriority = 1
+	}
+	limit.Memory = DefaultReplicatePieceTaskMemoryLimit
+	return limit
+}
+
+func (m *ReplicatePieceTask) GetCreateTime() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetCreateTime()
+}
+
+func (m *ReplicatePieceTask) SetCreateTime(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetCreateTime(time)
+}
+
+func (m *ReplicatePieceTask) GetUpdateTime() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetUpdateTime()
+}
+
+func (m *ReplicatePieceTask) SetUpdateTime(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetUpdateTime(time)
+}
+
+func (m *ReplicatePieceTask) GetTimeout() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetTimeout()
+}
+
+func (m *ReplicatePieceTask) SetTimeout(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetTimeout(time)
+}
+
+func (m *ReplicatePieceTask) GetPriority() tqueue.TPriority {
+	if m == nil {
+		return tqueue.TPriority(0)
+	}
+	if m.GetTask() == nil {
+		return tqueue.TPriority(0)
+	}
+	return m.GetTask().GetPriority()
+}
+
+func (m *ReplicatePieceTask) SetPriority(prio tqueue.TPriority) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetPriority(prio)
+}
+
+func (m *ReplicatePieceTask) IncRetry() bool {
+	if m == nil {
+		return false
+	}
+	if m.GetTask() == nil {
+		return false
+	}
+	return m.GetTask().GetRetry() <= m.GetTask().GetRetryLimit()
+}
+
+func (m *ReplicatePieceTask) GetRetry() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetRetry()
+}
+
+func (m *ReplicatePieceTask) Expired() bool {
+	if m == nil {
+		return true
+	}
+	if m.GetTask() == nil {
+		return true
+	}
+	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() < time.Now().Unix()
+}
+
+func (m *ReplicatePieceTask) GetRetryLimit() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetRetryLimit()
+}
+
+func (m *ReplicatePieceTask) SetRetryLimit(limit int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetRetryLimit(limit)
+}
+
+func (m *ReplicatePieceTask) RetryExceed() bool {
+	if m == nil {
+		return true
+	}
+	if m.GetTask() == nil {
+		return true
+	}
+	return m.GetTask().GetRetry() > m.GetTask().GetRetryLimit()
+}
+
+func (m *ReplicatePieceTask) Error() error {
+	if m == nil {
+		return nil
+	}
+	if m.GetTask() == nil {
+		return nil
+	}
+	return m.GetTask().Error()
+}
+
+func (m *ReplicatePieceTask) SetError(err error) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetError(err)
+}

--- a/pkg/taskqueue/types/replicate_task.go
+++ b/pkg/taskqueue/types/replicate_task.go
@@ -10,7 +10,7 @@ import (
 
 var _ tqueue.ReplicatePieceTask = &ReplicatePieceTask{}
 
-func NewReplicatePieceTask(objectInfo *storagetypes.ObjectInfo) (*ReplicatePieceTask, error) {
+func NewReplicatePieceTask(objectInfo *storagetypes.ObjectInfo, sealObject *storagetypes.MsgSealObject) (*ReplicatePieceTask, error) {
 	if objectInfo == nil {
 		return nil, ErrObjectDangling
 	}
@@ -22,8 +22,9 @@ func NewReplicatePieceTask(objectInfo *storagetypes.ObjectInfo) (*ReplicatePiece
 		TaskPriority: int32(GetTaskPriorityMap().GetPriority(tqueue.TypeTaskReplicatePiece)),
 	}
 	return &ReplicatePieceTask{
-		ObjectInfo: objectInfo,
 		Task:       task,
+		ObjectInfo: objectInfo,
+		SealObject: sealObject,
 	}, nil
 }
 

--- a/pkg/taskqueue/types/seal_task.go
+++ b/pkg/taskqueue/types/seal_task.go
@@ -1,0 +1,215 @@
+package types
+
+import (
+	"time"
+
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/rcmgr"
+	tqueue "github.com/bnb-chain/greenfield-storage-provider/pkg/taskqueue"
+	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
+)
+
+var _ tqueue.SealObjectTask = &SealObjectTask{}
+
+func NewSealObjectTask(object *storagetypes.ObjectInfo) (*SealObjectTask, error) {
+	if object == nil {
+		return nil, ErrObjectDangling
+	}
+	task := &Task{
+		CreateTime:   time.Now().Unix(),
+		UpdateTime:   time.Now().Unix(),
+		RetryLimit:   DefaultSealObjectTaskRetryLimit,
+		Timeout:      DefaultSealObjectTimeout,
+		TaskPriority: int32(GetTaskPriorityMap().GetPriority(tqueue.TypeTaskSealObject)),
+	}
+	return &SealObjectTask{
+		Object: object,
+		Task:   task,
+	}, nil
+}
+
+func (m *SealObjectTask) Key() tqueue.TKey {
+	if m == nil {
+		return ""
+	}
+	if m.GetObject() == nil {
+		return ""
+	}
+	return tqueue.TKey(m.GetObject().Id.String())
+}
+
+func (m *SealObjectTask) Type() tqueue.TType {
+	return tqueue.TypeTaskSealObject
+}
+
+func (m *SealObjectTask) LimitEstimate() rcmgr.Limit {
+	limit := &rcmgr.BaseLimit{}
+	prio := m.GetPriority()
+	if GetTaskPriorityMap().HighLevelPriority(prio) {
+		limit.TasksHighPriority = 1
+	} else if GetTaskPriorityMap().LowLevelPriority(prio) {
+		limit.TasksLowPriority = 1
+	} else {
+		limit.TasksMediumPriority = 1
+	}
+	return limit
+}
+
+func (m *SealObjectTask) GetCreateTime() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetCreateTime()
+}
+
+func (m *SealObjectTask) SetCreateTime(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetCreateTime(time)
+}
+
+func (m *SealObjectTask) GetUpdateTime() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetUpdateTime()
+}
+
+func (m *SealObjectTask) SetUpdateTime(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetUpdateTime(time)
+}
+
+func (m *SealObjectTask) GetTimeout() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetTimeout()
+}
+
+func (m *SealObjectTask) SetTimeout(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetTimeout(time)
+}
+
+func (m *SealObjectTask) GetPriority() tqueue.TPriority {
+	if m == nil {
+		return tqueue.TPriority(0)
+	}
+	if m.GetTask() == nil {
+		return tqueue.TPriority(0)
+	}
+	return m.GetTask().GetPriority()
+}
+
+func (m *SealObjectTask) SetPriority(prio tqueue.TPriority) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetPriority(prio)
+}
+
+func (m *SealObjectTask) IncRetry() bool {
+	if m == nil {
+		return false
+	}
+	if m.GetTask() == nil {
+		return false
+	}
+	return m.GetTask().GetRetry() <= m.GetTask().GetRetryLimit()
+}
+
+func (m *SealObjectTask) GetRetry() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetRetry()
+}
+
+func (m *SealObjectTask) Expired() bool {
+	if m == nil {
+		return true
+	}
+	if m.GetTask() == nil {
+		return true
+	}
+	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() < time.Now().Unix()
+}
+
+func (m *SealObjectTask) GetRetryLimit() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetRetryLimit()
+}
+
+func (m *SealObjectTask) SetRetryLimit(limit int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetRetryLimit(limit)
+}
+
+func (m *SealObjectTask) RetryExceed() bool {
+	if m == nil {
+		return true
+	}
+	if m.GetTask() == nil {
+		return true
+	}
+	return m.GetTask().GetRetry() > m.GetTask().GetRetryLimit()
+}
+
+func (m *SealObjectTask) Error() error {
+	if m == nil {
+		return nil
+	}
+	if m.GetTask() == nil {
+		return nil
+	}
+	return m.GetTask().Error()
+}
+
+func (m *SealObjectTask) SetError(err error) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetError(err)
+}

--- a/pkg/taskqueue/types/seal_task.go
+++ b/pkg/taskqueue/types/seal_task.go
@@ -10,8 +10,8 @@ import (
 
 var _ tqueue.SealObjectTask = &SealObjectTask{}
 
-func NewSealObjectTask(object *storagetypes.ObjectInfo) (*SealObjectTask, error) {
-	if object == nil {
+func NewSealObjectTask(objectInfo *storagetypes.ObjectInfo) (*SealObjectTask, error) {
+	if objectInfo == nil {
 		return nil, ErrObjectDangling
 	}
 	task := &Task{
@@ -22,8 +22,8 @@ func NewSealObjectTask(object *storagetypes.ObjectInfo) (*SealObjectTask, error)
 		TaskPriority: int32(GetTaskPriorityMap().GetPriority(tqueue.TypeTaskSealObject)),
 	}
 	return &SealObjectTask{
-		Object: object,
-		Task:   task,
+		ObjectInfo: objectInfo,
+		Task:       task,
 	}, nil
 }
 
@@ -31,10 +31,10 @@ func (m *SealObjectTask) Key() tqueue.TKey {
 	if m == nil {
 		return ""
 	}
-	if m.GetObject() == nil {
+	if m.GetObjectInfo() == nil {
 		return ""
 	}
-	return tqueue.TKey(m.GetObject().Id.String())
+	return tqueue.TKey(m.GetObjectInfo().Id.String())
 }
 
 func (m *SealObjectTask) Type() tqueue.TType {

--- a/pkg/taskqueue/types/seal_task.go
+++ b/pkg/taskqueue/types/seal_task.go
@@ -141,7 +141,7 @@ func (m *SealObjectTask) IncRetry() bool {
 	if m.GetTask() == nil {
 		return false
 	}
-	return m.GetTask().GetRetry() <= m.GetTask().GetRetryLimit()
+	return m.GetTask().IncRetry()
 }
 
 func (m *SealObjectTask) GetRetry() int64 {
@@ -161,7 +161,7 @@ func (m *SealObjectTask) Expired() bool {
 	if m.GetTask() == nil {
 		return true
 	}
-	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() < time.Now().Unix()
+	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() > time.Now().Unix()
 }
 
 func (m *SealObjectTask) GetRetryLimit() int64 {

--- a/pkg/taskqueue/types/seal_task.go
+++ b/pkg/taskqueue/types/seal_task.go
@@ -10,7 +10,7 @@ import (
 
 var _ tqueue.SealObjectTask = &SealObjectTask{}
 
-func NewSealObjectTask(objectInfo *storagetypes.ObjectInfo) (*SealObjectTask, error) {
+func NewSealObjectTask(objectInfo *storagetypes.ObjectInfo, sealObject *storagetypes.MsgSealObject) (*SealObjectTask, error) {
 	if objectInfo == nil {
 		return nil, ErrObjectDangling
 	}
@@ -22,8 +22,9 @@ func NewSealObjectTask(objectInfo *storagetypes.ObjectInfo) (*SealObjectTask, er
 		TaskPriority: int32(GetTaskPriorityMap().GetPriority(tqueue.TypeTaskSealObject)),
 	}
 	return &SealObjectTask{
-		ObjectInfo: objectInfo,
 		Task:       task,
+		ObjectInfo: objectInfo,
+		SealObject: sealObject,
 	}, nil
 }
 

--- a/pkg/taskqueue/types/task.go
+++ b/pkg/taskqueue/types/task.go
@@ -61,7 +61,7 @@ func (m *Task) Expired() bool {
 	if m == nil {
 		return true
 	}
-	return m.GetUpdateTime()+m.GetTimeout() < time.Now().Unix()
+	return m.GetUpdateTime()+m.GetTimeout() > time.Now().Unix()
 }
 
 func (m *Task) IncRetry() bool {

--- a/pkg/taskqueue/types/task.go
+++ b/pkg/taskqueue/types/task.go
@@ -1,0 +1,104 @@
+package types
+
+import (
+	"errors"
+	"time"
+
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/rcmgr"
+	tqueue "github.com/bnb-chain/greenfield-storage-provider/pkg/taskqueue"
+)
+
+var _ tqueue.Task = &Task{}
+
+func (m *Task) Key() tqueue.TKey {
+	return ""
+}
+
+func (m *Task) Type() tqueue.TType {
+	return tqueue.TypeTaskUnknown
+}
+
+func (m *Task) SetCreateTime(time int64) {
+	if m == nil {
+		return
+	}
+	m.CreateTime = time
+}
+
+func (m *Task) GetPriority() tqueue.TPriority {
+	if m == nil {
+		return tqueue.TPriority(tqueue.UnKnownTaskPriority)
+	}
+	return tqueue.TPriority(m.GetTaskPriority())
+}
+
+func (m *Task) SetPriority(prio tqueue.TPriority) {
+	if m == nil {
+		return
+	}
+	m.TaskPriority = int32(prio)
+}
+
+func (m *Task) LimitEstimate() rcmgr.Limit {
+	return rcmgr.InfinitesimalLimit()
+}
+
+func (m *Task) SetUpdateTime(time int64) {
+	if m == nil {
+		return
+	}
+	m.UpdateTime = time
+}
+
+func (m *Task) SetTimeout(time int64) {
+	if m == nil {
+		return
+	}
+	m.Timeout = time
+}
+
+func (m *Task) Expired() bool {
+	if m == nil {
+		return true
+	}
+	return m.GetUpdateTime()+m.GetTimeout() < time.Now().Unix()
+}
+
+func (m *Task) IncRetry() bool {
+	if m == nil {
+		return false
+	}
+	m.Retry++
+	return m.GetRetry() <= m.GetRetryLimit()
+}
+
+func (m *Task) SetRetryLimit(limit int64) {
+	if m == nil {
+		return
+	}
+	m.RetryLimit = limit
+}
+
+func (m *Task) RetryExceed() bool {
+	if m == nil {
+		return true
+	}
+	return m.GetRetry() > m.GetRetryLimit()
+}
+
+func (m *Task) Error() error {
+	if m == nil {
+		return nil
+	}
+	if len(m.ErrMsg) == 0 {
+		return nil
+	}
+	return errors.New(m.ErrMsg)
+}
+
+func (m *Task) SetError(err error) {
+	if m == nil {
+		return
+	}
+	m.ErrMsg = err.Error()
+}

--- a/pkg/taskqueue/types/task_priority.go
+++ b/pkg/taskqueue/types/task_priority.go
@@ -1,0 +1,170 @@
+package types
+
+import (
+	"errors"
+	"math"
+	"sync"
+
+	tqueue "github.com/bnb-chain/greenfield-storage-provider/pkg/taskqueue"
+)
+
+var (
+	ErrTaskPriorityLvlOutOfBound = errors.New("priority task level out of bound")
+	ErrLowLvlExceedHigh          = errors.New("low  priority task level more than high level")
+	ErrHighLvlExceedLow          = errors.New("high priority task level less than low level")
+)
+
+var _ tqueue.TTaskPriority = &TaskPriority{}
+
+var (
+	gTaskPriority *TaskPriority
+	once          sync.Once
+)
+
+func GetTaskPriorityMap() *TaskPriority {
+	once.Do(func() {
+		gTaskPriority = getTaskPriority()
+	})
+	return gTaskPriority
+}
+
+type TaskPriority struct {
+	typeToPriority map[tqueue.TType]tqueue.TPriority
+	priorityToType map[tqueue.TPriority][]tqueue.TType
+	priorityLevel  map[tqueue.TPriorityLevel]tqueue.TPriority
+	mux            sync.RWMutex
+}
+
+func getTaskPriority() *TaskPriority {
+	t2p := map[tqueue.TType]tqueue.TPriority{
+		tqueue.TypeTaskUnknown:        tqueue.UnSchedulingPriority,
+		tqueue.TypeTaskReceivePiece:   tqueue.UnSchedulingPriority,
+		tqueue.TypeTaskDownloadObject: tqueue.UnSchedulingPriority,
+		tqueue.TypeTaskUpload:         tqueue.UnSchedulingPriority,
+		tqueue.TypeTaskGCStore:        tqueue.DefaultSmallerPriority / 4,
+		tqueue.TypeTaskGCZombiePiece:  tqueue.DefaultSmallerPriority / 2,
+		tqueue.TypeTaskGCObject:       tqueue.DefaultSmallerPriority,
+		tqueue.TypeTaskReplicatePiece: tqueue.DefaultLargerTaskPriority,
+		tqueue.TypeTaskSealObject:     tqueue.MaxTaskPriority,
+	}
+	p2t := make(map[tqueue.TPriority][]tqueue.TType)
+	for tType, priority := range t2p {
+		p2t[priority] = append(p2t[priority], tType)
+	}
+	p2l := map[tqueue.TPriorityLevel]tqueue.TPriority{
+		tqueue.TLowPriorityLevel:  tqueue.DefaultSmallerPriority,
+		tqueue.THighPriorityLevel: tqueue.DefaultLargerTaskPriority,
+	}
+	return &TaskPriority{
+		typeToPriority: t2p,
+		priorityToType: p2t,
+		priorityLevel:  p2l,
+	}
+}
+
+func (t *TaskPriority) GetPriority(tType tqueue.TType) tqueue.TPriority {
+	t.mux.RLock()
+	defer t.mux.RUnlock()
+	if _, ok := t.typeToPriority[tType]; !ok {
+		return tqueue.UnKnownTaskPriority
+	}
+	return t.typeToPriority[tType]
+}
+
+func (t *TaskPriority) SetPriority(tType tqueue.TType, proi tqueue.TPriority) {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+	t.deleteItem(tType, proi)
+	t.typeToPriority[tType] = proi
+	t.priorityToType[proi] = append(t.priorityToType[proi], tType)
+}
+
+func (t *TaskPriority) deleteItem(tType tqueue.TType, proi tqueue.TPriority) {
+	index := -1
+	for i, taskTpye := range t.priorityToType[proi] {
+		if taskTpye == tType {
+			index = i
+			break
+		}
+	}
+	if index != -1 {
+		t.priorityToType[proi] = append(t.priorityToType[proi][0:index], t.priorityToType[proi][index+1:]...)
+	}
+	delete(t.typeToPriority, tType)
+}
+
+func (t *TaskPriority) GetAllPriorities() map[tqueue.TType]tqueue.TPriority {
+	t.mux.RLock()
+	defer t.mux.RUnlock()
+	return t.typeToPriority
+}
+
+func (t *TaskPriority) SetAllPriorities(t2p map[tqueue.TType]tqueue.TPriority) {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+	t.typeToPriority = t2p
+	p2t := make(map[tqueue.TPriority][]tqueue.TType)
+	for tType, priority := range t.typeToPriority {
+		p2t[priority] = append(p2t[priority], tType)
+	}
+	t.priorityToType = p2t
+}
+
+func (t *TaskPriority) GetLowLevelPriority() tqueue.TPriority {
+	t.mux.RLock()
+	defer t.mux.RUnlock()
+	return t.priorityLevel[tqueue.TLowPriorityLevel]
+}
+
+func (t *TaskPriority) SetLowLevelPriority(lvl tqueue.TPriority) error {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+	if lvl < 0 || lvl > math.MaxUint8 {
+		return ErrTaskPriorityLvlOutOfBound
+	}
+	if uint8(lvl) > uint8(t.priorityLevel[tqueue.THighPriorityLevel]) {
+		return ErrLowLvlExceedHigh
+	}
+	t.priorityLevel[tqueue.TLowPriorityLevel] = lvl
+	return nil
+}
+
+func (t *TaskPriority) GetHighLevelPriority() tqueue.TPriority {
+	t.mux.RLock()
+	defer t.mux.RUnlock()
+	return t.priorityLevel[tqueue.THighPriorityLevel]
+}
+
+func (t *TaskPriority) SetHighLevelPriority(lvl tqueue.TPriority) error {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+	if lvl < 0 || lvl > math.MaxUint8 {
+		return ErrTaskPriorityLvlOutOfBound
+	}
+	if uint8(lvl) < uint8(t.priorityLevel[tqueue.TLowPriorityLevel]) {
+		return ErrHighLvlExceedLow
+	}
+	t.priorityLevel[tqueue.THighPriorityLevel] = lvl
+	return nil
+}
+
+func (t *TaskPriority) HighLevelPriority(lvl tqueue.TPriority) bool {
+	t.mux.RLock()
+	defer t.mux.RUnlock()
+	hPrio := t.priorityLevel[tqueue.THighPriorityLevel]
+	return lvl >= hPrio
+}
+
+func (t *TaskPriority) LowLevelPriority(lvl tqueue.TPriority) bool {
+	t.mux.RLock()
+	defer t.mux.RUnlock()
+	lPrio := t.priorityLevel[tqueue.TLowPriorityLevel]
+	return lvl >= lPrio
+}
+
+func (t *TaskPriority) SupportTask(tType tqueue.TType) bool {
+	t.mux.RLock()
+	defer t.mux.RUnlock()
+	_, ok := t.typeToPriority[tType]
+	return ok
+}

--- a/pkg/taskqueue/types/task_priority.go
+++ b/pkg/taskqueue/types/task_priority.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"errors"
-	"math"
 	"sync"
 
 	tqueue "github.com/bnb-chain/greenfield-storage-provider/pkg/taskqueue"
@@ -40,7 +39,7 @@ func getTaskPriority() *TaskPriority {
 		tqueue.TypeTaskUnknown:        tqueue.UnSchedulingPriority,
 		tqueue.TypeTaskReceivePiece:   tqueue.UnSchedulingPriority,
 		tqueue.TypeTaskDownloadObject: tqueue.UnSchedulingPriority,
-		tqueue.TypeTaskUpload:         tqueue.UnSchedulingPriority,
+		tqueue.TypeTaskUploadObject:   tqueue.UnSchedulingPriority,
 		tqueue.TypeTaskGCStore:        tqueue.DefaultSmallerPriority / 4,
 		tqueue.TypeTaskGCZombiePiece:  tqueue.DefaultSmallerPriority / 2,
 		tqueue.TypeTaskGCObject:       tqueue.DefaultSmallerPriority,
@@ -119,9 +118,6 @@ func (t *TaskPriority) GetLowLevelPriority() tqueue.TPriority {
 func (t *TaskPriority) SetLowLevelPriority(lvl tqueue.TPriority) error {
 	t.mux.Lock()
 	defer t.mux.Unlock()
-	if lvl < 0 || lvl > math.MaxUint8 {
-		return ErrTaskPriorityLvlOutOfBound
-	}
 	if uint8(lvl) > uint8(t.priorityLevel[tqueue.THighPriorityLevel]) {
 		return ErrLowLvlExceedHigh
 	}
@@ -138,9 +134,6 @@ func (t *TaskPriority) GetHighLevelPriority() tqueue.TPriority {
 func (t *TaskPriority) SetHighLevelPriority(lvl tqueue.TPriority) error {
 	t.mux.Lock()
 	defer t.mux.Unlock()
-	if lvl < 0 || lvl > math.MaxUint8 {
-		return ErrTaskPriorityLvlOutOfBound
-	}
 	if uint8(lvl) < uint8(t.priorityLevel[tqueue.TLowPriorityLevel]) {
 		return ErrHighLvlExceedLow
 	}

--- a/pkg/taskqueue/types/upload_task.go
+++ b/pkg/taskqueue/types/upload_task.go
@@ -1,0 +1,205 @@
+package types
+
+import (
+	"time"
+
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/rcmgr"
+	tqueue "github.com/bnb-chain/greenfield-storage-provider/pkg/taskqueue"
+	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
+)
+
+var _ tqueue.UploadObjectTask = &UploadObjectTask{}
+
+func NewUploadObjectTask(object *storagetypes.ObjectInfo) (*UploadObjectTask, error) {
+	if object == nil {
+		return nil, ErrObjectDangling
+	}
+	task := &Task{
+		CreateTime:   time.Now().Unix(),
+		UpdateTime:   time.Now().Unix(),
+		Timeout:      ComputeTransferDataTime(object.GetPayloadSize()),
+		TaskPriority: int32(GetTaskPriorityMap().GetPriority(tqueue.TypeTaskUpload)),
+	}
+	return &UploadObjectTask{
+		Object: object,
+		Task:   task,
+	}, nil
+}
+
+func (m *UploadObjectTask) Key() tqueue.TKey {
+	if m == nil {
+		return ""
+	}
+	if m.GetObject() == nil {
+		return ""
+	}
+	return tqueue.TKey(m.GetObject().Id.String())
+}
+
+func (m *UploadObjectTask) Type() tqueue.TType {
+	return tqueue.TypeTaskUpload
+}
+
+func (m *UploadObjectTask) LimitEstimate() rcmgr.Limit {
+	return rcmgr.InfiniteLimit()
+}
+
+func (m *UploadObjectTask) GetCreateTime() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetCreateTime()
+}
+
+func (m *UploadObjectTask) SetCreateTime(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetCreateTime(time)
+}
+
+func (m *UploadObjectTask) GetUpdateTime() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetUpdateTime()
+}
+
+func (m *UploadObjectTask) SetUpdateTime(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetUpdateTime(time)
+}
+
+func (m *UploadObjectTask) GetTimeout() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetTimeout()
+}
+
+func (m *UploadObjectTask) SetTimeout(time int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetTimeout(time)
+}
+
+func (m *UploadObjectTask) GetPriority() tqueue.TPriority {
+	if m == nil {
+		return tqueue.TPriority(0)
+	}
+	if m.GetTask() == nil {
+		return tqueue.TPriority(0)
+	}
+	return m.GetTask().GetPriority()
+}
+
+func (m *UploadObjectTask) SetPriority(prio tqueue.TPriority) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetPriority(prio)
+}
+
+func (m *UploadObjectTask) IncRetry() bool {
+	if m == nil {
+		return false
+	}
+	if m.GetTask() == nil {
+		return false
+	}
+	return m.GetTask().GetRetry() <= m.GetTask().GetRetryLimit()
+}
+
+func (m *UploadObjectTask) GetRetry() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetRetry()
+}
+
+func (m *UploadObjectTask) Expired() bool {
+	if m == nil {
+		return true
+	}
+	if m.GetTask() == nil {
+		return true
+	}
+	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() < time.Now().Unix()
+}
+
+func (m *UploadObjectTask) GetRetryLimit() int64 {
+	if m == nil {
+		return 0
+	}
+	if m.GetTask() == nil {
+		return 0
+	}
+	return m.GetTask().GetRetryLimit()
+}
+
+func (m *UploadObjectTask) SetRetryLimit(limit int64) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetRetryLimit(limit)
+}
+
+func (m *UploadObjectTask) RetryExceed() bool {
+	if m == nil {
+		return true
+	}
+	if m.GetTask() == nil {
+		return true
+	}
+	return m.GetTask().GetRetry() > m.GetTask().GetRetryLimit()
+}
+
+func (m *UploadObjectTask) Error() error {
+	if m == nil {
+		return nil
+	}
+	if m.GetTask() == nil {
+		return nil
+	}
+	return m.GetTask().Error()
+}
+
+func (m *UploadObjectTask) SetError(err error) {
+	if m == nil {
+		return
+	}
+	if m.GetTask() == nil {
+		return
+	}
+	m.GetTask().SetError(err)
+}

--- a/pkg/taskqueue/types/upload_task.go
+++ b/pkg/taskqueue/types/upload_task.go
@@ -10,19 +10,19 @@ import (
 
 var _ tqueue.UploadObjectTask = &UploadObjectTask{}
 
-func NewUploadObjectTask(object *storagetypes.ObjectInfo) (*UploadObjectTask, error) {
-	if object == nil {
+func NewUploadObjectTask(objectInfo *storagetypes.ObjectInfo) (*UploadObjectTask, error) {
+	if objectInfo == nil {
 		return nil, ErrObjectDangling
 	}
 	task := &Task{
 		CreateTime:   time.Now().Unix(),
 		UpdateTime:   time.Now().Unix(),
-		Timeout:      ComputeTransferDataTime(object.GetPayloadSize()),
+		Timeout:      ComputeTransferDataTime(objectInfo.GetPayloadSize()),
 		TaskPriority: int32(GetTaskPriorityMap().GetPriority(tqueue.TypeTaskUploadObject)),
 	}
 	return &UploadObjectTask{
-		Object: object,
-		Task:   task,
+		ObjectInfo: objectInfo,
+		Task:       task,
 	}, nil
 }
 
@@ -30,10 +30,10 @@ func (m *UploadObjectTask) Key() tqueue.TKey {
 	if m == nil {
 		return ""
 	}
-	if m.GetObject() == nil {
+	if m.GetObjectInfo() == nil {
 		return ""
 	}
-	return tqueue.TKey(m.GetObject().Id.String())
+	return tqueue.TKey(m.GetObjectInfo().Id.String())
 }
 
 func (m *UploadObjectTask) Type() tqueue.TType {

--- a/pkg/taskqueue/types/upload_task.go
+++ b/pkg/taskqueue/types/upload_task.go
@@ -18,7 +18,7 @@ func NewUploadObjectTask(object *storagetypes.ObjectInfo) (*UploadObjectTask, er
 		CreateTime:   time.Now().Unix(),
 		UpdateTime:   time.Now().Unix(),
 		Timeout:      ComputeTransferDataTime(object.GetPayloadSize()),
-		TaskPriority: int32(GetTaskPriorityMap().GetPriority(tqueue.TypeTaskUpload)),
+		TaskPriority: int32(GetTaskPriorityMap().GetPriority(tqueue.TypeTaskUploadObject)),
 	}
 	return &UploadObjectTask{
 		Object: object,
@@ -37,7 +37,7 @@ func (m *UploadObjectTask) Key() tqueue.TKey {
 }
 
 func (m *UploadObjectTask) Type() tqueue.TType {
-	return tqueue.TypeTaskUpload
+	return tqueue.TypeTaskUploadObject
 }
 
 func (m *UploadObjectTask) LimitEstimate() rcmgr.Limit {
@@ -131,7 +131,7 @@ func (m *UploadObjectTask) IncRetry() bool {
 	if m.GetTask() == nil {
 		return false
 	}
-	return m.GetTask().GetRetry() <= m.GetTask().GetRetryLimit()
+	return m.GetTask().IncRetry()
 }
 
 func (m *UploadObjectTask) GetRetry() int64 {
@@ -151,7 +151,7 @@ func (m *UploadObjectTask) Expired() bool {
 	if m.GetTask() == nil {
 		return true
 	}
-	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() < time.Now().Unix()
+	return m.GetTask().GetUpdateTime()+m.GetTask().GetTimeout() > time.Now().Unix()
 }
 
 func (m *UploadObjectTask) GetRetryLimit() int64 {

--- a/proto/pkg/taskqueue/types/task.proto
+++ b/proto/pkg/taskqueue/types/task.proto
@@ -17,28 +17,28 @@ message Task {
 
 message UploadObjectTask {
   Task task = 1;
-  bnbchain.greenfield.storage.ObjectInfo object = 2;
+  bnbchain.greenfield.storage.ObjectInfo object_info = 2;
 }
 
 message ReplicatePieceTask {
   Task task = 1;
-  bnbchain.greenfield.storage.ObjectInfo object = 2;
+  bnbchain.greenfield.storage.ObjectInfo object_info = 2;
 }
 
 message SealObjectTask {
   Task task = 1;
-  bnbchain.greenfield.storage.ObjectInfo object = 2;
+  bnbchain.greenfield.storage.ObjectInfo object_info = 2;
 }
 
 message ReceivePieceTask {
   Task task = 1;
-  bnbchain.greenfield.storage.ObjectInfo object = 2;
+  bnbchain.greenfield.storage.ObjectInfo object_info = 2;
   uint32 replicate_idx = 3;
 }
 
 message DownloadObjectTask {
   Task task = 1;
-  bnbchain.greenfield.storage.ObjectInfo object = 2;
+  bnbchain.greenfield.storage.ObjectInfo object_info = 2;
   uint64 low = 3;
   uint64 high = 4;
   bool need_integrity = 5;

--- a/proto/pkg/taskqueue/types/task.proto
+++ b/proto/pkg/taskqueue/types/task.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+package pkg.taskqueue.types;
+
+import "greenfield/storage/types.proto";
+
+option go_package = "github.com/bnb-chain/greenfield-storage-provider/pkg/taskqueue/types";
+
+message Task {
+  int64 create_time = 1;
+  int64 update_time = 2;
+  int64 timeout = 3;
+  int32 task_priority = 4;
+  int64 retry = 5;
+  int64 retry_limit = 6;
+  string err_msg = 7;
+}
+
+message UploadObjectTask {
+  Task task = 1;
+  bnbchain.greenfield.storage.ObjectInfo object = 2;
+}
+
+message ReplicatePieceTask {
+  Task task = 1;
+  bnbchain.greenfield.storage.ObjectInfo object = 2;
+}
+
+message SealObjectTask {
+  Task task = 1;
+  bnbchain.greenfield.storage.ObjectInfo object = 2;
+}
+
+message ReceivePieceTask {
+  Task task = 1;
+  bnbchain.greenfield.storage.ObjectInfo object = 2;
+  uint32 replicate_idx = 3;
+}
+
+message DownloadObjectTask {
+  Task task = 1;
+  bnbchain.greenfield.storage.ObjectInfo object = 2;
+  uint64 low = 3;
+  uint64 high = 4;
+  bool need_integrity = 5;
+}
+
+message GCObjectTask {
+  Task task = 1;
+  uint64 start_block_number = 2;
+  uint64 end_block_number = 3;
+  uint64 current_block_number = 4;
+  uint64 object_id = 5;
+  bool running = 6;
+}
+
+message GCZombiePieceTask {
+  Task task = 1;
+  uint64 delete_count = 2;
+  bool running = 3;
+}
+
+message GCStoreTask {
+  Task task = 1;
+  uint64 current_idx = 2;
+  uint64 delete_count = 3;
+  bool running = 4;
+}

--- a/proto/pkg/taskqueue/types/task.proto
+++ b/proto/pkg/taskqueue/types/task.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package pkg.taskqueue.types;
 
 import "greenfield/storage/types.proto";
+import "greenfield/storage/tx.proto";
 
 option go_package = "github.com/bnb-chain/greenfield-storage-provider/pkg/taskqueue/types";
 
@@ -23,11 +24,13 @@ message UploadObjectTask {
 message ReplicatePieceTask {
   Task task = 1;
   bnbchain.greenfield.storage.ObjectInfo object_info = 2;
+  bnbchain.greenfield.storage.MsgSealObject seal_object = 3;
 }
 
 message SealObjectTask {
   Task task = 1;
   bnbchain.greenfield.storage.ObjectInfo object_info = 2;
+  bnbchain.greenfield.storage.MsgSealObject seal_object = 3;
 }
 
 message ReceivePieceTask {

--- a/proto/service/manager/types/manager.proto
+++ b/proto/service/manager/types/manager.proto
@@ -71,14 +71,14 @@ message Limit {
   int64 low_priority_task = 4;
 }
 
-// AskTaskRequest is request type for the AskTask RPC method.
-message AskTaskRequest {
+// AllocTaskRequest is request type for the AllocTask RPC method.
+message AllocTaskRequest {
   // limit defines the requester resource to run task.
   Limit limit = 1;
 }
 
-// AskTaskResponse is response type for the AskTask RPC method.
-message AskTaskResponse {
+// AllocTaskResponse is response type for the AllocTask RPC method.
+message AllocTaskResponse {
   // task defines the manager dispatches the task to execute.
   oneof task {
     // replicate_piece_task stands dispatch the replicate piece task.
@@ -88,7 +88,7 @@ message AskTaskResponse {
     // gc_object_task stands dispatch the gc object task.
     pkg.taskqueue.types.GCObjectTask gc_object_task = 3;
   }
-  bool has_task = 4;
+  // bool has_task = 4;
 }
 
 // AskTaskResponse is response type for the AskTask RPC method.
@@ -123,8 +123,8 @@ service ManagerService {
   rpc DoneReplicatePieceTask(DoneReplicatePieceTaskRequest) returns (DoneReplicatePieceTaskResponse) {};
   // DoneSealObjectTask notifies the manager the seal object task has been done.
   rpc DoneSealObjectTask(DoneSealObjectTaskRequest) returns (DoneSealObjectTaskResponse) {};
-  // AskTask asks the task to execute.
-  rpc AskTask(AskTaskRequest) returns (AskTaskResponse) {};
+  // AllocTask alloc the task to execute.
+  rpc AllocTask(AllocTaskRequest) returns (AllocTaskResponse) {};
   // DoneGCObjectTask notifies the manager the gc object task has been done.
   rpc DoneGCObjectTask(DoneGCObjectTaskRequest) returns (DoneGCObjectTaskResponse) {};
   // ReportGCObjectProgress notifies the manager the gc object task progress.

--- a/proto/service/manager/types/manager.proto
+++ b/proto/service/manager/types/manager.proto
@@ -100,13 +100,13 @@ message DoneGCObjectTaskRequest {
 message DoneGCObjectTaskResponse {
 }
 
-// ReportGCObjectProcessRequest is response type for the ReportGCObjectProcess RPC method.
-message ReportGCObjectProcessRequest {
+// ReportGCObjectProgressRequest is response type for the ReportGCObjectProgress RPC method.
+message ReportGCObjectProgressRequest {
   pkg.taskqueue.types.GCObjectTask gc_object_task = 1;
 }
 
-// ReportGCObjectProcessResponse is response type for the ReportGCObjectProcess RPC method.
-message ReportGCObjectProcessResponse {
+// ReportGCObjectProcessResponse is response type for the ReportGCObjectProgress RPC method.
+message ReportGCObjectProgressResponse {
   bool cancel = 1;
 }
 
@@ -126,6 +126,6 @@ service ManagerService {
   rpc AskTask(AskTaskRequest) returns (AskTaskResponse) {};
   // DoneGCObjectTask notifies the manager the gc object task has been done.
   rpc DoneGCObjectTask(DoneGCObjectTaskRequest) returns (DoneGCObjectTaskResponse) {};
-  // ReportGCObjectProcess notifies the manager the gc object task process.
-  rpc ReportGCObjectProcess(ReportGCObjectProcessRequest) returns (ReportGCObjectProcessResponse) {};
+  // ReportGCObjectProgress notifies the manager the gc object task progress.
+  rpc ReportGCObjectProgress(ReportGCObjectProgressRequest) returns (ReportGCObjectProgressResponse) {};
 }

--- a/proto/service/manager/types/manager.proto
+++ b/proto/service/manager/types/manager.proto
@@ -111,6 +111,7 @@ message ReportGCObjectProgressResponse {
 }
 
 // ManagerService defines the service offer gRPC service for SP manager.
+// TODO: refine it, begin/report.
 service ManagerService {
   // AskUploadObject asks to create object to SP manager.
   rpc AskUploadObject(AskUploadObjectRequest) returns (AskUploadObjectResponse) {};

--- a/proto/service/manager/types/manager.proto
+++ b/proto/service/manager/types/manager.proto
@@ -1,0 +1,131 @@
+syntax = "proto3";
+package service.manager.types;
+
+import "pkg/taskqueue/types/task.proto";
+
+option go_package = "github.com/bnb-chain/greenfield-storage-provider/service/manager/types";
+
+// AskUploadObjectRequest is request type for the AskUploadObject RPC method.
+message AskUploadObjectRequest {
+  // upload_object_task defines the upload object task.
+  pkg.taskqueue.types.UploadObjectTask upload_object_task = 1;
+}
+
+// AskUploadObjectResponse is response type for the AskUploadObject RPC method.
+message AskUploadObjectResponse {
+  // allow defines whether allow to upload object.
+  bool allow = 1;
+  // refuse_reason defines the reason of refusing upload object.
+  string refuse_reason = 2;
+}
+
+// CreateUploadObjectTaskRequest is request type for the CreateUploadObjectTask RPC method.
+message CreateUploadObjectTaskRequest {
+  // upload_object_task defines the upload object task that to upload.
+  pkg.taskqueue.types.UploadObjectTask upload_object_task = 1;
+}
+
+// CreateUploadObjectTaskResponse is response type for the CreateUploadObjectTask RPC method.
+message CreateUploadObjectTaskResponse{
+}
+
+// DoneUploadObjectTaskRequest is request type for the DoneUploadObjectTask RPC method.
+message DoneUploadObjectTaskRequest {
+  // upload_object_task defines the upload object task that has been done.
+  pkg.taskqueue.types.UploadObjectTask upload_object_task = 1;
+}
+
+// DoneUploadObjectTaskResponse is response type for the DoneUploadObjectTask RPC method.
+message DoneUploadObjectTaskResponse {
+}
+
+// DoneReplicatePieceTaskRequest is request type for the DoneReplicatePieceTask RPC method.
+message DoneReplicatePieceTaskRequest {
+  // replicate_piece_task defines the replicate piece task that to be replicated.
+  pkg.taskqueue.types.ReplicatePieceTask replicate_piece_task = 1;
+}
+
+// DoneReplicatePieceTaskResponse is response type for the DoneReplicatePieceTask RPC method.
+message DoneReplicatePieceTaskResponse {
+}
+
+// DoneSealObjectTaskRequest is request type for the DoneSealObjectTask RPC method.
+message DoneSealObjectTaskRequest {
+  // seal_object_task defines the seal object task that to be sealed.
+  pkg.taskqueue.types.SealObjectTask seal_object_task = 1;
+}
+
+// DoneSealObjectTaskResponse is response type for the DoneSealObjectTask RPC method.
+message DoneSealObjectTaskResponse {
+}
+
+// Limit defines the resource limits for executing task.
+message Limit {
+  // memory defines the limit of memory size.
+  int64 memory = 1;
+  // high_priority_task defines the limit of high priority task number.
+  int64 high_priority_task = 2;
+  // medium_priority_task defines the limit of medium priority task number.
+  int64 medium_priority_task = 3;
+  // low_priority_task defines the limit of low priority task number.
+  int64 low_priority_task = 4;
+}
+
+// AskTaskRequest is request type for the AskTask RPC method.
+message AskTaskRequest {
+  // limit defines the requester resource to run task.
+  Limit limit = 1;
+}
+
+// AskTaskResponse is response type for the AskTask RPC method.
+message AskTaskResponse {
+  // task defines the manager dispatches the task to execute.
+  oneof task {
+    // replicate_piece_task stands dispatch the replicate piece task.
+    pkg.taskqueue.types.ReplicatePieceTask replicate_piece_task = 1;
+    // seal_object_task stands dispatch the seal object task.
+    pkg.taskqueue.types.SealObjectTask seal_object_task = 2;
+    // gc_object_task stands dispatch the gc object task.
+    pkg.taskqueue.types.GCObjectTask gc_object_task = 3;
+  }
+  bool has_task = 4;
+}
+
+// AskTaskResponse is response type for the AskTask RPC method.
+message DoneGCObjectTaskRequest {
+  pkg.taskqueue.types.GCObjectTask gc_object_task = 1;
+}
+
+// DoneGCObjectTaskResponse is response type for the DoneGCObjectTas RPC method.
+message DoneGCObjectTaskResponse {
+}
+
+// ReportGCObjectProcessRequest is response type for the ReportGCObjectProcess RPC method.
+message ReportGCObjectProcessRequest {
+  pkg.taskqueue.types.GCObjectTask gc_object_task = 1;
+}
+
+// ReportGCObjectProcessResponse is response type for the ReportGCObjectProcess RPC method.
+message ReportGCObjectProcessResponse {
+  bool cancel = 1;
+}
+
+// ManagerService defines the service offer gRPC service for SP manager.
+service ManagerService {
+  // AskUploadObject asks to create object to SP manager.
+  rpc AskUploadObject(AskUploadObjectRequest) returns (AskUploadObjectResponse) {};
+  // CreateUploadObjectTask asks to upload object to SP manager.
+  rpc CreateUploadObjectTask(CreateUploadObjectTaskRequest) returns (CreateUploadObjectTaskResponse) {};
+  // DoneUploadTask notifies the manager the upload object task has been done.
+  rpc DoneUploadObjectTask(DoneUploadObjectTaskRequest) returns (DoneUploadObjectTaskResponse) {};
+  // DoneReplicatePieceTask notifies the manager the replicate piece task has been done.
+  rpc DoneReplicatePieceTask(DoneReplicatePieceTaskRequest) returns (DoneReplicatePieceTaskResponse) {};
+  // DoneSealObjectTask notifies the manager the seal object task has been done.
+  rpc DoneSealObjectTask(DoneSealObjectTaskRequest) returns (DoneSealObjectTaskResponse) {};
+  // AskTask asks the task to execute.
+  rpc AskTask(AskTaskRequest) returns (AskTaskResponse) {};
+  // DoneGCObjectTask notifies the manager the gc object task has been done.
+  rpc DoneGCObjectTask(DoneGCObjectTaskRequest) returns (DoneGCObjectTaskResponse) {};
+  // ReportGCObjectProcess notifies the manager the gc object task process.
+  rpc ReportGCObjectProcess(ReportGCObjectProcessRequest) returns (ReportGCObjectProcessResponse) {};
+}

--- a/proto/service/signer/types/signer.proto
+++ b/proto/service/signer/types/signer.proto
@@ -73,7 +73,7 @@ message SignIntegrityHashResponse {
 // SealObjectOnChainRequest is request type for the SealObjectOnChain RPC method.
 message SealObjectOnChainRequest {
   // seal_object defines the information of the seal object action.
-  bnbchain.greenfield.storage.MsgSealObject seal_object= 1;
+  bnbchain.greenfield.storage.MsgSealObject seal_object = 1;
 }
 
 // SealObjectOnChainResponse is response type for the SealObjectOnChain RPC method.

--- a/service/manager/client/manager_client.go
+++ b/service/manager/client/manager_client.go
@@ -100,21 +100,29 @@ func (client *ManagerClient) DoneUploadObjectTask(ctx context.Context,
 
 // DoneReplicatePieceTask notifies the manager the replicate piece task has been done.
 func (client *ManagerClient) DoneReplicatePieceTask(ctx context.Context,
-	task *tqueuetypes.ReplicatePieceTask, opts ...grpc.CallOption) error {
+	objectInfo *storagetypes.ObjectInfo, sealObjectInfo *storagetypes.MsgSealObject, opts ...grpc.CallOption) error {
+	task, err := tqueuetypes.NewReplicatePieceTask(objectInfo, sealObjectInfo)
+	if err != nil {
+		return err
+	}
 	req := &types.DoneReplicatePieceTaskRequest{
 		ReplicatePieceTask: task,
 	}
-	_, err := client.manager.DoneReplicatePieceTask(ctx, req, opts...)
+	_, err = client.manager.DoneReplicatePieceTask(ctx, req, opts...)
 	return err
 }
 
 // DoneSealObjectTask notifies the manager the seal object task has been done.
 func (client *ManagerClient) DoneSealObjectTask(ctx context.Context,
-	task *tqueuetypes.SealObjectTask, opts ...grpc.CallOption) error {
+	objectInfo *storagetypes.ObjectInfo, opts ...grpc.CallOption) error {
+	task, err := tqueuetypes.NewSealObjectTask(objectInfo, nil)
+	if err != nil {
+		return err
+	}
 	req := &types.DoneSealObjectTaskRequest{
 		SealObjectTask: task,
 	}
-	_, err := client.manager.DoneSealObjectTask(ctx, req, opts...)
+	_, err = client.manager.DoneSealObjectTask(ctx, req, opts...)
 	return err
 }
 

--- a/service/manager/client/manager_client.go
+++ b/service/manager/client/manager_client.go
@@ -118,13 +118,13 @@ func (client *ManagerClient) DoneSealObjectTask(ctx context.Context,
 	return err
 }
 
-// AskTask asks the task to execute
-func (client *ManagerClient) AskTask(ctx context.Context,
-	rclimit rcmgr.Limit, opts ...grpc.CallOption) (*types.AskTaskResponse, error) {
-	req := &types.AskTaskRequest{
+// AllocTask alloc the task to execute
+func (client *ManagerClient) AllocTask(ctx context.Context,
+	rclimit rcmgr.Limit, opts ...grpc.CallOption) (*types.AllocTaskResponse, error) {
+	req := &types.AllocTaskRequest{
 		Limit: types.NewLimits(rclimit),
 	}
-	resp, err := client.manager.AskTask(ctx, req, opts...)
+	resp, err := client.manager.AllocTask(ctx, req, opts...)
 	return resp, err
 }
 

--- a/service/manager/client/manager_client.go
+++ b/service/manager/client/manager_client.go
@@ -1,0 +1,152 @@
+package client
+
+import (
+	"context"
+
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/rcmgr"
+	tqueuetypes "github.com/bnb-chain/greenfield-storage-provider/pkg/taskqueue/types"
+	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
+	"google.golang.org/grpc"
+
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/metrics"
+	"github.com/bnb-chain/greenfield-storage-provider/service/manager/types"
+	utilgrpc "github.com/bnb-chain/greenfield-storage-provider/util/grpc"
+)
+
+// ManagerClient is a challenge gRPC service client wrapper
+type ManagerClient struct {
+	address string
+	manager types.ManagerServiceClient
+	conn    *grpc.ClientConn
+}
+
+const managerRPCServiceName = "service.manager.types.ManagerService"
+
+// NewManagerClient return a manager client instance
+func NewManagerClient(address string) (*ManagerClient, error) {
+	options := utilgrpc.GetDefaultClientOptions()
+	retryOption, err := utilgrpc.GetDefaultGRPCRetryPolicy(managerRPCServiceName)
+	if err != nil {
+		log.Errorw("failed to get manager client retry option", "error", err)
+		return nil, err
+	}
+	options = append(options, retryOption)
+	if metrics.GetMetrics().Enabled() {
+		options = append(options, utilgrpc.GetDefaultClientInterceptor()...)
+	}
+	conn, err := grpc.DialContext(context.Background(), address, options...)
+	if err != nil {
+		log.Errorw("failed to dial manager", "error", err)
+		return nil, err
+	}
+	client := &ManagerClient{
+		address: address,
+		conn:    conn,
+		manager: types.NewManagerServiceClient(conn),
+	}
+	return client, nil
+}
+
+// Close the manager gPRC connection
+func (client *ManagerClient) Close() error {
+	return client.conn.Close()
+}
+
+// AskUploadObject asks to create object to SP manager.
+func (client *ManagerClient) AskUploadObject(ctx context.Context,
+	object *storagetypes.ObjectInfo, opts ...grpc.CallOption) (bool, error) {
+	task, err := tqueuetypes.NewUploadObjectTask(object)
+	if err != nil {
+		return false, err
+	}
+	req := &types.AskUploadObjectRequest{
+		UploadObjectTask: task,
+	}
+	resp, err := client.manager.AskUploadObject(ctx, req, opts...)
+	if err != nil {
+		return false, err
+	}
+	return resp.GetAllow(), err
+}
+
+// CreateUploadObjectTask asks to upload object to SP manager.
+func (client *ManagerClient) CreateUploadObjectTask(ctx context.Context,
+	object *storagetypes.ObjectInfo, opts ...grpc.CallOption) error {
+	task, err := tqueuetypes.NewUploadObjectTask(object)
+	if err != nil {
+		return err
+	}
+	req := &types.CreateUploadObjectTaskRequest{
+		UploadObjectTask: task,
+	}
+	_, err = client.manager.CreateUploadObjectTask(ctx, req, opts...)
+	return err
+}
+
+// DoneUploadObjectTask notifies the manager the upload object task has been done.
+func (client *ManagerClient) DoneUploadObjectTask(ctx context.Context,
+	object *storagetypes.ObjectInfo, opts ...grpc.CallOption) error {
+	task, err := tqueuetypes.NewUploadObjectTask(object)
+	if err != nil {
+		return err
+	}
+	req := &types.DoneUploadObjectTaskRequest{
+		UploadObjectTask: task,
+	}
+	_, err = client.manager.DoneUploadObjectTask(ctx, req, opts...)
+	return err
+}
+
+// DoneReplicatePieceTask notifies the manager the replicate piece task has been done.
+func (client *ManagerClient) DoneReplicatePieceTask(ctx context.Context,
+	task *tqueuetypes.ReplicatePieceTask, opts ...grpc.CallOption) error {
+	req := &types.DoneReplicatePieceTaskRequest{
+		ReplicatePieceTask: task,
+	}
+	_, err := client.manager.DoneReplicatePieceTask(ctx, req, opts...)
+	return err
+}
+
+// DoneSealObjectTask notifies the manager the seal object task has been done.
+func (client *ManagerClient) DoneSealObjectTask(ctx context.Context,
+	task *tqueuetypes.SealObjectTask, opts ...grpc.CallOption) error {
+	req := &types.DoneSealObjectTaskRequest{
+		SealObjectTask: task,
+	}
+	_, err := client.manager.DoneSealObjectTask(ctx, req, opts...)
+	return err
+}
+
+// AskTask asks the task to execute
+func (client *ManagerClient) AskTask(ctx context.Context,
+	rclimit rcmgr.Limit, opts ...grpc.CallOption) (*types.AskTaskResponse, error) {
+	req := &types.AskTaskRequest{
+		Limit: types.NewLimits(rclimit),
+	}
+	resp, err := client.manager.AskTask(ctx, req, opts...)
+	return resp, err
+}
+
+// DoneGCObjectTask notifies the manager the gc object task has been done.
+func (client *ManagerClient) DoneGCObjectTask(ctx context.Context,
+	task *tqueuetypes.GCObjectTask, opts ...grpc.CallOption) error {
+	req := &types.DoneGCObjectTaskRequest{
+		GcObjectTask: task,
+	}
+	_, err := client.manager.DoneGCObjectTask(ctx, req, opts...)
+	return err
+}
+
+// ReportGCObjectProcess notifies the manager the gc object task process.
+func (client *ManagerClient) ReportGCObjectProcess(ctx context.Context,
+	task *tqueuetypes.GCObjectTask, opts ...grpc.CallOption) (bool, error) {
+	req := &types.ReportGCObjectProcessRequest{
+		GcObjectTask: task,
+	}
+	resp, err := client.manager.ReportGCObjectProcess(ctx, req, opts...)
+	if err != nil {
+		return false, err
+	}
+	return resp.GetCancel(), nil
+}

--- a/service/manager/client/manager_client.go
+++ b/service/manager/client/manager_client.go
@@ -14,16 +14,16 @@ import (
 	utilgrpc "github.com/bnb-chain/greenfield-storage-provider/util/grpc"
 )
 
-// ManagerClient is a challenge gRPC service client wrapper
+// ManagerClient is a manager gRPC service client wrapper
 type ManagerClient struct {
 	address string
-	manager types.ManagerServiceClient
 	conn    *grpc.ClientConn
+	manager types.ManagerServiceClient
 }
 
 const managerRPCServiceName = "service.manager.types.ManagerService"
 
-// NewManagerClient return a manager client instance
+// NewManagerClient returns a manager client instance
 func NewManagerClient(address string) (*ManagerClient, error) {
 	options := utilgrpc.GetDefaultClientOptions()
 	retryOption, err := utilgrpc.GetDefaultGRPCRetryPolicy(managerRPCServiceName)
@@ -138,13 +138,13 @@ func (client *ManagerClient) DoneGCObjectTask(ctx context.Context,
 	return err
 }
 
-// ReportGCObjectProcess notifies the manager the gc object task process.
-func (client *ManagerClient) ReportGCObjectProcess(ctx context.Context,
+// ReportGCObjectProgress notifies the manager the gc object task process.
+func (client *ManagerClient) ReportGCObjectProgress(ctx context.Context,
 	task *tqueuetypes.GCObjectTask, opts ...grpc.CallOption) (bool, error) {
-	req := &types.ReportGCObjectProcessRequest{
+	req := &types.ReportGCObjectProgressRequest{
 		GcObjectTask: task,
 	}
-	resp, err := client.manager.ReportGCObjectProcess(ctx, req, opts...)
+	resp, err := client.manager.ReportGCObjectProgress(ctx, req, opts...)
 	if err != nil {
 		return false, err
 	}

--- a/service/manager/manager.go
+++ b/service/manager/manager.go
@@ -16,14 +16,14 @@ import (
 var _ lifecycle.Service = &Manager{}
 
 var (
-	// RefreshSPInfoAndStorageParamsTimer defines the period of refresh sp info and storage params
+	// RefreshSPInfoAndStorageParamsTimer defines the period of refresh sp info and storage params.
 	RefreshSPInfoAndStorageParamsTimer = 5 * 60
-	// GCManagerPriorityQueueTimer defines the period of gc manager priority queue
+	// GCManagerPriorityQueueTimer defines the period of gc manager priority queue.
 	GCManagerPriorityQueueTimer = 60
 )
 
 // Manager module is responsible for implementing internal management functions.
-// Currently, it supports periodic update of sp info list and storage params information in spdb.
+// Currently, it supports periodic update of sp info list and storage params information in sp db.
 // TODO::support gc and configuration management, etc.
 type Manager struct {
 	config  *ManagerConfig
@@ -85,7 +85,7 @@ func (m *Manager) eventLoop() {
 		case <-refreshSPInfoAndStorageParamsTicker.C:
 			go m.refreshSPInfoAndStorageParams()
 		case <-gcMPQueueTicker.C:
-			go m.pqueue.GCMQueueTask()
+			go m.pqueue.GCMPQueueTask()
 		case <-m.stopCh:
 			return
 		}

--- a/service/manager/manager_config.go
+++ b/service/manager/manager_config.go
@@ -10,4 +10,9 @@ type ManagerConfig struct {
 	SpOperatorAddress string
 	ChainConfig       *gnfd.GreenfieldChainConfig
 	SpDBConfig        *config.SQLDBConfig
+	UploadParallel    int
+	UploadQueueCap    int
+	ReplicateQueueCap int
+	SealQueueCap      int
+	GCObjectQueueCap  int
 }

--- a/service/manager/manager_config.go
+++ b/service/manager/manager_config.go
@@ -7,6 +7,7 @@ import (
 
 // ManagerConfig defines manager service config
 type ManagerConfig struct {
+	GRPCAddress         string
 	SpOperatorAddress   string
 	ChainConfig         *gnfd.GreenfieldChainConfig
 	SpDBConfig          *config.SQLDBConfig
@@ -15,4 +16,13 @@ type ManagerConfig struct {
 	ReplicateQueueCap   int
 	SealQueueCap        int
 	GCObjectQueueCap    int
+}
+
+// DefaultManagerConfig is the default config.
+var DefaultManagerConfig = &ManagerConfig{
+	MaxUploadConcurrent: 10000,
+	UploadQueueCap:      5000,
+	ReplicateQueueCap:   5000,
+	SealQueueCap:        5000,
+	GCObjectQueueCap:    5000,
 }

--- a/service/manager/manager_config.go
+++ b/service/manager/manager_config.go
@@ -7,12 +7,12 @@ import (
 
 // ManagerConfig defines manager service config
 type ManagerConfig struct {
-	SpOperatorAddress string
-	ChainConfig       *gnfd.GreenfieldChainConfig
-	SpDBConfig        *config.SQLDBConfig
-	UploadParallel    int
-	UploadQueueCap    int
-	ReplicateQueueCap int
-	SealQueueCap      int
-	GCObjectQueueCap  int
+	SpOperatorAddress   string
+	ChainConfig         *gnfd.GreenfieldChainConfig
+	SpDBConfig          *config.SQLDBConfig
+	MaxUploadConcurrent int // include upload, replicate and seal.
+	UploadQueueCap      int
+	ReplicateQueueCap   int
+	SealQueueCap        int
+	GCObjectQueueCap    int
 }

--- a/service/manager/manager_pqueue.go
+++ b/service/manager/manager_pqueue.go
@@ -46,7 +46,7 @@ func NewMPQueue(chain *greenfield.Greenfield, uploadQueueSize, replicateQueueSiz
 	}
 	uploadStrategy := queue.NewStrategy()
 	uploadStrategy.SetCollectionCallback(queue.DefaultGCTasksByTimeout)
-	uploadQueue := queue.NewTaskQueue(SubQueueUploadObject, uploadQueueSize, uploadStrategy, false)
+	uploadQueue := queue.NewTaskQueue(SubQueueUploadObject, uploadQueueSize, uploadStrategy, true)
 
 	replicateStrategy := queue.NewStrategy()
 	replicateStrategy.SetCollectionCallback(queue.DefaultGCTasksByRetry)
@@ -60,7 +60,7 @@ func NewMPQueue(chain *greenfield.Greenfield, uploadQueueSize, replicateQueueSiz
 
 	gcObjectStrategy := queue.NewStrategy()
 	gcObjectStrategy.SetCollectionCallback(mpq.GCObjectQueueCallBack)
-	gcObjectQueue := queue.NewTaskQueue(SubQueueGCObject, gcObjectQueueSize, gcObjectStrategy, true)
+	gcObjectQueue := queue.NewTaskQueue(SubQueueGCObject, gcObjectQueueSize, gcObjectStrategy, false)
 
 	subQueues := map[tqueue.TPriority]tqueue.TQueueWithLimit{
 		tqueuetypes.GetTaskPriorityMap().GetPriority(tqueue.TypeTaskUploadObject):   uploadQueue,
@@ -72,6 +72,8 @@ func NewMPQueue(chain *greenfield.Greenfield, uploadQueueSize, replicateQueueSiz
 	mstrategy := queue.NewStrategy()
 	mstrategy.SetPickUpCallback(queue.DefaultPickUpTaskByPriority)
 	mpq.pqueue = queue.NewTaskPriorityQueue(PriorityQueueManager, subQueues, mstrategy, true)
+	log.Infow("succeed to new manager pqueue", "upload_queue_size", uploadQueueSize,
+		"replicate_queue_size", replicateQueueSize, "seal_queue_size", sealQueueSize, "gc_queue_size", gcObjectQueueSize)
 	return mpq
 }
 

--- a/service/manager/manager_pqueue.go
+++ b/service/manager/manager_pqueue.go
@@ -1,0 +1,149 @@
+package manager
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/greenfield"
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/rcmgr"
+	tqueue "github.com/bnb-chain/greenfield-storage-provider/pkg/taskqueue"
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/taskqueue/queue"
+	tqueuetypes "github.com/bnb-chain/greenfield-storage-provider/pkg/taskqueue/types"
+)
+
+const (
+	PriorityQueueManage    = "priority-queue-manager"
+	SubQueueUpload         = "sub-queue-upload"
+	SubQueueReplicatePiece = "sub-queue-replicate-piece"
+	SubQueueSealObject     = "sub-queue-seal-object"
+	SubQueueGCObject       = "sub-queue-gc-object"
+
+	GCBlockDistance uint64 = 1800
+	GCBlockInternal uint64 = 1000
+)
+
+type MPQueue struct {
+	pqueue        tqueue.TPriorityQueueWithLimit
+	chain         *greenfield.Greenfield
+	gcBlockNumber uint64
+	gcRunning     atomic.Int32
+	mux           sync.RWMutex
+}
+
+func NewMPQueue(chain *greenfield.Greenfield, uploadQueueSize, replicateQueueSize, sealQueueSize, gcObjectQueueSize int) *MPQueue {
+	mpq := &MPQueue{
+		chain: chain,
+	}
+	uploadStrategy := queue.NewStrategy()
+	uploadStrategy.SetCollectionCallback(queue.DefaultGCTasksByTimeout)
+	uploadQueue := queue.NewTaskQueue(SubQueueUpload, uploadQueueSize, uploadStrategy, false)
+
+	replicateStrategy := queue.NewStrategy()
+	replicateStrategy.SetCollectionCallback(queue.DefaultGCTasksByRetry)
+	replicateStrategy.SetPickUpFilterCallback(queue.DefaultPickUpFilterTaskByRetry)
+	replicateQueue := queue.NewTaskQueue(SubQueueReplicatePiece, replicateQueueSize, replicateStrategy, true)
+
+	sealStrategy := queue.NewStrategy()
+	sealStrategy.SetCollectionCallback(queue.DefaultGCTasksByRetry)
+	replicateStrategy.SetPickUpFilterCallback(queue.DefaultPickUpFilterTaskByRetry)
+	sealQueue := queue.NewTaskQueue(SubQueueSealObject, sealQueueSize, sealStrategy, true)
+
+	gcObjectStrategy := queue.NewStrategy()
+	gcObjectStrategy.SetCollectionCallback(mpq.GCObjectQueueCallBack)
+	gcObjectQueue := queue.NewTaskQueue(SubQueueGCObject, gcObjectQueueSize, gcObjectStrategy, true)
+
+	subQueues := map[tqueue.TPriority]tqueue.TQueueWithLimit{
+		tqueuetypes.GetTaskPriorityMap().GetPriority(tqueue.TypeTaskUpload):         uploadQueue,
+		tqueuetypes.GetTaskPriorityMap().GetPriority(tqueue.TypeTaskReplicatePiece): replicateQueue,
+		tqueuetypes.GetTaskPriorityMap().GetPriority(tqueue.TypeTaskSealObject):     sealQueue,
+		tqueuetypes.GetTaskPriorityMap().GetPriority(tqueue.TypeTaskGCObject):       gcObjectQueue,
+	}
+
+	mstrategy := queue.NewStrategy()
+	mstrategy.SetPickUpCallback(queue.DefaultPickUpTaskByPriority)
+	pqueue := queue.NewTaskPriorityQueue(PriorityQueueManage, subQueues, mstrategy, true)
+	mpq.pqueue = pqueue
+	return mpq
+}
+
+func (q *MPQueue) HasTask(key tqueue.TKey) bool {
+	return q.pqueue.Has(key)
+}
+
+func (q *MPQueue) PopTask(key tqueue.TKey) tqueue.Task {
+	return q.pqueue.PopByKey(key)
+}
+
+func (q *MPQueue) PopTaskByLimit(limit rcmgr.Limit) tqueue.Task {
+	return q.pqueue.PopByLimit(limit)
+}
+
+func (q *MPQueue) PushTask(task tqueue.Task) error {
+	return q.pqueue.Push(task)
+}
+
+func (q *MPQueue) PopPushTask(task tqueue.Task) error {
+	return q.pqueue.PopPush(task)
+}
+
+func (q *MPQueue) GCMQueueTask() {
+	if q.gcRunning.Swap(1) == 1 {
+		log.Debugw("manager priority queue gc is running")
+		return
+	}
+	defer q.gcRunning.Swap(0)
+	q.pqueue.RunCollection()
+}
+
+func (q *MPQueue) GetUploadingTasksCount() int {
+	return q.GetUploadPrimaryTasksCount() + q.GetReplicatePieceTasksCount() + q.GetSealObjectTasksCount()
+}
+
+func (q *MPQueue) GetUploadPrimaryTasksCount() int {
+	prio := tqueuetypes.GetTaskPriorityMap().GetPriority(tqueue.TypeTaskUpload)
+	return q.pqueue.SubQueueLen(prio)
+}
+
+func (q *MPQueue) GetReplicatePieceTasksCount() int {
+	prio := tqueuetypes.GetTaskPriorityMap().GetPriority(tqueue.TypeTaskReplicatePiece)
+	return q.pqueue.SubQueueLen(prio)
+}
+
+func (q *MPQueue) GetSealObjectTasksCount() int {
+	prio := tqueuetypes.GetTaskPriorityMap().GetPriority(tqueue.TypeTaskSealObject)
+	return q.pqueue.SubQueueLen(prio)
+}
+
+func (q *MPQueue) GCObjectQueueCallBack(queue tqueue.TQueueOnStrategy, keys []tqueue.TKey) {
+	for _, key := range keys {
+		if queue.Expired(key) {
+			task := queue.PopByKey(key)
+			if task == nil {
+				continue
+			}
+			task.SetCreateTime(time.Now().Unix())
+			queue.Push(task)
+		}
+	}
+	if queue.Len() < queue.Cap() {
+		height, err := q.chain.GetCurrentHeight(context.Background())
+		if err != nil {
+			return
+		}
+		for atomic.LoadUint64(&q.gcBlockNumber)+GCBlockInternal <= height-GCBlockDistance {
+			task, err := tqueuetypes.NewGCObjectTask(atomic.LoadUint64(&q.gcBlockNumber)+1,
+				atomic.LoadUint64(&q.gcBlockNumber)+GCBlockInternal)
+			if err != nil {
+				break
+			}
+			err = queue.Push(task)
+			if err != nil {
+				break
+			}
+			atomic.AddUint64(&q.gcBlockNumber, GCBlockInternal)
+		}
+	}
+}

--- a/service/manager/manager_service.go
+++ b/service/manager/manager_service.go
@@ -1,0 +1,223 @@
+package manager
+
+import (
+	"context"
+	"time"
+
+	merrors "github.com/bnb-chain/greenfield-storage-provider/model/errors"
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
+	tqueuetypes "github.com/bnb-chain/greenfield-storage-provider/pkg/taskqueue/types"
+	"github.com/bnb-chain/greenfield-storage-provider/service/manager/types"
+)
+
+var _ types.ManagerServiceServer = &Manager{}
+
+// AskUploadObject asks to create object to SP manager.
+func (m *Manager) AskUploadObject(ctx context.Context, req *types.AskUploadObjectRequest) (
+	*types.AskUploadObjectResponse, error) {
+	task := req.GetUploadObjectTask()
+	if task == nil {
+		return nil, merrors.ErrDanglingTaskPointer
+	}
+	ctx = log.WithValue(ctx, "object_id", string(task.Key()))
+	resp := &types.AskUploadObjectResponse{}
+	if m.pqueue.HasTask(task.Key()) {
+		resp.Allow = false
+		resp.RefuseReason = merrors.ErrRepeatedTask.Error()
+		return resp, merrors.ErrRepeatedTask
+	}
+	uploading := m.pqueue.GetUploadingTasksCount()
+	if uploading >= m.config.UploadParallel {
+		resp.Allow = false
+		resp.RefuseReason = merrors.ErrExceedUploadParallel.Error()
+		return resp, merrors.ErrRepeatedTask
+	} else {
+		resp.Allow = true
+	}
+	return resp, nil
+}
+
+// CreateUploadObjectTask asks to upload object to SP manager.
+func (m *Manager) CreateUploadObjectTask(ctx context.Context, req *types.CreateUploadObjectTaskRequest) (
+	*types.CreateUploadObjectTaskResponse, error) {
+	resp := &types.CreateUploadObjectTaskResponse{}
+	task := req.GetUploadObjectTask()
+	if task == nil {
+		return resp, merrors.ErrDanglingTaskPointer
+	}
+	ctx = log.WithValue(ctx, "object_id", string(task.Key()))
+	if m.pqueue.HasTask(task.Key()) {
+		oldTask := m.pqueue.PopTask(task.Key())
+		if oldTask != nil && !oldTask.Expired() {
+			log.CtxErrorw(ctx, "failed to create upload object task, has repeated task")
+			m.pqueue.PushTask(oldTask)
+			return resp, merrors.ErrRepeatedTask
+		}
+	}
+	err := m.pqueue.PushTask(task)
+	if err != nil {
+		log.CtxErrorw(ctx, "failed to push upload object task to queue", "error", err)
+		return resp, err
+	}
+	log.CtxDebugw(ctx, "succeed to push upload object task to queue")
+	return resp, err
+}
+
+// DoneUploadObjectTask notifies the manager the upload object task has been done.
+func (m *Manager) DoneUploadObjectTask(ctx context.Context, req *types.DoneUploadObjectTaskRequest) (
+	*types.DoneUploadObjectTaskResponse, error) {
+	resp := &types.DoneUploadObjectTaskResponse{}
+	task := req.GetUploadObjectTask()
+	if task == nil {
+		return resp, merrors.ErrDanglingTaskPointer
+	}
+	ctx = log.WithValue(ctx, "object_id", string(task.Key()))
+	m.pqueue.PopTask(task.Key())
+	replicateTask, err := tqueuetypes.NewReplicatePieceTask(task.GetObject())
+	if err != nil {
+		log.CtxErrorw(ctx, "failed to make replicate piece task", "error", err)
+		return resp, err
+	}
+	err = m.pqueue.PushTask(replicateTask)
+	if err != nil {
+		log.CtxErrorw(ctx, "failed to push replicate task to queue", "error", err)
+		return resp, err
+	}
+	log.CtxDebugw(ctx, "succeed to push replicate task to queue")
+	return resp, err
+}
+
+// DoneReplicatePieceTask notifies the manager the replicate piece task has been done.
+func (m *Manager) DoneReplicatePieceTask(ctx context.Context, req *types.DoneReplicatePieceTaskRequest) (
+	*types.DoneReplicatePieceTaskResponse, error) {
+	resp := &types.DoneReplicatePieceTaskResponse{}
+	task := req.GetReplicatePieceTask()
+	if task == nil {
+		return resp, merrors.ErrDanglingTaskPointer
+	}
+	ctx = log.WithValue(ctx, "object_id", string(task.Key()))
+	if task.Error() != nil {
+		log.CtxErrorw(ctx, "failed execute replicate piece task", "error", task.Error())
+		if task.RetryExceed() {
+			m.pqueue.PopTask(task.Key())
+			log.CtxErrorw(ctx, "cancel replicate piece task", "retry", task.GetRetry(),
+				"retry_limit", task.GetRetryLimit(), "time_out", task.GetTimeout())
+			return resp, nil
+		}
+		task.SetUpdateTime(time.Now().Unix())
+		m.pqueue.PopPushTask(task)
+		return resp, nil
+	}
+	m.pqueue.PopTask(task.Key())
+	sealTask, err := tqueuetypes.NewSealObjectTask(task.GetObject())
+	if err != nil {
+		log.CtxErrorw(ctx, "failed to make seal task", "error", err)
+		return resp, err
+	}
+	err = m.pqueue.PushTask(sealTask)
+	if err != nil {
+		log.CtxErrorw(ctx, "failed to push seal object task to queue", "error", err)
+		return resp, err
+	}
+	log.CtxDebugw(ctx, "succeed to push seal object task to queue")
+	return resp, err
+}
+
+// DoneSealObjectTask notifies the manager the seal object task has been done.
+func (m *Manager) DoneSealObjectTask(ctx context.Context, req *types.DoneSealObjectTaskRequest) (
+	*types.DoneSealObjectTaskResponse, error) {
+	resp := &types.DoneSealObjectTaskResponse{}
+	task := req.GetSealObjectTask()
+	if task == nil {
+		return resp, merrors.ErrDanglingTaskPointer
+	}
+	ctx = log.WithValue(ctx, "object_id", string(task.Key()))
+	if task.Error() != nil {
+		log.CtxErrorw(ctx, "failed execute seal object task", "error", task.Error())
+		if task.RetryExceed() {
+			m.pqueue.PopTask(task.Key())
+			log.CtxErrorw(ctx, "cancel seal object task", "retry", task.GetRetry(),
+				"retry_limit", task.GetRetryLimit(), "time_out", task.GetTimeout())
+			return resp, nil
+		}
+		task.SetUpdateTime(time.Now().Unix())
+		m.pqueue.PopPushTask(task)
+		return resp, nil
+	}
+	m.pqueue.PopTask(task.Key())
+	log.CtxDebugw(ctx, "succeed to seal object on chain")
+	return resp, nil
+}
+
+// AskTask asks the task to execute
+func (m *Manager) AskTask(ctx context.Context, req *types.AskTaskRequest) (*types.AskTaskResponse, error) {
+	resp := &types.AskTaskResponse{}
+	limit := req.GetLimit().TransferRcmgrLimits()
+	task := m.pqueue.PopTaskByLimit(limit)
+	if task == nil {
+		return resp, nil
+	}
+	defer func() {
+		task.IncRetry()
+		task.SetUpdateTime(time.Now().Unix())
+		m.pqueue.PushTask(task)
+	}()
+	switch t := (task).(type) {
+	case *tqueuetypes.ReplicatePieceTask:
+		resp.Task = &types.AskTaskResponse_ReplicatePieceTask{
+			ReplicatePieceTask: t,
+		}
+	case *tqueuetypes.SealObjectTask:
+		resp.Task = &types.AskTaskResponse_SealObjectTask{
+			SealObjectTask: t,
+		}
+	case *tqueuetypes.GCObjectTask:
+		resp.Task = &types.AskTaskResponse_GcObjectTask{
+			GcObjectTask: t,
+		}
+	default:
+		log.CtxErrorw(ctx, "task node does not support task type", "task_type", task.Type())
+		return resp, merrors.ErrUnsupportedDispatchTaskType
+	}
+	resp.HasTask = true
+	return resp, nil
+}
+
+// DoneGCObjectTask notifies the manager the gc object task has been done.
+func (m *Manager) DoneGCObjectTask(ctx context.Context, req *types.DoneGCObjectTaskRequest) (
+	*types.DoneGCObjectTaskResponse, error) {
+	resp := &types.DoneGCObjectTaskResponse{}
+	task := req.GetGcObjectTask()
+	if task == nil {
+		return resp, merrors.ErrDanglingTaskPointer
+	}
+	ctx = log.WithValue(ctx, "object_id", string(task.Key()))
+	if task.Error() != nil {
+		log.CtxErrorw(ctx, "failed execute gc object task", "error", task.Error())
+		task.SetUpdateTime(time.Now().Unix())
+		m.pqueue.PopPushTask(task)
+		return resp, nil
+	}
+	m.pqueue.PopTask(task.Key())
+	log.CtxInfow(ctx, "succeed to run gc object")
+	return resp, nil
+}
+
+// ReportGCObjectProcess notifies the manager the gc object task process.
+func (m *Manager) ReportGCObjectProcess(ctx context.Context, req *types.ReportGCObjectProcessRequest) (
+	*types.ReportGCObjectProcessResponse, error) {
+	resp := &types.ReportGCObjectProcessResponse{}
+	task := req.GetGcObjectTask()
+	if task == nil {
+		return resp, merrors.ErrDanglingTaskPointer
+	}
+	ctx = log.WithValue(ctx, "object_id", string(task.Key()))
+	if !m.pqueue.HasTask(task.Key()) {
+		log.CtxErrorw(ctx, "failed to report gc object process", "error", merrors.ErrTaskCanceled)
+		resp.Cancel = true
+		return resp, merrors.ErrTaskCanceled
+	}
+	task.SetUpdateTime(time.Now().Unix())
+	m.pqueue.PopPushTask(task)
+	return resp, nil
+}

--- a/service/manager/manager_service.go
+++ b/service/manager/manager_service.go
@@ -72,7 +72,7 @@ func (m *Manager) DoneUploadObjectTask(ctx context.Context, req *types.DoneUploa
 	}
 	ctx = log.WithValue(ctx, "object_id", string(task.Key()))
 	m.pqueue.PopTask(task.Key())
-	replicateTask, err := tqueuetypes.NewReplicatePieceTask(task.GetObjectInfo())
+	replicateTask, err := tqueuetypes.NewReplicatePieceTask(task.GetObjectInfo(), nil)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to make replicate piece task", "error", err)
 		return resp, err
@@ -108,7 +108,7 @@ func (m *Manager) DoneReplicatePieceTask(ctx context.Context, req *types.DoneRep
 		return resp, nil
 	}
 	m.pqueue.PopTask(task.Key())
-	sealTask, err := tqueuetypes.NewSealObjectTask(task.GetObjectInfo())
+	sealTask, err := tqueuetypes.NewSealObjectTask(task.GetObjectInfo(), task.GetSealObject())
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to make seal task", "error", err)
 		return resp, err

--- a/service/manager/types/limit.go
+++ b/service/manager/types/limit.go
@@ -1,0 +1,24 @@
+package types
+
+import "github.com/bnb-chain/greenfield-storage-provider/pkg/rcmgr"
+
+func NewLimits(rcLimit rcmgr.Limit) *Limit {
+	m := &Limit{}
+	m.Memory = rcLimit.GetMemoryLimit()
+	m.HighPriorityTask = int64(rcLimit.GetTaskLimit(rcmgr.ReserveTaskPriorityHigh))
+	m.MediumPriorityTask = int64(rcLimit.GetTaskLimit(rcmgr.ReserveTaskPriorityMedium))
+	m.LowPriorityTask = int64(rcLimit.GetTaskLimit(rcmgr.ReserveTaskPriorityLow))
+	return m
+}
+
+func (m *Limit) TransferRcmgrLimits() rcmgr.Limit {
+	if m == nil {
+		return rcmgr.InfinitesimalLimit()
+	}
+	rcLimits := rcmgr.InfinitesimalLimit().(*rcmgr.BaseLimit)
+	rcLimits.Memory = m.GetMemory()
+	rcLimits.TasksHighPriority = int(m.GetHighPriorityTask())
+	rcLimits.TasksMediumPriority = int(m.GetMediumPriorityTask())
+	rcLimits.TasksLowPriority = int(m.GetLowPriorityTask())
+	return rcLimits
+}

--- a/service/tasknode/seal_object_task.go
+++ b/service/tasknode/seal_object_task.go
@@ -1,0 +1,64 @@
+package tasknode
+
+import (
+	"context"
+
+	merrors "github.com/bnb-chain/greenfield-storage-provider/model/errors"
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
+	servicetypes "github.com/bnb-chain/greenfield-storage-provider/service/types"
+	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
+)
+
+// sealObjectTask represents the background object seal task.
+type sealObjectTask struct {
+	ctx            context.Context
+	taskNode       *TaskNode
+	objectInfo     *storagetypes.ObjectInfo
+	sealObjectInfo *storagetypes.MsgSealObject
+}
+
+// newSealObjectTask returns a sealObjectTask instance.
+func newSealObjectTask(ctx context.Context, task *TaskNode, objectInfo *storagetypes.ObjectInfo, sealObjectInfo *storagetypes.MsgSealObject) (*sealObjectTask, error) {
+	if ctx == nil || task == nil || objectInfo == nil || sealObjectInfo == nil {
+		return nil, merrors.ErrInvalidParams
+	}
+	return &sealObjectTask{
+		ctx:            ctx,
+		taskNode:       task,
+		objectInfo:     objectInfo,
+		sealObjectInfo: sealObjectInfo,
+	}, nil
+}
+
+// init is used to synchronize the resources which is needed to initialize the task.
+func (t *sealObjectTask) init() error {
+	return nil
+}
+
+// updateTaskState is used to update task state.
+func (t *sealObjectTask) updateTaskState(state servicetypes.JobState) error {
+	return t.taskNode.spDB.UpdateJobState(t.objectInfo.Id.Uint64(), state)
+}
+
+// execute is used to start the task, and waitCh is used to wait runtime initialization.
+func (t *sealObjectTask) execute(waitCh chan error) {
+	// TODO: refine it
+	waitCh <- nil
+	t.updateTaskState(servicetypes.JobState_JOB_STATE_SIGN_OBJECT_DOING)
+	_, err := t.taskNode.signer.SealObjectOnChain(context.Background(), t.sealObjectInfo)
+	if err != nil {
+		t.updateTaskState(servicetypes.JobState_JOB_STATE_SIGN_OBJECT_ERROR)
+		log.CtxErrorw(t.ctx, "failed to sign object by signer", "error", err)
+		return
+	}
+	t.updateTaskState(servicetypes.JobState_JOB_STATE_SEAL_OBJECT_DOING)
+	err = t.taskNode.chain.ListenObjectSeal(context.Background(), t.objectInfo.GetBucketName(),
+		t.objectInfo.GetObjectName(), 10)
+	if err != nil {
+		t.updateTaskState(servicetypes.JobState_JOB_STATE_SEAL_OBJECT_ERROR)
+		log.CtxErrorw(t.ctx, "failed to seal object on chain", "error", err)
+		return
+	}
+	t.updateTaskState(servicetypes.JobState_JOB_STATE_SEAL_OBJECT_DONE)
+	t.taskNode.manager.DoneSealObjectTask(context.Background(), t.objectInfo)
+}

--- a/service/tasknode/task_node_config.go
+++ b/service/tasknode/task_node_config.go
@@ -8,11 +8,12 @@ import (
 
 // TaskNodeConfig defines TaskNode service config
 type TaskNodeConfig struct {
-	SpOperatorAddress string
-	GRPCAddress       string
-	SignerGrpcAddress string
-	P2PGrpcAddress    string
-	SpDBConfig        *config.SQLDBConfig
-	PieceStoreConfig  *storage.PieceStoreConfig
-	ChainConfig       *greenfield.GreenfieldChainConfig
+	SpOperatorAddress  string
+	GRPCAddress        string
+	SignerGrpcAddress  string
+	P2PGrpcAddress     string
+	ManagerGrpcAddress string
+	SpDBConfig         *config.SQLDBConfig
+	PieceStoreConfig   *storage.PieceStoreConfig
+	ChainConfig        *greenfield.GreenfieldChainConfig
 }

--- a/service/uploader/uploader.go
+++ b/service/uploader/uploader.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/lifecycle"
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/metrics"
+	managerclient "github.com/bnb-chain/greenfield-storage-provider/service/manager/client"
 	signerclient "github.com/bnb-chain/greenfield-storage-provider/service/signer/client"
 	tasknodeclient "github.com/bnb-chain/greenfield-storage-provider/service/tasknode/client"
 	"github.com/bnb-chain/greenfield-storage-provider/service/uploader/types"
@@ -31,6 +32,7 @@ type Uploader struct {
 	pieceStore *psclient.StoreClient
 	signer     *signerclient.SignerClient
 	taskNode   *tasknodeclient.TaskNodeClient
+	manager    *managerclient.ManagerClient
 	grpcServer *grpc.Server
 }
 
@@ -56,6 +58,10 @@ func NewUploaderService(cfg *UploaderConfig) (*Uploader, error) {
 	}
 	if uploader.taskNode, err = tasknodeclient.NewTaskNodeClient(cfg.TaskNodeGrpcAddress); err != nil {
 		log.Errorw("failed to create task node client", "error", err)
+		return nil, err
+	}
+	if uploader.manager, err = managerclient.NewManagerClient(cfg.ManagerGrpcAddress); err != nil {
+		log.Errorw("failed to create manager client", "error", err)
 		return nil, err
 	}
 	if uploader.pieceStore, err = psclient.NewStoreClient(cfg.PieceStoreConfig); err != nil {

--- a/service/uploader/uploader_config.go
+++ b/service/uploader/uploader_config.go
@@ -9,7 +9,8 @@ import (
 type UploaderConfig struct {
 	GRPCAddress         string
 	SignerGrpcAddress   string
-	TaskNodeGrpcAddress string
+	TaskNodeGrpcAddress string // TODO: will be deleted.
+	ManagerGrpcAddress  string
 	SpDBConfig          *config.SQLDBConfig
 	PieceStoreConfig    *storage.PieceStoreConfig
 }

--- a/service/uploader/uploader_service.go
+++ b/service/uploader/uploader_service.go
@@ -46,15 +46,19 @@ func (uploader *Uploader) PutObject(stream types.UploaderService_PutObjectServer
 			return
 		}
 		// TODO: report upload state
+		log.CtxDebugw(ctx, "begin to done upload object task")
 		if err = uploader.manager.DoneUploadObjectTask(ctx, objectInfo); err != nil {
 			log.CtxErrorw(ctx, "failed to done upload object task", "error", err)
 			return
 		}
-		if err = uploader.taskNode.ReplicateObject(ctx, objectInfo); err != nil {
-			log.CtxErrorw(ctx, "failed to notify task node to replicate object", "error", err)
-			uploader.spDB.UpdateJobState(objectID, servicetypes.JobState_JOB_STATE_REPLICATE_OBJECT_ERROR)
-			return
-		}
+		log.CtxDebugw(ctx, "begin to done upload object task")
+		/*
+			if err = uploader.taskNode.ReplicateObject(ctx, objectInfo); err != nil {
+				log.CtxErrorw(ctx, "failed to notify task node to replicate object", "error", err)
+				uploader.spDB.UpdateJobState(objectID, servicetypes.JobState_JOB_STATE_REPLICATE_OBJECT_ERROR)
+				return
+			}
+		*/
 		err = stream.SendAndClose(resp)
 		pstream.Close()
 		log.CtxInfow(ctx, "succeed to put object", "error", err)

--- a/service/uploader/uploader_service.go
+++ b/service/uploader/uploader_service.go
@@ -51,7 +51,7 @@ func (uploader *Uploader) PutObject(stream types.UploaderService_PutObjectServer
 			log.CtxErrorw(ctx, "failed to done upload object task", "error", err)
 			return
 		}
-		log.CtxDebugw(ctx, "begin to done upload object task")
+		log.CtxDebugw(ctx, "finish to done upload object task")
 		/*
 			if err = uploader.taskNode.ReplicateObject(ctx, objectInfo); err != nil {
 				log.CtxErrorw(ctx, "failed to notify task node to replicate object", "error", err)

--- a/test/e2e/localup_env/greenfield_sp_env/sp0/config.toml
+++ b/test/e2e/localup_env/greenfield_sp_env/sp0/config.toml
@@ -12,6 +12,7 @@ receiver = "localhost:10533"
 signer = "localhost:10633"
 tasknode = "localhost:10433"
 uploader = "localhost:10133"
+manager = "localhost:10935"
 
 [ListenAddress]
 auth = "localhost:10033"
@@ -24,6 +25,7 @@ receiver = "localhost:10533"
 signer = "localhost:10633"
 tasknode = "localhost:10433"
 uploader = "localhost:10133"
+manager = "localhost:10935"
 
 [SpDBConfig]
 User = "root"

--- a/test/e2e/localup_env/greenfield_sp_env/sp1/config.toml
+++ b/test/e2e/localup_env/greenfield_sp_env/sp1/config.toml
@@ -12,6 +12,7 @@ receiver = "localhost:11533"
 signer = "localhost:11633"
 tasknode = "localhost:11433"
 uploader = "localhost:11133"
+manager = "localhost:11935"
 
 [ListenAddress]
 auth = "localhost:11033"
@@ -24,6 +25,8 @@ receiver = "localhost:11533"
 signer = "localhost:11633"
 tasknode = "localhost:11433"
 uploader = "localhost:11133"
+manager = "localhost:11935"
+
 
 [SpDBConfig]
 User = "root"

--- a/test/e2e/localup_env/greenfield_sp_env/sp2/config.toml
+++ b/test/e2e/localup_env/greenfield_sp_env/sp2/config.toml
@@ -12,6 +12,8 @@ receiver = "localhost:12533"
 signer = "localhost:12633"
 tasknode = "localhost:12433"
 uploader = "localhost:12133"
+manager = "localhost:12935"
+
 
 [ListenAddress]
 auth = "localhost:12033"
@@ -24,6 +26,8 @@ receiver = "localhost:12533"
 signer = "localhost:12633"
 tasknode = "localhost:12433"
 uploader = "localhost:12133"
+manager = "localhost:12935"
+
 
 [SpDBConfig]
 User = "root"

--- a/test/e2e/localup_env/greenfield_sp_env/sp3/config.toml
+++ b/test/e2e/localup_env/greenfield_sp_env/sp3/config.toml
@@ -12,6 +12,8 @@ receiver = "localhost:13533"
 signer = "localhost:13633"
 tasknode = "localhost:13433"
 uploader = "localhost:13133"
+manager = "localhost:13935"
+
 
 [ListenAddress]
 auth = "localhost:13033"
@@ -24,6 +26,8 @@ receiver = "localhost:13533"
 signer = "localhost:13633"
 tasknode = "localhost:13433"
 uploader = "localhost:13133"
+manager = "localhost:13935"
+
 
 [SpDBConfig]
 User = "root"

--- a/test/e2e/localup_env/greenfield_sp_env/sp4/config.toml
+++ b/test/e2e/localup_env/greenfield_sp_env/sp4/config.toml
@@ -12,6 +12,8 @@ receiver = "localhost:14533"
 signer = "localhost:14633"
 tasknode = "localhost:14433"
 uploader = "localhost:14133"
+manager = "localhost:14935"
+
 
 [ListenAddress]
 auth = "localhost:14033"
@@ -24,6 +26,8 @@ receiver = "localhost:14533"
 signer = "localhost:14633"
 tasknode = "localhost:14433"
 uploader = "localhost:14133"
+manager = "localhost:14935"
+
 
 [SpDBConfig]
 User = "root"

--- a/test/e2e/localup_env/greenfield_sp_env/sp5/config.toml
+++ b/test/e2e/localup_env/greenfield_sp_env/sp5/config.toml
@@ -12,6 +12,8 @@ receiver = "localhost:15533"
 signer = "localhost:15633"
 tasknode = "localhost:15433"
 uploader = "localhost:15133"
+manager = "localhost:15935"
+
 
 [ListenAddress]
 auth = "localhost:15033"
@@ -24,6 +26,8 @@ receiver = "localhost:15533"
 signer = "localhost:15633"
 tasknode = "localhost:15433"
 uploader = "localhost:15133"
+manager = "localhost:15935"
+
 
 [SpDBConfig]
 User = "root"

--- a/test/e2e/localup_env/greenfield_sp_env/sp6/config.toml
+++ b/test/e2e/localup_env/greenfield_sp_env/sp6/config.toml
@@ -12,6 +12,8 @@ receiver = "localhost:16533"
 signer = "localhost:16633"
 tasknode = "localhost:16433"
 uploader = "localhost:16133"
+manager = "localhost:16935"
+
 
 [ListenAddress]
 auth = "localhost:16033"
@@ -24,6 +26,8 @@ receiver = "localhost:16533"
 signer = "localhost:16633"
 tasknode = "localhost:16433"
 uploader = "localhost:16133"
+manager = "localhost:16935"
+
 
 [SpDBConfig]
 User = "root"


### PR DESCRIPTION
### Description

This PR adds scheduling task logic for the manager. the manager schedules the SP tasks, including uploading the object to the primary, replicating pieces to the secondary SP, and deleting the object.

The manager will consider two factors when assigning tasks to task nodes. The first is the priority of the task. The higher the priority, the greater the probability of being dispatched. Second, the number of resources available to the task node will not cause the task node to fail to execute tasks due to excessive resource consumption.

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 
* pkg/taskqueue
* service/manager