### PR TITLE
feat: add universal endpoint view option

### DIFF
--- a/model/const.go
+++ b/model/const.go
@@ -155,11 +155,11 @@ const (
 	ContentTypeJSONHeaderValue = "application/json"
 	// ContentTypeXMLHeaderValue is used to indicate xml
 	ContentTypeXMLHeaderValue = "application/xml"
-	//ContentDispositionHeader is used to indicate the media disposition of the resource
+	// ContentDispositionHeader is used to indicate the media disposition of the resource
 	ContentDispositionHeader = "Content-Disposition"
-	//ContentDispositionAttachmentValue is used to indicate attachment
+	// ContentDispositionAttachmentValue is used to indicate attachment
 	ContentDispositionAttachmentValue = "attachment"
-	//ContentDispositionInlineValue is used to indicate inline
+	// ContentDispositionInlineValue is used to indicate inline
 	ContentDispositionInlineValue = "inline"
 
 	// SignAlgorithm uses secp256k1 with the ECDSA algorithm

--- a/model/const.go
+++ b/model/const.go
@@ -159,6 +159,8 @@ const (
 	ContentDispositionHeader = "Content-Disposition"
 	//ContentDispositionAttachmentValue is used to indicate attachment
 	ContentDispositionAttachmentValue = "attachment"
+	//ContentDispositionInlineValue is used to indicate inline
+	ContentDispositionInlineValue = "inline"
 
 	// SignAlgorithm uses secp256k1 with the ECDSA algorithm
 	SignAlgorithm = "ECDSA-secp256k1"
@@ -177,8 +179,6 @@ const (
 
 	// GetApprovalPath defines get-approval path style suffix
 	GetApprovalPath = "/greenfield/admin/v1/get-approval"
-	// UniversalEndpointPath defines universal endpoint path style suffix
-	UniversalEndpointPath = "/download/{bucket:[^/]*}/{object:.+}"
 	// ActionQuery defines get-approval's type, currently include create bucket and create object
 	ActionQuery = "action"
 	// UploadProgressQuery defines upload progress query, which is used to route request

--- a/service/gateway/object_handler.go
+++ b/service/gateway/object_handler.go
@@ -254,7 +254,7 @@ func (gateway *Gateway) putObjectHandler(w http.ResponseWriter, r *http.Request)
 }
 
 // getObjectByUniversalEndpointHandler handles the get object request sent by universal endpoint
-func (gateway *Gateway) getObjectByUniversalEndpointHandler(w http.ResponseWriter, r *http.Request) {
+func (gateway *Gateway) getObjectByUniversalEndpointHandler(w http.ResponseWriter, r *http.Request, isDownload bool) {
 	var (
 		err            error
 		errDescription *errorDescription
@@ -267,6 +267,7 @@ func (gateway *Gateway) getObjectByUniversalEndpointHandler(w http.ResponseWrite
 		size           int
 		statusCode     = http.StatusOK
 		ctx, cancel    = context.WithCancel(context.Background())
+		redirectUrl    string
 	)
 
 	reqContext = newRequestContext(r)
@@ -276,6 +277,14 @@ func (gateway *Gateway) getObjectByUniversalEndpointHandler(w http.ResponseWrite
 			statusCode = errDescription.statusCode
 			_ = errDescription.errorResponse(w, reqContext)
 		}
+
+		var getObjectByUniversalEndpointName string
+		if isDownload {
+			getObjectByUniversalEndpointName = downloadObjectByUniversalEndpointName
+		} else {
+			getObjectByUniversalEndpointName = viewObjectByUniversalEndpointName
+		}
+
 		if statusCode == http.StatusOK || statusCode == http.StatusPartialContent {
 			log.Infof("action(%v) statusCode(%v) %v", getObjectByUniversalEndpointName, statusCode, reqContext.generateRequestDetail())
 		} else {
@@ -334,7 +343,14 @@ func (gateway *Gateway) getObjectByUniversalEndpointHandler(w http.ResponseWrite
 			errDescription = InvalidAddress
 			return
 		}
-		redirectUrl := endpoint + "/download/" + reqContext.bucketName + "/" + reqContext.objectName
+
+		if isDownload {
+			redirectUrl = endpoint + "/download/" + reqContext.bucketName + "/" + reqContext.objectName
+			w.Header().Set(model.ContentDispositionHeader, model.ContentDispositionAttachmentValue+"; filename=\""+escapedObjectName+"\"")
+		} else {
+			redirectUrl = endpoint + "/view/" + reqContext.bucketName + "/" + reqContext.objectName
+			w.Header().Set(model.ContentDispositionHeader, model.ContentDispositionInlineValue)
+		}
 
 		log.Debugw("getting redirect url:", "redirectUrl", redirectUrl)
 
@@ -378,7 +394,7 @@ func (gateway *Gateway) getObjectByUniversalEndpointHandler(w http.ResponseWrite
 		errDescription = makeErrorDescription(err)
 		return
 	}
-	w.Header().Set(model.ContentDispositionHeader, model.ContentDispositionAttachmentValue)
+
 	for {
 		resp, err := stream.Recv()
 		if err == io.EOF {
@@ -412,4 +428,14 @@ func (gateway *Gateway) getObjectByUniversalEndpointHandler(w http.ResponseWrite
 		size = size + writeN
 	}
 	w.Header().Set(model.GnfdRequestIDHeader, reqContext.requestID)
+}
+
+// downloadObjectByUniversalEndpointHandler handles the download object request sent by universal endpoint
+func (gateway *Gateway) downloadObjectByUniversalEndpointHandler(w http.ResponseWriter, r *http.Request) {
+	gateway.getObjectByUniversalEndpointHandler(w, r, true)
+}
+
+// viewObjectByUniversalEndpointHandler handles the view object request sent by universal endpoint
+func (gateway *Gateway) viewObjectByUniversalEndpointHandler(w http.ResponseWriter, r *http.Request) {
+	gateway.getObjectByUniversalEndpointHandler(w, r, false)
 }

--- a/service/gateway/object_handler.go
+++ b/service/gateway/object_handler.go
@@ -346,10 +346,8 @@ func (gateway *Gateway) getObjectByUniversalEndpointHandler(w http.ResponseWrite
 
 		if isDownload {
 			redirectUrl = endpoint + "/download/" + reqContext.bucketName + "/" + reqContext.objectName
-			w.Header().Set(model.ContentDispositionHeader, model.ContentDispositionAttachmentValue+"; filename=\""+escapedObjectName+"\"")
 		} else {
 			redirectUrl = endpoint + "/view/" + reqContext.bucketName + "/" + reqContext.objectName
-			w.Header().Set(model.ContentDispositionHeader, model.ContentDispositionInlineValue)
 		}
 
 		log.Debugw("getting redirect url:", "redirectUrl", redirectUrl)
@@ -393,6 +391,12 @@ func (gateway *Gateway) getObjectByUniversalEndpointHandler(w http.ResponseWrite
 		log.Errorf("failed to get object", "error", err)
 		errDescription = makeErrorDescription(err)
 		return
+	}
+
+	if isDownload {
+		w.Header().Set(model.ContentDispositionHeader, model.ContentDispositionAttachmentValue+"; filename=\""+escapedObjectName+"\"")
+	} else {
+		w.Header().Set(model.ContentDispositionHeader, model.ContentDispositionInlineValue)
 	}
 
 	for {

--- a/service/gateway/router.go
+++ b/service/gateway/router.go
@@ -12,19 +12,20 @@ import (
 )
 
 const (
-	approvalRouterName               = "GetApproval"
-	putObjectRouterName              = "PutObject"
-	getObjectRouterName              = "GetObject"
-	challengeRouterName              = "Challenge"
-	replicateObjectPieceRouterName   = "ReplicateObjectPiece"
-	getUserBucketsRouterName         = "GetUserBuckets"
-	listObjectsByBucketRouterName    = "ListObjectsByBucketName"
-	getBucketReadQuotaRouterName     = "GetBucketReadQuota"
-	listBucketReadRecordRouterName   = "ListBucketReadRecord"
-	requestNonceName                 = "RequestNonce"
-	updateUserPublicKey              = "UpdateUserPublicKey"
-	queryUploadProgressRouterName    = "queryUploadProgress"
-	getObjectByUniversalEndpointName = "GetObjectByUniversalEndpoint"
+	approvalRouterName                    = "GetApproval"
+	putObjectRouterName                   = "PutObject"
+	getObjectRouterName                   = "GetObject"
+	challengeRouterName                   = "Challenge"
+	replicateObjectPieceRouterName        = "ReplicateObjectPiece"
+	getUserBucketsRouterName              = "GetUserBuckets"
+	listObjectsByBucketRouterName         = "ListObjectsByBucketName"
+	getBucketReadQuotaRouterName          = "GetBucketReadQuota"
+	listBucketReadRecordRouterName        = "ListBucketReadRecord"
+	requestNonceName                      = "RequestNonce"
+	updateUserPublicKey                   = "UpdateUserPublicKey"
+	queryUploadProgressRouterName         = "queryUploadProgress"
+	downloadObjectByUniversalEndpointName = "DownloadObjectByUniversalEndpoint"
+	viewObjectByUniversalEndpointName     = "ViewObjectByUniversalEndpoint"
 )
 
 const (
@@ -107,12 +108,17 @@ func (g *Gateway) registerHandler(r *mux.Router) {
 		Name(replicateObjectPieceRouterName).
 		Methods(http.MethodPut).
 		HandlerFunc(g.replicatePieceHandler)
-	//universal endpoint
-	r.Path(model.UniversalEndpointPath).
-		Name(getObjectByUniversalEndpointName).
+	// universal endpoint download
+	r.Path("/download/{bucket:[^/]*}/{object:.+}").
+		Name(downloadObjectByUniversalEndpointName).
 		Methods(http.MethodGet).
-		HandlerFunc(g.getObjectByUniversalEndpointHandler)
-	//redirect for universal endpoint
+		HandlerFunc(g.downloadObjectByUniversalEndpointHandler)
+	// universal endpoint view
+	r.Path("/view/{bucket:[^/]*}/{object:.+}").
+		Name(viewObjectByUniversalEndpointName).
+		Methods(http.MethodGet).
+		HandlerFunc(g.viewObjectByUniversalEndpointHandler)
+	// redirect for universal endpoint
 	http.Handle("/", r)
 
 	// off-chain-auth router


### PR DESCRIPTION
### Description

Add view option for universal endpoint and fix download file name without suffix

### Rationale

Users want to have a view option for universal endpoint, such that if they host html file on Dcellar, the universal endpoint will open the html in a new page other than download it as an attachment.
 
### Example

Universal Endpoint View link is like:
{endpoint}/view/{bucket_name}/{object_name}

### Changes

Notable changes: 
* Add new Universal Endpoint api in Downloader
