### PR TITLE
fix: universal endpoint space

### DIFF
--- a/service/gateway/object_handler.go
+++ b/service/gateway/object_handler.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/bnb-chain/greenfield/types/s3util"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
@@ -278,13 +279,20 @@ func (gateway *Gateway) getObjectByUniversalEndpointHandler(w http.ResponseWrite
 		return
 	}
 
+	escapedObjectName, err := url.QueryUnescape(reqContext.objectName)
+	if err != nil {
+		log.Errorw("failed to unescape object name ", "object_name", reqContext.objectName, "error", err)
+		errDescription = InvalidKey
+		return
+	}
+
 	if err = s3util.CheckValidBucketName(reqContext.bucketName); err != nil {
 		log.Errorw("failed to check bucket name", "bucket_name", reqContext.bucketName, "error", err)
 		errDescription = InvalidBucketName
 		return
 	}
-	if err = s3util.CheckValidObjectName(reqContext.objectName); err != nil {
-		log.Errorw("failed to check object name", "object_name", reqContext.objectName, "error", err)
+	if err = s3util.CheckValidObjectName(escapedObjectName); err != nil {
+		log.Errorw("failed to check object name", "object_name", escapedObjectName, "error", err)
 		errDescription = InvalidKey
 		return
 	}
@@ -326,14 +334,14 @@ func (gateway *Gateway) getObjectByUniversalEndpointHandler(w http.ResponseWrite
 
 	// In first phase, do not provide universal endpoint for private object
 	getObjectInfoReq := &metatypes.GetObjectByObjectNameAndBucketNameRequest{
-		ObjectName: reqContext.objectName,
+		ObjectName: escapedObjectName,
 		BucketName: reqContext.bucketName,
 		IsFullList: false,
 	}
 
 	getObjectInfoRes, err := gateway.metadata.GetObjectByObjectNameAndBucketName(ctx, getObjectInfoReq)
 	if err != nil || getObjectInfoRes == nil || getObjectInfoRes.GetObject() == nil || getObjectInfoRes.GetObject().GetObjectInfo() == nil {
-		log.Errorw("failed to check object info", "object_name", reqContext.objectName, "error", err)
+		log.Errorw("failed to check object info", "object_name", escapedObjectName, "error", err)
 		errDescription = InvalidKey
 		return
 	}

--- a/service/metadata/service/object.go
+++ b/service/metadata/service/object.go
@@ -110,14 +110,14 @@ func (metadata *Metadata) GetObjectByObjectNameAndBucketName(ctx context.Context
 	)
 
 	ctx = log.Context(ctx, req)
-	if err = s3util.CheckValidBucketName(req.ObjectName); err != nil {
+	if err = s3util.CheckValidObjectName(req.ObjectName); err != nil {
 		log.Errorw("failed to check object name", "object_name", req.ObjectName, "error", err)
 		return nil, err
 	}
 
 	object, err = metadata.bsDB.GetObjectByName(req.ObjectName, req.BucketName, req.IsFullList)
 	if err != nil {
-		log.CtxErrorw(ctx, "failed to get bucket by bucket name", "error", err)
+		log.CtxErrorw(ctx, "failed to get object by object name", "error", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
### Description

Fix universal endpoint cannot handle space in object name issue

### Rationale

Universal endpoint should support space and other escaped characters in object name

### Example

https://gf-sp-a.bk.nodereal.cc/download/rickie12/image (6).png -> in url become
https://gf-sp-a.bk.nodereal.cc/download/rickie12/image%20(6).png
shall be handled correctly with %20.

### Changes

Notable changes: 
* Downloader
