### PR TITLE
fix: use EIP-4361 message template for off-chain-auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,6 @@ test:
 
 clean:
 	rm -rf ./service/types/*.pb.go && rm -rf ./service/*/types/*.pb.go
+
+lint:
+	golangci-lint run --fix

--- a/model/const.go
+++ b/model/const.go
@@ -236,7 +236,7 @@ const (
 	GnfdOffChainAuthAppRegNonceHeader = "X-Gnfd-App-Reg-Nonce"
 	// GnfdOffChainAuthAppRegPublicKeyHeader defines the EDDSA public key for which user is trying to register
 	GnfdOffChainAuthAppRegPublicKeyHeader = "X-Gnfd-App-Reg-Public-Key"
-	// GnfdOffChainAuthAppRegExpiryDateHeader defines the Expiry-Date formatted in '2006-01-02 15:04:05 GMT-07:00', used to register the EDDSA public key
+	// GnfdOffChainAuthAppRegExpiryDateHeader defines the Expiry-Date is the ISO 8601 datetime string (e.g. 2021-09-30T16:25:24Z), used to register the EDDSA public key
 	GnfdOffChainAuthAppRegExpiryDateHeader = "X-Gnfd-App-Reg-Expiry-Date"
 )
 

--- a/service/downloader/downloader_service.go
+++ b/service/downloader/downloader_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/bnb-chain/greenfield-storage-provider/model"
 	merrors "github.com/bnb-chain/greenfield-storage-provider/model/errors"
 	"github.com/bnb-chain/greenfield-storage-provider/model/piecestore"

--- a/service/gateway/auth_handler_test.go
+++ b/service/gateway/auth_handler_test.go
@@ -29,14 +29,22 @@ import (
 var Now = time.Now
 
 const (
-	TestSpAddress           string = "0x1c62EF97a13654A759C7E706Adf9EB3bAb0F807A"
-	UnsignedContentTemplate string = `Register your identity of dapp %s
-with your identity key %s
-In the following SPs:
-- SP %s (name: SP_001) with nonce: %s
-- SP 0x20Bb76D063a6d2B18B6DaBb2aC985234a4B9eDe0 (name: SP_002) with nonce: 1
+	TestSpAddress string = "0x1c62EF97a13654A759C7E706Adf9EB3bAb0F807A"
+	TestUserAcct  string = "0xa64fdc3b4866cd2ac664998c7b180813fb9b06e6"
 
-The expiry date is %s`
+	UnsignedContentTemplate string = `%s wants you to sign in with your BNB Greenfield account:
+%s
+
+Register your identity public key %s
+
+URI: %s
+Version: 1
+Chain ID: 5600
+Issued At: %s
+Expiration Time: %s
+Resources:
+- SP %s (name: SP_001) with nonce: %s
+- SP 0x20Bb76D063a6d2B18B6DaBb2aC985234a4B9eDe0 (name: SP_002) with nonce: 1`
 )
 
 func TestRequestNonceHandler(t *testing.T) {
@@ -155,9 +163,8 @@ func TestRequestNonceHandler(t *testing.T) {
 }
 
 func getSampleRequestWithAuthSig(domain string, nonce string, eddsaPublicKey string, spAddr string, validExpiryDate string) *http.Request {
-	unSignedContent := UnsignedContentTemplate
+	unSignedContent := fmt.Sprintf(UnsignedContentTemplate, domain, TestUserAcct, eddsaPublicKey, domain, SampleIssueDate, validExpiryDate, TestSpAddress, nonce)
 
-	unSignedContent = fmt.Sprintf(unSignedContent, domain, eddsaPublicKey, spAddr, nonce, validExpiryDate)
 	log.Infof("unSignedContent is: %s", unSignedContent)
 	unSignedContentHash := accounts.TextHash([]byte(unSignedContent))
 	// Account information.
@@ -733,7 +740,7 @@ func TestUpdateUserPublicKeyHandler(t *testing.T) {
 	}
 }
 
-func TestAuthHandlerVerifySignedContent(t *testing.T) {
+func TestAuthHandlerVerifySignedContentInEip4361Template(t *testing.T) {
 	gateway := &Gateway{
 		config: &GatewayConfig{
 			SpOperatorAddress: TestSpAddress,
@@ -742,9 +749,10 @@ func TestAuthHandlerVerifySignedContent(t *testing.T) {
 	expectedDomain := SampleDAppDomain
 	expectedNonce := "123456"
 	expectedPublicKey := SamplePublicKey
-	expectedExpiryDate := "test_expiry_date"
-	unSignedContent := fmt.Sprintf(UnsignedContentTemplate, expectedDomain, expectedPublicKey, TestSpAddress, expectedNonce, expectedExpiryDate)
-
+	expectedExpiryDate := "2023-04-18T16:25:24Z"
+	expectedIssueDate := SampleIssueDate
+	unSignedContent := fmt.Sprintf(UnsignedContentTemplate, expectedDomain, TestUserAcct, expectedPublicKey, expectedDomain, expectedIssueDate, expectedExpiryDate, TestSpAddress, expectedNonce)
+	log.Infof(unSignedContent)
 	// Test case 1: all inputs are correct.
 	assert.Nil(t, gateway.verifySignedContent(unSignedContent, expectedDomain, expectedNonce, expectedPublicKey, expectedExpiryDate))
 

--- a/service/gateway/request_util_test.go
+++ b/service/gateway/request_util_test.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/bnb-chain/greenfield-storage-provider/model"
 	"github.com/bnb-chain/greenfield-storage-provider/model/errors"
@@ -25,6 +24,7 @@ const (
 	AuthStrFormat    = "PersonalSign ECDSA-secp256k1,SignedMsg=%s,Signature=%s"
 	SampleDAppDomain = "https://greenfield.dapp.sample.io"
 	SamplePublicKey  = "a_sample_eddsa_public_key_for_off_chain_auth"
+	SampleIssueDate  = "2023-04-17T16:25:24Z"
 )
 
 // TODO: Stop referencing SDK code for testing, If needed, move the mainly function to Greenfield Common
@@ -95,12 +95,13 @@ func Test_verifyPersonalSignatureFromWallet(t *testing.T) {
 }
 
 func Test_verifyPersonalSignatureFromRequest(t *testing.T) {
-	nonce := "123456"
-	spAddr := "0x1234567"
-	unSignedContent := UnsignedContentTemplate
+	expectedDomain := SampleDAppDomain
+	expectedNonce := "123456"
+	expectedPublicKey := SamplePublicKey
+	expectedExpiryDate := "2023-04-18T16:25:24Z"
+	expectedIssueDate := SampleIssueDate
+	unSignedContent := fmt.Sprintf(UnsignedContentTemplate, expectedDomain, TestUserAcct, expectedPublicKey, expectedDomain, expectedIssueDate, expectedExpiryDate, TestSpAddress, expectedNonce)
 
-	validExpiryDate := time.Now().Add(time.Hour * 60).Format(ExpiryDateFormat)
-	unSignedContent = fmt.Sprintf(unSignedContent, SampleDAppDomain, SamplePublicKey, spAddr, nonce, validExpiryDate)
 	log.Infof("unSignedContent is: %s", unSignedContent)
 	unSignedContentHash := accounts.TextHash([]byte(unSignedContent))
 	// Account information.

--- a/service/metadata/service/object.go
+++ b/service/metadata/service/object.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+
 	model "github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
 	"github.com/bnb-chain/greenfield/types/s3util"
 


### PR DESCRIPTION
### use EIP-4361 message template for off-chain-auth

Change the current off-chain-auth key update msg to EIP-4361 template

### Rationale

Though we are not implementing EIP-4361, it would be better use its msg template

### Example

The unsigned message presenting to end users will look like this:
```
https://greenfield.dapp.sample.io wants you to sign in with your BNB Greenfield account:
0xa64FdC3B4866CD2aC664998C7b180813fB9B06E6

Register your identity public key 4db642fe6bc2ceda2e002feb8d78dfbcb2879d8fe28e84e02b7a940bc0440083

URI: https://greenfield.dapp.sample.io
Version: 1
Chain ID: 5600
Issued At: 2023-04-18T16:25:24Z
Expiration Time: 2023-04-24T16:25:24Z
Resources:
- SP 677265656e6669656c642d73746f726167652d70726f7669646572 (name: SP_001) with nonce: 8
- SP 0x20Bb76D063a6d2B18B6DaBb2aC985234a4B9eDe0 (name: SP_002) with nonce: 1
```
### Changes

Notable changes: 
* template regex parsing
* related unit tests
