### PR TITLE
feat: add private object access for universal endpoint

### DIFF
--- a/service/gateway/response_util.go
+++ b/service/gateway/response_util.go
@@ -30,6 +30,7 @@ var (
 	InvalidRange       = &errorDescription{errorCode: "InvalidRange", errorMessage: "Range is invalid", statusCode: http.StatusBadRequest}
 	InvalidAddress     = &errorDescription{errorCode: "InvalidAddress", errorMessage: "Address is illegal", statusCode: http.StatusBadRequest}
 	SignatureNotMatch  = &errorDescription{errorCode: "SignatureDoesNotMatch", errorMessage: "SignatureDoesNotMatch", statusCode: http.StatusForbidden}
+	SignatureExpired   = &errorDescription{errorCode: "SignatureExpired", errorMessage: "SignatureExpired", statusCode: http.StatusForbidden}
 	AccessDenied       = &errorDescription{errorCode: "AccessDenied", errorMessage: "Access Denied", statusCode: http.StatusForbidden}
 	OutOfQuota         = &errorDescription{errorCode: "AccessDenied", errorMessage: "Out of Quota", statusCode: http.StatusForbidden}
 	NoSuchKey          = &errorDescription{errorCode: "NoSuchKey", errorMessage: "The specified key does not exist.", statusCode: http.StatusNotFound}


### PR DESCRIPTION
### Description

Add access for private object for Universal Endpoint

### Rationale

Owners might want to share not only their publicly viewable files, but also private files. They can set sharing deadlines for each file and sign the sharing decision to create Universal Endpoint share link.

### Example

{endpoint}/download/{bucket_name}/{object_name}?expires=2023-05-16T13:28:58Z&signature=0xb0322371e12f061b70e09fe0e35109bc2b627c01e39d751c1dccb9d195f7dbbe7e31d6ebbd659e7997ce59777a2cd96cc5f45f7efe60aecb42aa02f3a9efdfc51b

### Changes

Notable changes: 
* Gateway
* Downloader