### PR TITLE
feat: add dual db warm up support for blocksyncer

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -130,7 +130,9 @@ var DefaultGreenfieldChainConfig = &gnfd.GreenfieldChainConfig{
 var DefaultBlockSyncerConfig = &blocksyncer.Config{
 	Modules:        []string{"epoch", "bucket", "object", "payment"},
 	Dsn:            "localhost:3308",
-	RecreateTables: true,
+	DsnBackup:      "localhost:3308",
+	RecreateTables: false,
+	Backup:         false,
 }
 
 // DefaultMetricsConfig defines the default config of Metrics service

--- a/config/subconfig.go
+++ b/config/subconfig.go
@@ -269,13 +269,15 @@ func (cfg *StorageProviderConfig) MakeBlockSyncerConfig() (*tomlconfig.TomlConfi
 			Type:               "mysql",
 			DSN:                cfg.BlockSyncerCfg.Dsn,
 			PartitionBatchSize: model.DefaultPartitionSize,
-			MaxIdleConnections: 1,
-			MaxOpenConnections: 1,
+			MaxIdleConnections: 10,
+			MaxOpenConnections: 30,
 		},
 		Logging: loggingconfig.Config{
 			Level: "debug",
 		},
 		RecreateTables: cfg.BlockSyncerCfg.RecreateTables,
+		Backup:         cfg.BlockSyncerCfg.Backup,
+		DsnBackup:      cfg.BlockSyncerCfg.DsnBackup,
 	}, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace (
 	github.com/bnb-chain/greenfield => github.com/bnb-chain/greenfield v0.1.2
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.0.13
-	github.com/forbole/juno/v4 => github.com/bnb-chain/juno/v4 v4.0.0-20230424013222-76149d522883
+	github.com/forbole/juno/v4 => github.com/bnb-chain/juno/v4 v4.0.0-20230506020239-30a66c48e129
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/tendermint/tendermint => github.com/bnb-chain/gnfd-tendermint v0.0.3
 )
@@ -132,7 +132,7 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
-	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.3
+	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/gtank/merlin v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -216,8 +216,8 @@ github.com/bnb-chain/greenfield-cosmos-sdk v0.0.13 h1:xm9qqrOjrGfX4imXxxruHIpuUU
 github.com/bnb-chain/greenfield-cosmos-sdk v0.0.13/go.mod h1:rvAY7ga/AakZWyYkA1zAsNtvKpdoyRFZTqF4MhFYzZ8=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230228075616-68ac309b432c h1:BLmdYaj7Dx0YOhfk77+KPPJSMCwpQl6f4Y30+801bf0=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230228075616-68ac309b432c/go.mod h1:u/MXvf8wbUbCsAEyQSSYXXMsczAsFX48e2D6JI86T4o=
-github.com/bnb-chain/juno/v4 v4.0.0-20230424013222-76149d522883 h1:SPDM4OqYpYXDk3xUMk8LGGi0rdYEI41GUTdO7WW3avk=
-github.com/bnb-chain/juno/v4 v4.0.0-20230424013222-76149d522883/go.mod h1:f8+o/XzjbBGWcKqxDBSTi3BwLItanrMkI4fNJ7P7miU=
+github.com/bnb-chain/juno/v4 v4.0.0-20230506020239-30a66c48e129 h1:Gy5vSLHfAheMhmPl9NOCI/a5mvcayU0DvBgVH4xgeoQ=
+github.com/bnb-chain/juno/v4 v4.0.0-20230506020239-30a66c48e129/go.mod h1:f8+o/XzjbBGWcKqxDBSTi3BwLItanrMkI4fNJ7P7miU=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/bradfitz/gomemcache v0.0.0-20170208213004-1952afaa557d/go.mod h1:PmM6Mmwb0LSuEubjR8N7PtNe1KxZLtOUHtbeikc5h60=

