### PR TITLE
fix: block syncer ignore group creation when no members included

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace (
 	github.com/bnb-chain/greenfield => github.com/bnb-chain/greenfield v0.1.2
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.0.13
-	github.com/forbole/juno/v4 => github.com/bnb-chain/juno/v4 v4.0.0-20230420110331-03f0d6934e45
+	github.com/forbole/juno/v4 => github.com/bnb-chain/juno/v4 v4.0.0-20230424013222-76149d522883
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/tendermint/tendermint => github.com/bnb-chain/gnfd-tendermint v0.0.3
 )

--- a/go.sum
+++ b/go.sum
@@ -216,8 +216,8 @@ github.com/bnb-chain/greenfield-cosmos-sdk v0.0.13 h1:xm9qqrOjrGfX4imXxxruHIpuUU
 github.com/bnb-chain/greenfield-cosmos-sdk v0.0.13/go.mod h1:rvAY7ga/AakZWyYkA1zAsNtvKpdoyRFZTqF4MhFYzZ8=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230228075616-68ac309b432c h1:BLmdYaj7Dx0YOhfk77+KPPJSMCwpQl6f4Y30+801bf0=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230228075616-68ac309b432c/go.mod h1:u/MXvf8wbUbCsAEyQSSYXXMsczAsFX48e2D6JI86T4o=
-github.com/bnb-chain/juno/v4 v4.0.0-20230420110331-03f0d6934e45 h1:EDH27lP+KcRSogGKwYQUu9+Fj/J7aNhlKnDESehGIvM=
-github.com/bnb-chain/juno/v4 v4.0.0-20230420110331-03f0d6934e45/go.mod h1:f8+o/XzjbBGWcKqxDBSTi3BwLItanrMkI4fNJ7P7miU=
+github.com/bnb-chain/juno/v4 v4.0.0-20230424013222-76149d522883 h1:SPDM4OqYpYXDk3xUMk8LGGi0rdYEI41GUTdO7WW3avk=
+github.com/bnb-chain/juno/v4 v4.0.0-20230424013222-76149d522883/go.mod h1:f8+o/XzjbBGWcKqxDBSTi3BwLItanrMkI4fNJ7P7miU=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/bradfitz/gomemcache v0.0.0-20170208213004-1952afaa557d/go.mod h1:PmM6Mmwb0LSuEubjR8N7PtNe1KxZLtOUHtbeikc5h60=


### PR DESCRIPTION
### Description

block syncer ignore group creation when no members included 

### Rationale

It's allowed when a group created with no members included, we return an error before, in this PR we fixed this and let it go

### Example

N/A

### Changes

Notable changes: 
* relative changes updated in juno
