### PR TITLE
fix: universal endpoint space

### DIFF
--- a/service/gateway/object_handler.go
+++ b/service/gateway/object_handler.go
@@ -289,7 +289,7 @@ func (gateway *Gateway) getObjectByUniversalEndpointHandler(w http.ResponseWrite
 		return
 	}
 
-	escapedObjectName, err := url.QueryUnescape(reqContext.objectName)
+	escapedObjectName, err := url.PathUnescape(reqContext.objectName)
 	if err != nil {
 		log.Errorw("failed to unescape object name ", "object_name", reqContext.objectName, "error", err)
 		errDescription = InvalidKey

--- a/service/metadata/service/object.go
+++ b/service/metadata/service/object.go
@@ -124,14 +124,14 @@ func (metadata *Metadata) GetObjectByObjectNameAndBucketName(ctx context.Context
 	)
 
 	ctx = log.Context(ctx, req)
-	if err = s3util.CheckValidBucketName(req.ObjectName); err != nil {
+	if err = s3util.CheckValidObjectName(req.ObjectName); err != nil {
 		log.Errorw("failed to check object name", "object_name", req.ObjectName, "error", err)
 		return nil, err
 	}
 
 	object, err = metadata.bsDB.GetObjectByName(req.ObjectName, req.BucketName, req.IsFullList)
 	if err != nil {
-		log.CtxErrorw(ctx, "failed to get bucket by bucket name", "error", err)
+		log.CtxErrorw(ctx, "failed to get object by object name", "error", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
### Description

Fix universal endpoint cannot handle space in object name issue

### Rationale

Universal endpoint should support space and other escaped characters in object name

### Example

https://gf-sp-a.bk.nodereal.cc/download/rickie12/image (6).png -> in url become
https://gf-sp-a.bk.nodereal.cc/download/rickie12/image%20(6).png
shall be handled correctly with %20.

### Changes

Notable changes: 
* Downloader