--- a/model/const.go
+++ b/model/const.go
@@ -22,6 +22,8 @@ var (
 	MetadataService = strings.ToLower("Metadata")
 	// BlockSyncerService defines the name of block sync service
 	BlockSyncerService = strings.ToLower("BlockSyncer")
+	// BlockSyncerServiceBackup defines the name of block sync service
+	BlockSyncerServiceBackup = strings.ToLower("BlockSyncerBackup")
 	// ManagerService defines the name of manager service
 	ManagerService = strings.ToLower("Manager")
 	// MetricsService defines the name of metrics service
@@ -121,6 +123,8 @@ const (
 	SpSealPrivKey = "SIGNER_SEAL_PRIV_KEY"
 	// DsnBlockSyncer defines env variable name for block syncer dsn
 	DsnBlockSyncer = "BLOCK_SYNCER_DSN"
+	// DsnBlockSyncerBackup defines env variable name for block syncer backup dsn
+	DsnBlockSyncerBackup = "BLOCK_SYNCER_BK_DSN"
 	// P2PPrivateKey defines env variable for p2p protocol private key
 	P2PPrivateKey = "P2P_PRIVATE_KEY"
 )
@@ -252,6 +256,10 @@ const (
 	MaxCallMsgSize = 25 * 1024 * 1024
 	// MaxRetryCount defines getting the latest height from the RPC client max retry count
 	MaxRetryCount = 50
+	// DefaultBlockHeightDiff defines default block height diff of main and backup service
+	DefaultBlockHeightDiff = 100
+	// DefaultCheckDiffPeriod defines check interval of block height diff
+	DefaultCheckDiffPeriod = 1
 	// DefaultPingPeriod defines p2p node ping period
 	DefaultPingPeriod = 1
 	// DefaultSpFreeReadQuotaSize defines sp bucket's default free quota size, the SP can modify it by itself

--- a/service/blocksyncer/block_syncer_config.go
+++ b/service/blocksyncer/block_syncer_config.go
@@ -9,8 +9,10 @@ import (
 type Config struct {
 	Modules        []string
 	Dsn            string
+	DsnBackup      string
 	RecreateTables bool
 	Workers        uint
+	Backup         bool
 }
 
 func getDBConfigFromEnv(dsn string) (string, error) {

--- a/service/blocksyncer/block_syncer_service.go
+++ b/service/blocksyncer/block_syncer_service.go
@@ -1,6 +1,7 @@
 package blocksyncer
 
 import (
+	"context"
 	"time"
 
 	"github.com/bnb-chain/greenfield-storage-provider/model"
@@ -13,10 +14,10 @@ import (
 )
 
 // enqueueNewBlocks enqueues new block heights onto the provided queue.
-func enqueueNewBlocks(exportQueue types.HeightQueue, ctx *parser.Context, currHeight uint64) {
+func (s *BlockSyncer) enqueueNewBlocks(exportQueue types.HeightQueue, ctx *parser.Context, currHeight uint64) {
 	// Enqueue upcoming heights
 	for {
-		latestBlockHeightAny := LatestBlockHeight.Load()
+		latestBlockHeightAny := Cast(s.parserCtx.Indexer).GetLatestBlockHeight().Load()
 		latestBlockHeight := latestBlockHeightAny.(int64)
 		// Enqueue all heights from the current height up to the latest height
 		for ; currHeight <= uint64(latestBlockHeight); currHeight++ {
@@ -42,4 +43,62 @@ func mustGetLatestHeight(ctx *parser.Context) uint64 {
 	}
 
 	return 0
+}
+
+func Cast(indexer parser.Indexer) *Impl {
+	s, ok := indexer.(*Impl)
+	if !ok {
+		panic("cannot cast")
+	}
+	return s
+}
+
+func CheckProgress() {
+	for {
+		epochMaster, err := MainService.parserCtx.Database.GetEpoch(context.TODO())
+		if err != nil {
+			continue
+		}
+		epochSlave, err := BackupService.parserCtx.Database.GetEpoch(context.TODO())
+		if err != nil {
+			continue
+		}
+		if epochMaster.BlockHeight-epochSlave.BlockHeight < model.DefaultBlockHeightDiff {
+			SwitchMasterDBFlag()
+			MainService.Stop(context.Background())
+			break
+		}
+		time.Sleep(time.Minute * model.DefaultCheckDiffPeriod)
+	}
+}
+
+func SwitchMasterDBFlag() error {
+	masterFlag, err := FlagDB.GetMasterDB(context.TODO())
+	if err != nil {
+		return err
+	}
+
+	//switch flag
+	masterFlag.IsMaster = masterFlag.IsMaster != true
+	if err = FlagDB.SetMasterDB(context.TODO(), masterFlag); err != nil {
+		return err
+	}
+	log.Infof("DB switched")
+	return nil
+}
+
+func determineMainService() error {
+	masterFlag, err := FlagDB.GetMasterDB(context.TODO())
+	if err != nil {
+		return err
+	}
+	if masterFlag.IsMaster {
+		return nil
+	} else {
+		//switch role
+		temp := MainService
+		MainService = BackupService
+		BackupService = temp
+	}
+	return nil
 }


### PR DESCRIPTION
### Description

add dual db warm up support for block syncer

### Rationale

each time we release a new version, block syncer need lot of time to get the latest block height. So we init 2 db when blocksyncer starts and switch master-slave relation when new db get the latest height
  
### Example

N/A

### Changes

Notable changes: 
* init 2 block syncer service when start up
* DB switch when new DB is ready
*  upgrade juno version for new configs
