### PR TITLE
fix: use PathUnescape instead of QueryUnescape

### DIFF
--- a/service/gateway/object_handler.go
+++ b/service/gateway/object_handler.go
@@ -279,7 +279,7 @@ func (gateway *Gateway) getObjectByUniversalEndpointHandler(w http.ResponseWrite
 		return
 	}
 
-	escapedObjectName, err := url.QueryUnescape(reqContext.objectName)
+	escapedObjectName, err := url.PathUnescape(reqContext.objectName)
 	if err != nil {
 		log.Errorw("failed to unescape object name ", "object_name", reqContext.objectName, "error", err)
 		errDescription = InvalidKey


### PR DESCRIPTION
### Description

Use PathUnescape instead of QueryUnescape

### Rationale

to handle + unescape correctly 

### Example

N/A

### Changes

Notable changes: 
* Downloader