### PR TITLE
fix: permit anonymous users to access public object

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -6,12 +6,14 @@ on:
       - master
       - develop
       - release*
+      - fix-release*
 
   pull_request:
     branches:
       - master
       - develop
       - release*
+      - fix-release*
 
 jobs:
   build-test:

--- a/.github/workflows/code-lint.yml
+++ b/.github/workflows/code-lint.yml
@@ -8,12 +8,14 @@ on:
       - master
       - develop
       - release*
+      - fix-release*
 
   pull_request:
     branches:
       - master
       - develop
       - release*
+      - fix-release*
 
 jobs:
   golangci:

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -6,12 +6,16 @@ on:
       - master
       - develop
       - release*
+      - fix-release*
+
 
   pull_request:
     branches:
       - master
       - develop
       - release*
+      - fix-release*
+
 
 jobs:
   commit-message-lint:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -6,12 +6,14 @@ on:
       - master
       - develop
       - release*
+      - fix-release*
 
   pull_request:
     branches:
       - master
       - develop
       - release*
+      - fix-release*
 
 env:
   GreenfileldTag: v0.0.10

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -6,11 +6,15 @@ on:
       - main
       - develop
       - release*
+      - fix-release*
+
   pull_request:
     branches:
       - master
       - develop
       - release*
+      - fix-release*
+
 jobs:
   gosec:
     name: gosec

--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -6,6 +6,8 @@ on:
       - master
       - develop
       - release*
+      - fix-release*
+
     paths:
       - 'proto/**'
 
@@ -14,6 +16,8 @@ on:
       - master
       - develop
       - release*
+      - fix-release*
+
     paths:
       - 'proto/**'
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,12 +6,14 @@ on:
       - master
       - develop
       - release*
+      - fix-release*
 
   pull_request:
     branches:
       - master
       - develop
       - release*
+      - fix-release*
 
 env:
   CGO_CFLAGS: "-O -D__BLST_PORTABLE__"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine as builder
+FROM golang:1.18-alpine as builder
 
 RUN apk add --no-cache make git bash protoc
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ SpOperatorAddress = ""
 [Endpoint]
 challenge = "localhost:9333"
 downloader = "localhost:9233"
-gateway = "gnfd.nodereal.com"
+gateway = "gnfd.test-sp.com"
 metadata = "localhost:9733"
 p2p = "localhost:9833"
 receiver = "localhost:9533"

