### PR TITLE
fix: permit anonymous users to access public object

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -6,12 +6,14 @@ on:
       - master
       - develop
       - release*
+      - fix-release*
 
   pull_request:
     branches:
       - master
       - develop
       - release*
+      - fix-release*
 
 jobs:
   build-test:

--- a/.github/workflows/code-lint.yml
+++ b/.github/workflows/code-lint.yml
@@ -8,12 +8,14 @@ on:
       - master
       - develop
       - release*
+      - fix-release*
 
   pull_request:
     branches:
       - master
       - develop
       - release*
+      - fix-release*
 
 jobs:
   golangci:

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -6,12 +6,16 @@ on:
       - master
       - develop
       - release*
+      - fix-release*
+
 
   pull_request:
     branches:
       - master
       - develop
       - release*
+      - fix-release*
+
 
 jobs:
   commit-message-lint:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -6,12 +6,14 @@ on:
       - master
       - develop
       - release*
+      - fix-release*
 
   pull_request:
     branches:
       - master
       - develop
       - release*
+      - fix-release*
 
 env:
   GreenfileldTag: v0.0.10

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -6,11 +6,15 @@ on:
       - main
       - develop
       - release*
+      - fix-release*
+
   pull_request:
     branches:
       - master
       - develop
       - release*
+      - fix-release*
+
 jobs:
   gosec:
     name: gosec

--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -6,6 +6,8 @@ on:
       - master
       - develop
       - release*
+      - fix-release*
+
     paths:
       - 'proto/**'
 
@@ -14,6 +16,8 @@ on:
       - master
       - develop
       - release*
+      - fix-release*
+
     paths:
       - 'proto/**'
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,12 +6,14 @@ on:
       - master
       - develop
       - release*
+      - fix-release*
 
   pull_request:
     branches:
       - master
       - develop
       - release*
+      - fix-release*
 
 env:
   CGO_CFLAGS: "-O -D__BLST_PORTABLE__"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine as builder
+FROM golang:1.18-alpine as builder
 
 RUN apk add --no-cache make git bash protoc
 

--- a/service/gateway/helper_test.go
+++ b/service/gateway/helper_test.go
@@ -1,0 +1,26 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+var (
+	testDomain = "www.route-test.com"
+	config     = &GatewayConfig{
+		Domain: testDomain,
+	}
+	gw = &Gateway{
+		config: config,
+	}
+	scheme     = "https://"
+	bucketName = "test-bucket-name"
+	objectName = "test-object-name"
+)
+
+func setupRouter(t *testing.T) *mux.Router {
+	gwRouter := mux.NewRouter().SkipClean(true)
+	gw.registerHandler(gwRouter)
+	return gwRouter
+}

--- a/service/gateway/request_util.go
+++ b/service/gateway/request_util.go
@@ -30,17 +30,18 @@ import (
 
 // requestContext is a request context.
 type requestContext struct {
+	request     *http.Request
+	routerName  string
 	requestID   string
 	bucketName  string
 	objectName  string
-	request     *http.Request
-	startTime   time.Time
+	accountID   string // accountID is used to provide authentication to the sp
 	vars        map[string]string
+	startTime   time.Time
 	skipAuth    bool // TODO: for auth v2 test, remove it in the future
+	isAnonymous bool // It is anonymous when there is no GnfdAuthorizationHeader
 	bucketInfo  *storagetypes.BucketInfo
 	objectInfo  *storagetypes.ObjectInfo
-	accountID   string // accountID is used to provide authentication to the sp
-	isAnonymous bool
 }
 
 // RecoverAddr recovers the sender address from msg and signature
@@ -63,14 +64,19 @@ func RecoverAddr(msg []byte, sig []byte) (sdk.AccAddress, ethsecp256k1.PubKey, e
 // newRequestContext return a request context.
 func newRequestContext(r *http.Request) *requestContext {
 	vars := mux.Vars(r)
+	routerName := ""
+	if mux.CurrentRoute(r) != nil {
+		routerName = mux.CurrentRoute(r).GetName()
+	}
 	return &requestContext{
+		request:    r,
+		routerName: routerName,
 		requestID:  util.GenerateRequestID(),
 		bucketName: vars["bucket"],
 		objectName: vars["object"],
 		accountID:  vars["account_id"],
-		request:    r,
-		startTime:  time.Now(),
 		vars:       vars,
+		startTime:  time.Now(),
 	}
 }
 
@@ -134,7 +140,7 @@ func (g *Gateway) verifySignature(reqContext *requestContext) (sdk.AccAddress, e
 		return g.verifyOffChainSignature(reqContext, requestSignature[len(OffChainSignaturePrefix):])
 	}
 	// Anonymous users can get public object.
-	if requestSignature == "" && mux.CurrentRoute(reqContext.request).GetName() == getObjectRouterName {
+	if requestSignature == "" && reqContext.routerName == getObjectRouterName {
 		reqContext.isAnonymous = true
 		return sdk.AccAddress{}, nil
 	}
@@ -382,7 +388,7 @@ func (g *Gateway) checkAuthorization(reqContext *requestContext, addr sdk.AccAdd
 		}
 	}
 
-	switch mux.CurrentRoute(reqContext.request).GetName() {
+	switch reqContext.routerName {
 	case putObjectRouterName, queryUploadProgressRouterName:
 		if reqContext.bucketInfo, reqContext.objectInfo, err = g.chain.QueryBucketInfoAndObjectInfo(
 			context.Background(), reqContext.bucketName, reqContext.objectName); err != nil {

--- a/service/gateway/request_util_test.go
+++ b/service/gateway/request_util_test.go
@@ -27,6 +27,18 @@ const (
 	SampleIssueDate  = "2023-04-17T16:25:24Z"
 )
 
+func TestVerifyEmptySignature(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, scheme+bucketName+"."+testDomain+"/"+objectName, nil)
+	require.NoError(t, err)
+	rc := &requestContext{
+		request:    req,
+		routerName: getObjectRouterName,
+	}
+	addrOutput, err := gw.verifySignature(rc)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "", addrOutput.String())
+}
+
 // TODO: Stop referencing SDK code for testing, If needed, move the mainly function to Greenfield Common
 /*
 func TestVerifySignatureV1(t *testing.T) {

--- a/service/gateway/router_test.go
+++ b/service/gateway/router_test.go
@@ -11,23 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var (
-	testDomain = "www.route-test.com"
-	config     = &GatewayConfig{
-		Domain: testDomain,
-	}
-	gw = &Gateway{
-		config: config,
-	}
-	scheme     = "https://"
-	bucketName = "test-bucket-name"
-	objectName = "test-object-name"
-)
-
 func TestRouters(t *testing.T) {
-	gwRouter := mux.NewRouter().SkipClean(true)
-	gw.registerHandler(gwRouter)
-
+	gwRouter := setupRouter(t)
 	testCases := []struct {
 		name             string
 		router           *mux.Router // the router being tested


### PR DESCRIPTION
### Description

1. Permit anonymous users to access the public object.
2. Refine some config to ensure fix-release* branches to run the action checker.

### Rationale

This should be allowed if the HTTP request has no `Authorization` header and gets the public object. And this change depends on the VerifyPermission interface behavior of the chain, and the chain needs to be upgraded at the same time.

### Example

N/A

### Changes

Notable changes: 
* Gateway.