--- a/config/config.go
+++ b/config/config.go
@@ -72,7 +72,7 @@ var DefaultStorageProviderConfig = &StorageProviderConfig{
 		model.P2PService:        model.P2PGRPCAddress,
 	},
 	Endpoint: map[string]string{
-		model.GatewayService:    "gnfd.nodereal.com",
+		model.GatewayService:    "gnfd.test-sp.com",
 		model.UploaderService:   model.UploaderGRPCAddress,
 		model.DownloaderService: model.DownloaderGRPCAddress,
 		model.ChallengeService:  model.ChallengeGRPCAddress,

--- a/service/gateway/helper_test.go
+++ b/service/gateway/helper_test.go
@@ -1,0 +1,26 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+var (
+	testDomain = "www.route-test.com"
+	config     = &GatewayConfig{
+		Domain: testDomain,
+	}
+	gw = &Gateway{
+		config: config,
+	}
+	scheme     = "https://"
+	bucketName = "test-bucket-name"
+	objectName = "test-object-name"
+)
+
+func setupRouter(t *testing.T) *mux.Router {
+	gwRouter := mux.NewRouter().SkipClean(true)
+	gw.registerHandler(gwRouter)
+	return gwRouter
+}

--- a/service/gateway/request_util_test.go
+++ b/service/gateway/request_util_test.go
@@ -17,15 +17,27 @@ import (
 	"github.com/bnb-chain/greenfield-storage-provider/model"
 )
 
+func TestVerifyEmptySignature(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, scheme+bucketName+"."+testDomain+"/"+objectName, nil)
+	require.NoError(t, err)
+	rc := &requestContext{
+		request:    req,
+		routerName: getObjectRouterName,
+	}
+	addrOutput, err := rc.verifySignature()
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "", addrOutput.String())
+}
+
 func TestVerifySignatureV1(t *testing.T) {
 	// mock request
 	urlmap := url.Values{}
 	urlmap.Add("greenfield", "storage-provider")
 	parms := io.NopCloser(strings.NewReader(urlmap.Encode()))
-	req, err := http.NewRequest("POST", "gnfd.nodereal.com", parms)
+	req, err := http.NewRequest("POST", "gnfd.test-sp.com", parms)
 	require.NoError(t, err)
 	req.Header.Set(model.ContentTypeHeader, "application/x-www-form-urlencoded")
-	req.Host = "testBucket.gnfd.nodereal.com"
+	req.Host = "testBucket.gnfd.test-sp.com"
 	// mock
 	privKey, _, addrInput := testdata.KeyEthSecp256k1TestPubAddr()
 	keyManager, err := keys.NewPrivateKeyManager(hex.EncodeToString(privKey.Bytes()))
@@ -52,7 +64,7 @@ func TestVerifySignatureV2(t *testing.T) {
 	req, err := http.NewRequest("POST", "example.com", parms)
 	require.NoError(t, err)
 	req.Header.Set(model.ContentTypeHeader, "application/x-www-form-urlencoded")
-	req.Host = "testBucket.gnfd.nodereal.com"
+	req.Host = "testBucket.gnfd.test-sp.com"
 	// mock pk
 	privKey, _, _ := testdata.KeyEthSecp256k1TestPubAddr()
 	keyManager, err := keys.NewPrivateKeyManager(hex.EncodeToString(privKey.Bytes()))

--- a/service/gateway/router_test.go
+++ b/service/gateway/router_test.go
@@ -11,23 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var (
-	testDomain = "www.route-test.com"
-	config     = &GatewayConfig{
-		Domain: testDomain,
-	}
-	gw = &Gateway{
-		config: config,
-	}
-	scheme     = "https://"
-	bucketName = "test-bucket-name"
-	objectName = "test-object-name"
-)
-
 func TestRouters(t *testing.T) {
-	gwRouter := mux.NewRouter().SkipClean(true)
-	gw.registerHandler(gwRouter)
-
+	gwRouter := setupRouter(t)
 	testCases := []struct {
 		name             string
 		router           *mux.Router // the router being tested

--- a/service/metadata/service/object.go
+++ b/service/metadata/service/object.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+
 	model "github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
 	"github.com/bnb-chain/greenfield/types/s3util"
 

--- a/test/e2e/localup_env/greenfield_sp_env/sp0/config.toml
+++ b/test/e2e/localup_env/greenfield_sp_env/sp0/config.toml
@@ -4,7 +4,7 @@ SpOperatorAddress = "0x84646D1d4AD147a6C1E1B67F771F39e89593aF4B"
 [Endpoint]
 challenge = "localhost:10333"
 downloader = "localhost:10233"
-gateway = "gnfd.nodereal.com"
+gateway = "gnfd.test-sp.com"
 metadata = "localhost:10733"
 p2p = "localhost:10833"
 receiver = "localhost:10533"

--- a/test/e2e/localup_env/greenfield_sp_env/sp1/config.toml
+++ b/test/e2e/localup_env/greenfield_sp_env/sp1/config.toml
@@ -4,7 +4,7 @@ SpOperatorAddress = "0x2cf731DB95681B799FA0054276C7Ca44def450f8"
 [Endpoint]
 challenge = "localhost:11333"
 downloader = "localhost:11233"
-gateway = "gnfd.nodereal.com"
+gateway = "gnfd.test-sp.com"
 metadata = "localhost:11733"
 p2p = "localhost:11833"
 receiver = "localhost:11533"

--- a/test/e2e/localup_env/greenfield_sp_env/sp2/config.toml
+++ b/test/e2e/localup_env/greenfield_sp_env/sp2/config.toml
@@ -4,7 +4,7 @@ SpOperatorAddress = "0x4C1674C0504bad30e023D7B3991824bCC47E193d"
 [Endpoint]
 challenge = "localhost:12333"
 downloader = "localhost:12233"
-gateway = "gnfd.nodereal.com"
+gateway = "gnfd.test-sp.com"
 metadata = "localhost:12733"
 p2p = "localhost:12833"
 receiver = "localhost:12533"

--- a/test/e2e/localup_env/greenfield_sp_env/sp3/config.toml
+++ b/test/e2e/localup_env/greenfield_sp_env/sp3/config.toml
@@ -4,7 +4,7 @@ SpOperatorAddress = "0xe620C05870A2392E4987676b345026E6C6228388"
 [Endpoint]
 challenge = "localhost:13333"
 downloader = "localhost:13233"
-gateway = "gnfd.nodereal.com"
+gateway = "gnfd.test-sp.com"
 metadata = "localhost:13733"
 p2p = "localhost:13833"
 receiver = "localhost:13533"

--- a/test/e2e/localup_env/greenfield_sp_env/sp4/config.toml
+++ b/test/e2e/localup_env/greenfield_sp_env/sp4/config.toml
@@ -4,7 +4,7 @@ SpOperatorAddress = "0x1ee57886094E9A7E08Cc8e740C1F8A51DDf40c63"
 [Endpoint]
 challenge = "localhost:14333"
 downloader = "localhost:14233"
-gateway = "gnfd.nodereal.com"
+gateway = "gnfd.test-sp.com"
 metadata = "localhost:14733"
 p2p = "localhost:14833"
 receiver = "localhost:14533"

--- a/test/e2e/localup_env/greenfield_sp_env/sp5/config.toml
+++ b/test/e2e/localup_env/greenfield_sp_env/sp5/config.toml
@@ -4,7 +4,7 @@ SpOperatorAddress = "0xafe242857feB1ae49678C301Fb41571C16b99E7c"
 [Endpoint]
 challenge = "localhost:15333"
 downloader = "localhost:15233"
-gateway = "gnfd.nodereal.com"
+gateway = "gnfd.test-sp.com"
 metadata = "localhost:15733"
 p2p = "localhost:15833"
 receiver = "localhost:15533"

--- a/test/e2e/localup_env/greenfield_sp_env/sp6/config.toml
+++ b/test/e2e/localup_env/greenfield_sp_env/sp6/config.toml
@@ -4,7 +4,7 @@ SpOperatorAddress = "0x193ae94602232A0600854D26eF322617aDDB2A44"
 [Endpoint]
 challenge = "localhost:16333"
 downloader = "localhost:16233"
-gateway = "gnfd.nodereal.com"
+gateway = "gnfd.test-sp.com"
 metadata = "localhost:16733"
 p2p = "localhost:16833"
 receiver = "localhost:16533"


### PR DESCRIPTION
### Description

1. Permit anonymous users to access the public object.
2. Refine some config to ensure to run action checker.

### Rationale

This should be allowed if the HTTP request has no `Authorization` header and gets the public object. And this change depends on the VerifyPermission interface behavior of the chain, and the chain needs to be upgraded at the same time.

Refer to: https://github.com/bnb-chain/greenfield/pull/186

### Example

N/A

### Changes

Notable changes: 
* Gateway.
