### PR TITLE
feat: support full-memory replicate task

### DIFF
--- a/pkg/p2p/node.go
+++ b/pkg/p2p/node.go
@@ -37,12 +37,12 @@ type Node struct {
 	stopCh            chan struct{}
 }
 
-// NewNode return an instance of Node
+// NewNode return an instance of Node.
 func NewNode(config *NodeConfig, SPAddr string, signer *signerclient.SignerClient) (*Node, error) {
 	if config.PingPeriod < PingPeriodMin {
 		config.PingPeriod = PingPeriodMin
 	}
-	privKey, localAddr, bootstrapIDs, bootstrapAddrs, err := config.ParseConfing()
+	privKey, localAddr, bootstrapIDs, bootstrapAddrs, err := config.ParseConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +197,7 @@ func (n *Node) eventLoop() {
 // broadcast sends request to all p2p nodes
 func (n *Node) broadcast(pc protocol.ID, data proto.Message) {
 	for _, peerID := range n.node.Peerstore().PeersWithAddrs() {
-		log.Debugw("broadcast msg to peer", "peer_id", peerID, "protocol", pc)
+		// log.Debugw("broadcast msg to peer", "peer_id", peerID, "protocol", pc)
 		if strings.Compare(n.node.ID().String(), peerID.String()) == 0 {
 			continue
 		}
@@ -222,7 +222,7 @@ func (n *Node) sendToPeer(peerID peer.ID, pc protocol.ID, data proto.Message) er
 		n.peers.DeletePeer(peerID)
 		return err
 	}
-	log.Debugw("success to send msg", "peer_id", peerID, "protocol", pc, "msg", data.String())
+	// log.Debugw("succeed to send msg", "peer_id", peerID, "protocol", pc, "msg", data.String())
 	s.Close()
 	return err
 }

--- a/pkg/p2p/node_config.go
+++ b/pkg/p2p/node_config.go
@@ -49,8 +49,8 @@ func (cfg *NodeConfig) overrideConfigFromEnv() {
 	}
 }
 
-// ParseConfing parsers the configuration into a format that go-libp2p can use
-func (cfg *NodeConfig) ParseConfing() (privKey crypto.PrivKey, hostAddr ma.Multiaddr, bootstrapIDs []peer.ID, bootstrapAddrs []ma.Multiaddr, err error) {
+// ParseConfig parsers the configuration into a format that go-libp2p can use
+func (cfg *NodeConfig) ParseConfig() (privKey crypto.PrivKey, hostAddr ma.Multiaddr, bootstrapIDs []peer.ID, bootstrapAddrs []ma.Multiaddr, err error) {
 	cfg.overrideConfigFromEnv()
 	if len(cfg.P2PPrivateKey) > 0 {
 		priKeyBytes, err := hex.DecodeString(cfg.P2PPrivateKey)

--- a/pkg/p2p/ping.go
+++ b/pkg/p2p/ping.go
@@ -31,7 +31,7 @@ func (n *Node) onPing(s network.Stream) {
 			log.Warnw("failed to response ping", "peer_id", peerID, "error", err)
 			return
 		}
-		log.Debugw("success to response ping", "peer_id", peerID)
+		// log.Debugw("succeed to response ping", "peer_id", peerID)
 	}()
 	ping := &types.Ping{}
 	buf, err := io.ReadAll(s)
@@ -46,7 +46,7 @@ func (n *Node) onPing(s network.Stream) {
 		log.Errorw("failed to unmarshal ping msg", "error", err)
 		return
 	}
-	log.Debugf("%s received ping request from %s. Message: %s", s.Conn().LocalPeer(), s.Conn().RemotePeer(), ping.String())
+	// log.Debugf("%s received ping request from %s. Message: %s", s.Conn().LocalPeer(), s.Conn().RemotePeer(), ping.String())
 
 	err = types.VerifySignature(ping.GetSpOperatorAddress(), ping.GetSignBytes(), ping.GetSignature())
 	if err != nil {
@@ -66,7 +66,7 @@ func (n *Node) onPing(s network.Stream) {
 			nodeInfo.MultiAddr = append(nodeInfo.MultiAddr, addr.String())
 		}
 		pong.Nodes = append(pong.Nodes, nodeInfo)
-		log.Debugw("send node to remote", "node_id", pID.String(), "remote_node", s.Conn().RemotePeer())
+		// log.Debugw("send node to remote", "node_id", pID.String(), "remote_node", s.Conn().RemotePeer())
 	}
 	pong.SpOperatorAddress = n.SpOperatorAddress
 	pong, err = n.signer.SignPongMsg(context.Background(), pong)
@@ -89,7 +89,7 @@ func (n *Node) onPong(s network.Stream) {
 			log.Warnw("failed to receive pong", "peer_id", peerID, "error", err)
 			return
 		}
-		log.Debugw("success to receive pong", "peer_id", peerID)
+		// log.Debugw("succeed to receive pong", "peer_id", peerID)
 	}()
 	pong := &types.Pong{}
 	buf, err := io.ReadAll(s)
@@ -104,7 +104,7 @@ func (n *Node) onPong(s network.Stream) {
 		log.Errorw("failed to unmarshal ping msg", "error", err)
 		return
 	}
-	log.Debugf("%s received pong request from %s.", s.Conn().LocalPeer(), s.Conn().RemotePeer())
+	// log.Debugf("%s received pong request from %s.", s.Conn().LocalPeer(), s.Conn().RemotePeer())
 
 	err = types.VerifySignature(pong.GetSpOperatorAddress(), pong.GetSignBytes(), pong.GetSignature())
 	if err != nil {
@@ -127,6 +127,6 @@ func (n *Node) onPong(s network.Stream) {
 			addrs = append(addrs, addr)
 		}
 		n.node.Peerstore().AddAddrs(pID, addrs, peerstore.PermanentAddrTTL)
-		log.Debugw("receive node from remote and permanent", "remote_node", s.Conn().RemotePeer(), "node_id", pID)
+		// log.Debugw("receive node from remote and permanent", "remote_node", s.Conn().RemotePeer(), "node_id", pID)
 	}
 }

--- a/service/gateway/object_handler.go
+++ b/service/gateway/object_handler.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/bnb-chain/greenfield-storage-provider/util"
 	"github.com/bnb-chain/greenfield/types/s3util"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -17,7 +18,6 @@ import (
 	"github.com/bnb-chain/greenfield-storage-provider/service/downloader/types"
 	metatypes "github.com/bnb-chain/greenfield-storage-provider/service/metadata/types"
 	uploadertypes "github.com/bnb-chain/greenfield-storage-provider/service/uploader/types"
-	"github.com/bnb-chain/greenfield-storage-provider/util"
 )
 
 // getObjectHandler handles the get object request
@@ -101,6 +101,12 @@ func (gateway *Gateway) getObjectHandler(w http.ResponseWriter, r *http.Request)
 		errDescription = makeErrorDescription(err)
 		return
 	}
+	w.Header().Set(model.GnfdRequestIDHeader, reqContext.requestID)
+	w.Header().Set(model.ContentTypeHeader, reqContext.objectInfo.GetContentType())
+	if !isRange {
+		w.Header().Set(model.ContentLengthHeader, util.Uint64ToString(reqContext.objectInfo.GetPayloadSize()))
+	}
+
 	for {
 		resp, err := stream.Recv()
 		if err == io.EOF {
@@ -132,11 +138,6 @@ func (gateway *Gateway) getObjectHandler(w http.ResponseWriter, r *http.Request)
 			return
 		}
 		size = size + writeN
-	}
-	w.Header().Set(model.GnfdRequestIDHeader, reqContext.requestID)
-	w.Header().Set(model.ContentTypeHeader, reqContext.objectInfo.GetContentType())
-	if !isRange {
-		w.Header().Set(model.ContentLengthHeader, util.Uint64ToString(reqContext.objectInfo.GetPayloadSize()))
 	}
 }
 
@@ -210,6 +211,10 @@ func (gateway *Gateway) putObjectHandler(w http.ResponseWriter, r *http.Request)
 		errDescription = makeErrorDescription(err)
 		return
 	}
+	w.Header().Set(model.GnfdRequestIDHeader, reqContext.requestID)
+	// Greenfield has an integrity hash, so there is no need for an etag
+	// w.Header().Set(model.ETagHeader, hex.EncodeToString(md5Hash.Sum(nil)))
+
 	for {
 		readN, err = r.Body.Read(buf)
 		if err != nil && err != io.EOF {
@@ -247,10 +252,6 @@ func (gateway *Gateway) putObjectHandler(w http.ResponseWriter, r *http.Request)
 			break
 		}
 	}
-
-	w.Header().Set(model.GnfdRequestIDHeader, reqContext.requestID)
-	// Greenfield has an integrity hash, so there is no need for an etag
-	// w.Header().Set(model.ETagHeader, hex.EncodeToString(md5Hash.Sum(nil)))
 }
 
 // getObjectByUniversalEndpointHandler handles the get object request sent by universal endpoint
@@ -398,6 +399,7 @@ func (gateway *Gateway) getObjectByUniversalEndpointHandler(w http.ResponseWrite
 	} else {
 		w.Header().Set(model.ContentDispositionHeader, model.ContentDispositionInlineValue)
 	}
+	w.Header().Set(model.GnfdRequestIDHeader, reqContext.requestID)
 
 	for {
 		resp, err := stream.Recv()
@@ -431,7 +433,6 @@ func (gateway *Gateway) getObjectByUniversalEndpointHandler(w http.ResponseWrite
 		}
 		size = size + writeN
 	}
-	w.Header().Set(model.GnfdRequestIDHeader, reqContext.requestID)
 }
 
 // downloadObjectByUniversalEndpointHandler handles the download object request sent by universal endpoint

--- a/service/tasknode/replicate_object_task.go
+++ b/service/tasknode/replicate_object_task.go
@@ -4,151 +4,76 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
-	"errors"
+	"fmt"
 	"io"
+	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	sdkmath "cosmossdk.io/math"
 	"github.com/bnb-chain/greenfield-common/go/redundancy"
 	"github.com/bnb-chain/greenfield-storage-provider/model"
-	merrors "github.com/bnb-chain/greenfield-storage-provider/model/errors"
-	"github.com/bnb-chain/greenfield-storage-provider/model/piecestore"
-	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/metrics"
-	p2ptypes "github.com/bnb-chain/greenfield-storage-provider/pkg/p2p/types"
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/rcmgr"
 	gatewayclient "github.com/bnb-chain/greenfield-storage-provider/service/gateway/client"
 	servicetypes "github.com/bnb-chain/greenfield-storage-provider/service/types"
-	"github.com/bnb-chain/greenfield-storage-provider/util/maps"
 	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
-	"github.com/bnb-chain/greenfield/x/storage/types"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	merrors "github.com/bnb-chain/greenfield-storage-provider/model/errors"
+	"github.com/bnb-chain/greenfield-storage-provider/model/piecestore"
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
+	p2ptypes "github.com/bnb-chain/greenfield-storage-provider/pkg/p2p/types"
+	"github.com/bnb-chain/greenfield-storage-provider/util/maps"
 )
 
-const (
-	// ReplicateFactor defines the redundancy of replication
-	// TODO:: will update to （1, 2] on main net
-	ReplicateFactor = 1
-	// GetApprovalTimeout defines the timeout of getting secondary sp approval
-	GetApprovalTimeout = 10
-	// MaxSealRetryNumber defines max number of retrying seal object
-	MaxSealRetryNumber = 3
-)
-
-// streamReader is used to stream produce/consume piece data stream.
-type streamReader struct {
-	pRead  *io.PipeReader
-	pWrite *io.PipeWriter
+// PieceDataReader defines [][]pieceData Reader.
+type PieceDataReader struct {
+	pieceData [][]byte
+	outerIdx  int
+	innerIdx  int
 }
 
 // Read populates the given byte slice with data and returns the number of bytes populated and an error value.
 // It returns an io.EOF error when the stream ends.
-func (s *streamReader) Read(buf []byte) (n int, err error) {
-	return s.pRead.Read(buf)
-}
-
-// streamReaderGroup is used to the primary sp replicate object piece data to other secondary sps.
-type streamReaderGroup struct {
-	task            *replicateObjectTask
-	pieceSize       int
-	streamReaderMap map[int]*streamReader
-}
-
-// newStreamReaderGroup returns a streamReaderGroup
-func newStreamReaderGroup(t *replicateObjectTask, excludeIndexMap map[int]bool) (*streamReaderGroup, error) {
-	var atLeastHasOne bool
-	sg := &streamReaderGroup{
-		task:            t,
-		streamReaderMap: make(map[int]*streamReader),
+func (p *PieceDataReader) Read(buf []byte) (n int, err error) {
+	if len(buf) == 0 {
+		return 0, fmt.Errorf("failed to read due to invalid args")
 	}
-	for segmentPieceIdx := 0; segmentPieceIdx < t.segmentPieceNumber; segmentPieceIdx++ {
-		for idx := 0; idx < t.redundancyNumber; idx++ {
-			if excludeIndexMap[idx] {
-				continue
-			}
-			sg.streamReaderMap[idx] = &streamReader{}
-			sg.streamReaderMap[idx].pRead, sg.streamReaderMap[idx].pWrite = io.Pipe()
-			atLeastHasOne = true
+
+	readLen := 0
+	for p.outerIdx < len(p.pieceData) {
+		curReadLen := copy(buf[readLen:], p.pieceData[p.outerIdx][p.innerIdx:])
+		p.innerIdx += curReadLen
+		if p.innerIdx == len(p.pieceData[p.outerIdx]) {
+			p.outerIdx += 1
+			p.innerIdx = 0
+		}
+		readLen = readLen + curReadLen
+		if readLen == len(buf) {
+			break
 		}
 	}
-	if !atLeastHasOne {
-		return nil, merrors.ErrInvalidParams
+	if readLen != 0 {
+		return readLen, nil
 	}
-	return sg, nil
+	return 0, io.EOF
 }
 
-// produceStreamPieceData produce stream piece data
-func (sg *streamReaderGroup) produceStreamPieceData() {
-	ch := make(chan int)
-	go func(pieceSizeCh chan int) {
-		defer close(pieceSizeCh)
-		gotPieceSize := false
-
-		for segmentPieceIdx := 0; segmentPieceIdx < sg.task.segmentPieceNumber; segmentPieceIdx++ {
-			segmentPieceKey := piecestore.EncodeSegmentPieceKey(sg.task.objectInfo.Id.Uint64(), uint32(segmentPieceIdx))
-			segmentPieceData, err := sg.task.taskNode.pieceStore.GetPiece(context.Background(), segmentPieceKey, 0, 0)
-			if err != nil {
-				for idx := range sg.streamReaderMap {
-					sg.streamReaderMap[idx].pWrite.CloseWithError(err)
-				}
-				log.Errorw("failed to get piece data", "piece_key", segmentPieceKey, "error", err)
-				return
-			}
-			if sg.task.objectInfo.GetRedundancyType() == types.REDUNDANCY_EC_TYPE {
-				ecPieceData, err := redundancy.EncodeRawSegment(segmentPieceData,
-					int(sg.task.storageParams.GetRedundantDataChunkNum()),
-					int(sg.task.storageParams.GetRedundantParityChunkNum()))
-				if err != nil {
-					for idx := range sg.streamReaderMap {
-						sg.streamReaderMap[idx].pWrite.CloseWithError(err)
-					}
-					log.Errorw("failed to encode ec piece data", "error", err)
-					return
-				}
-				if !gotPieceSize {
-					pieceSizeCh <- len(ecPieceData[0])
-					gotPieceSize = true
-				}
-				for idx := range sg.streamReaderMap {
-					sg.streamReaderMap[idx].pWrite.Write(ecPieceData[idx])
-					log.Debugw("succeed to produce an ec piece data", "piece_len", len(ecPieceData[idx]), "redundancy_index", idx)
-				}
-			} else {
-				if !gotPieceSize {
-					pieceSizeCh <- len(segmentPieceData)
-					gotPieceSize = true
-				}
-				for idx := range sg.streamReaderMap {
-					sg.streamReaderMap[idx].pWrite.Write(segmentPieceData)
-					log.Debugw("succeed to produce an segment piece data", "piece_len", len(segmentPieceData), "redundancy_index", idx)
-				}
-			}
-		}
-		for idx := range sg.streamReaderMap {
-			sg.streamReaderMap[idx].pWrite.Close()
-			log.Debugw("succeed to finish a piece stream",
-				"redundancy_index", idx, "redundancy_type", sg.task.objectInfo.GetRedundancyType())
-		}
-	}(ch)
-	sg.pieceSize = <-ch
-}
-
-// streamPieceDataReplicator replicates a piece stream to the target sp
-type streamPieceDataReplicator struct {
+// pieceDataReplicator replicates a piece data to the target sp.
+type pieceDataReplicator struct {
 	task                  *replicateObjectTask
-	dataSize              int64
-	pieceSize             uint32
 	redundancyIndex       uint32
 	expectedIntegrityHash []byte
-	streamReader          *streamReader
+	pieceDataReader       *PieceDataReader
 	sp                    *sptypes.StorageProvider
 	approval              *p2ptypes.GetApprovalResponse
 }
 
 // replicate is used to start replicate the piece stream
-func (r *streamPieceDataReplicator) replicate() (integrityHash []byte, signature []byte, err error) {
+func (r *pieceDataReplicator) replicate() (integrityHash []byte, signature []byte, err error) {
 	var (
 		gwClient      *gatewayclient.GatewayClient
 		originMsgHash []byte
@@ -162,7 +87,7 @@ func (r *streamPieceDataReplicator) replicate() (integrityHash []byte, signature
 		return
 	}
 	integrityHash, signature, err = gwClient.ReplicateObjectPieceStream(r.task.objectInfo.Id.Uint64(),
-		r.pieceSize, r.dataSize, r.redundancyIndex, r.approval, r.streamReader)
+		uint32(r.task.pieceSize), r.task.replicateDataSize, r.redundancyIndex, r.approval, r.pieceDataReader)
 	if err != nil {
 		log.Errorw("failed to replicate object piece stream",
 			"endpoint", r.sp.GetEndpoint(), "error", err)
@@ -196,23 +121,25 @@ func (r *streamPieceDataReplicator) replicate() (integrityHash []byte, signature
 }
 
 // replicateObjectTask represents the background object replicate task, include replica/ec redundancy type.
+// The task loads all segment piece data to memory and then replicates, thus consumes more memory than stream-task.
 type replicateObjectTask struct {
 	ctx                 context.Context
 	taskNode            *TaskNode
-	objectInfo          *types.ObjectInfo
+	objectInfo          *storagetypes.ObjectInfo
 	approximateMemSize  int
 	storageParams       *storagetypes.Params
 	segmentPieceNumber  int
 	redundancyNumber    int
 	replicateDataSize   int64
+	pieceSize           int64
 	mux                 sync.Mutex
 	spMap               map[string]*sptypes.StorageProvider
 	approvalResponseMap map[string]*p2ptypes.GetApprovalResponse
 	sortedSpEndpoints   []string
 }
 
-// newReplicateObjectTask returns a ReplicateObjectTask instance
-func newReplicateObjectTask(ctx context.Context, task *TaskNode, object *types.ObjectInfo) (*replicateObjectTask, error) {
+// newReplicateObjectTask returns a ReplicateObjectTask instance.
+func newReplicateObjectTask(ctx context.Context, task *TaskNode, object *storagetypes.ObjectInfo) (*replicateObjectTask, error) {
 	if ctx == nil || task == nil || object == nil {
 		return nil, merrors.ErrInvalidParams
 	}
@@ -252,18 +179,19 @@ func (t *replicateObjectTask) init() error {
 		return err
 	}
 	t.sortedSpEndpoints = maps.SortKeys(t.approvalResponseMap)
+
 	// calculate the reserve memory, which is used in execute time
-	t.approximateMemSize = int(float64(t.storageParams.GetMaxSegmentSize()) *
-		(float64(t.redundancyNumber)/float64(t.storageParams.GetRedundantDataChunkNum()) + 1))
-	if t.objectInfo.GetPayloadSize() < t.storageParams.GetMaxSegmentSize() {
-		t.approximateMemSize = int(float64(t.objectInfo.GetPayloadSize()) *
-			(float64(t.redundancyNumber)/float64(t.storageParams.GetRedundantDataChunkNum()) + 1))
+	if t.objectInfo.GetRedundancyType() == storagetypes.REDUNDANCY_REPLICA_TYPE {
+		t.approximateMemSize = (int(t.storageParams.GetRedundantDataChunkNum()) +
+			int(t.storageParams.GetRedundantParityChunkNum())) *
+			int(t.objectInfo.GetPayloadSize())
+	} else {
+		t.approximateMemSize = int(math.Ceil(
+			((float64(t.storageParams.GetRedundantDataChunkNum())+float64(t.storageParams.GetRedundantParityChunkNum()))/
+				float64(t.storageParams.GetRedundantDataChunkNum()) + 1) *
+				float64(t.objectInfo.GetPayloadSize())))
 	}
-	err = t.ComputeReplicatePiecesSizeForOneSP()
-	if err != nil {
-		log.CtxErrorw(t.ctx, "failed to compute replicate pieces data size per sp", "error", err)
-		return err
-	}
+
 	return nil
 }
 
@@ -278,16 +206,18 @@ func (t *replicateObjectTask) execute(waitCh chan error) {
 		sealMsg              *storagetypes.MsgSealObject
 		progressInfo         *servicetypes.ReplicatePieceInfo
 	)
+
 	// runtime initialization
 	startTime = time.Now()
 	succeedIndexMap = make(map[int]bool, t.redundancyNumber)
-	isAllSucceed := func(inputIndexMap map[int]bool) bool {
+	getNeedReplicateNumber := func(inputIndexMap map[int]bool) int {
+		var needReplicateNumber int
 		for i := 0; i < t.redundancyNumber; i++ {
 			if !inputIndexMap[i] {
-				return false
+				needReplicateNumber++
 			}
 		}
-		return true
+		return needReplicateNumber
 	}
 	metrics.ReplicateObjectTaskGauge.WithLabelValues(model.TaskNodeService).Inc()
 	t.updateTaskState(servicetypes.JobState_JOB_STATE_REPLICATE_OBJECT_DOING)
@@ -305,6 +235,12 @@ func (t *replicateObjectTask) execute(waitCh chan error) {
 	}
 	log.CtxDebugw(t.ctx, "reserve memory from resource manager",
 		"reserve_size", t.approximateMemSize, "resource_state", rcmgr.GetServiceState(model.TaskNodeService))
+	replicateData, err := t.encodeReplicateData()
+	if err != nil {
+		log.CtxErrorw(t.ctx, "failed to encode replicate data", "error", err)
+		waitCh <- err
+		return
+	}
 	waitCh <- nil
 
 	// defer func
@@ -314,7 +250,7 @@ func (t *replicateObjectTask) execute(waitCh chan error) {
 		observer := metrics.SealObjectTimeHistogram.WithLabelValues(model.TaskNodeService)
 		observer.Observe(time.Since(startTime).Seconds())
 
-		if isAllSucceed(succeedIndexMap) {
+		if getNeedReplicateNumber(succeedIndexMap) == 0 {
 			metrics.SealObjectTotalCounter.WithLabelValues("success").Inc()
 			log.CtxInfo(t.ctx, "succeed to seal object on chain")
 		} else {
@@ -358,75 +294,80 @@ func (t *replicateObjectTask) execute(waitCh chan error) {
 	progressInfo = &servicetypes.ReplicatePieceInfo{
 		PieceInfos: make([]*servicetypes.PieceInfo, t.redundancyNumber),
 	}
-
 	for {
-		if isAllSucceed(succeedIndexMap) {
+		if getNeedReplicateNumber(succeedIndexMap) == 0 {
 			log.CtxInfo(t.ctx, "succeed to replicate object data")
 			break
 		}
-		var sg *streamReaderGroup
-		sg, err = newStreamReaderGroup(t, succeedIndexMap)
-		if err != nil {
-			log.CtxErrorw(t.ctx, "failed to new stream reader group", "error", err)
-			return
-		}
-		if len(sg.streamReaderMap) > len(t.sortedSpEndpoints) {
+		if getNeedReplicateNumber(succeedIndexMap) > len(t.sortedSpEndpoints) {
 			log.CtxError(t.ctx, "failed to replicate due to sp is not enough")
 			err = merrors.ErrExhaustedSP
 			return
 		}
-		sg.produceStreamPieceData()
 
 		var wg sync.WaitGroup
-		for redundancyIdx := range sg.streamReaderMap {
-			wg.Add(1)
-			go func(rIdx int) {
-				defer wg.Done()
+		for rIdx := 0; rIdx < t.redundancyNumber; rIdx++ {
+			succeedIndexMapMutex.Lock()
+			_, hasReplicated := succeedIndexMap[rIdx]
+			succeedIndexMapMutex.Unlock()
 
-				sp, approval, innerErr := pickSp()
-				if innerErr != nil {
-					log.CtxErrorw(t.ctx, "failed to pick a secondary sp", "redundancy_index", rIdx, "error", innerErr)
-					return
-				}
-				r := &streamPieceDataReplicator{
-					task:                  t,
-					dataSize:              t.replicateDataSize,
-					pieceSize:             uint32(sg.pieceSize),
-					redundancyIndex:       uint32(rIdx),
-					expectedIntegrityHash: sg.task.objectInfo.GetChecksums()[rIdx+1],
-					streamReader:          sg.streamReaderMap[rIdx],
-					sp:                    sp,
-					approval:              approval,
-				}
-				integrityHash, signature, innerErr := r.replicate()
-				if innerErr != nil {
-					log.CtxErrorw(t.ctx, "failed to replicate piece stream", "redundancy_index", rIdx, "error", innerErr)
-					return
-				}
+			if !hasReplicated {
+				wg.Add(1)
+				log.CtxDebugw(t.ctx, "start to replicate object", "redundancy_index", rIdx)
+				go func(rIdx int) {
+					defer wg.Done()
 
-				succeedIndexMapMutex.Lock()
-				succeedIndexMap[rIdx] = true
-				succeedIndexMapMutex.Unlock()
+					sp, approval, innerErr := pickSp()
+					if innerErr != nil {
+						log.CtxErrorw(t.ctx, "failed to pick a secondary sp", "redundancy_index", rIdx, "error", innerErr)
+						return
+					}
+					var toReplicateData [][]byte
+					for idx := 0; idx < t.segmentPieceNumber; idx++ {
+						toReplicateData = append(toReplicateData, replicateData[idx][rIdx])
+					}
+					r := &pieceDataReplicator{
+						task:                  t,
+						redundancyIndex:       uint32(rIdx),
+						expectedIntegrityHash: t.objectInfo.GetChecksums()[rIdx+1],
+						pieceDataReader: &PieceDataReader{
+							pieceData: toReplicateData,
+						},
+						sp:       sp,
+						approval: approval,
+					}
+					integrityHash, signature, innerErr := r.replicate()
+					if innerErr != nil {
+						log.CtxErrorw(t.ctx, "failed to replicate piece stream", "redundancy_index", rIdx, "error", innerErr)
+						return
+					}
 
-				sealMsg.GetSecondarySpAddresses()[rIdx] = sp.GetOperator().String()
-				sealMsg.GetSecondarySpSignatures()[rIdx] = signature
-				progressInfo.PieceInfos[rIdx] = &servicetypes.PieceInfo{
-					ObjectInfo:    t.objectInfo,
-					Signature:     signature,
-					IntegrityHash: integrityHash,
-				}
-				t.objectInfo.SecondarySpAddresses[rIdx] = sp.GetOperator().String()
-				t.taskNode.spDB.SetObjectInfo(t.objectInfo.Id.Uint64(), t.objectInfo)
-				t.taskNode.cache.Add(t.objectInfo.Id.Uint64(), progressInfo)
-				log.CtxInfow(t.ctx, "succeed to replicate object piece stream to the target sp",
-					"sp", sp.GetOperator(), "endpoint", sp.GetEndpoint(), "redundancy_index", rIdx)
-			}(redundancyIdx)
+					succeedIndexMapMutex.Lock()
+					succeedIndexMap[rIdx] = true
+					succeedIndexMapMutex.Unlock()
+
+					sealMsg.GetSecondarySpAddresses()[rIdx] = sp.GetOperator().String()
+					sealMsg.GetSecondarySpSignatures()[rIdx] = signature
+					progressInfo.PieceInfos[rIdx] = &servicetypes.PieceInfo{
+						ObjectInfo:    t.objectInfo,
+						Signature:     signature,
+						IntegrityHash: integrityHash,
+					}
+					t.objectInfo.SecondarySpAddresses[rIdx] = sp.GetOperator().String()
+					t.taskNode.spDB.SetObjectInfo(t.objectInfo.Id.Uint64(), t.objectInfo)
+					t.taskNode.cache.Add(t.objectInfo.Id.Uint64(), progressInfo)
+					log.CtxInfow(t.ctx, "succeed to replicate object piece stream to the target sp",
+						"sp", sp.GetOperator(), "endpoint", sp.GetEndpoint(), "redundancy_index", rIdx)
+
+				}(rIdx)
+			}
+
 		}
 		wg.Wait()
 	}
 
 	// seal onto the greenfield chain
-	if isAllSucceed(succeedIndexMap) {
+	if getNeedReplicateNumber(succeedIndexMap) == 0 { // succeed
 		retry := 0
 		for {
 			if retry >= MaxSealRetryNumber {
@@ -437,7 +378,7 @@ func (t *replicateObjectTask) execute(waitCh chan error) {
 			t.updateTaskState(servicetypes.JobState_JOB_STATE_SIGN_OBJECT_DOING)
 			_, err = t.taskNode.signer.SealObjectOnChain(context.Background(), sealMsg)
 			if err != nil {
-				t.taskNode.spDB.UpdateJobState(t.objectInfo.Id.Uint64(), servicetypes.JobState_JOB_STATE_SIGN_OBJECT_ERROR)
+				t.updateTaskState(servicetypes.JobState_JOB_STATE_SIGN_OBJECT_ERROR)
 				log.CtxErrorw(t.ctx, "failed to sign object by signer", "error", err, "retry", retry)
 				continue
 			}
@@ -455,42 +396,60 @@ func (t *replicateObjectTask) execute(waitCh chan error) {
 	} // the else failed case is in defer func
 }
 
-func (t *replicateObjectTask) ComputeReplicatePiecesSizeForOneSP() error {
-	if t.segmentPieceNumber <= 0 {
-		return errors.New("segment piece number invalid")
+// encodeReplicateData load segment data and encode according to redundancy type.
+func (t *replicateObjectTask) encodeReplicateData() (data [][][]byte, err error) {
+	var (
+		wg            sync.WaitGroup
+		succeedNumber int64
+	)
+	for i := 0; i < t.segmentPieceNumber; i++ {
+		data = append(data, make([][]byte, t.redundancyNumber))
 	}
 
-	pieceSize := func(idx int) (int, error) {
-		segmentPieceKey := piecestore.EncodeSegmentPieceKey(t.objectInfo.Id.Uint64(), uint32(idx))
-		segmentPieceData, err := t.taskNode.pieceStore.GetPiece(context.Background(), segmentPieceKey, 0, 0)
-		if err != nil {
-			return 0, err
-		}
-		if t.objectInfo.GetRedundancyType() == types.REDUNDANCY_EC_TYPE {
-			ecPieceData, err := redundancy.EncodeRawSegment(segmentPieceData,
-				int(t.storageParams.GetRedundantDataChunkNum()),
-				int(t.storageParams.GetRedundantParityChunkNum()))
-			if err != nil {
-				return 0, err
+	log.CtxDebugw(t.ctx, "start to encode replicate data", "segment_number", t.segmentPieceNumber,
+		"redundancy_number", t.redundancyNumber)
+	for segIdx := 0; segIdx < t.segmentPieceNumber; segIdx++ {
+		wg.Add(1)
+		go func(segIdx int) {
+			defer wg.Done()
+			key := piecestore.EncodeSegmentPieceKey(t.objectInfo.Id.Uint64(), uint32(segIdx))
+			segmentPieceData, innerErr := t.taskNode.pieceStore.GetPiece(t.ctx, key, 0, 0)
+			if innerErr != nil {
+				log.CtxErrorw(t.ctx, "failed to get segment piece", "key", key)
+				return
 			}
-			return len(ecPieceData[0]), nil
-		} else {
-			return len(segmentPieceData), nil
-		}
+			if t.objectInfo.GetRedundancyType() == storagetypes.REDUNDANCY_EC_TYPE {
+				encodeData, innerErr := redundancy.EncodeRawSegment(segmentPieceData,
+					int(t.storageParams.GetRedundantDataChunkNum()),
+					int(t.storageParams.GetRedundantParityChunkNum()))
+				if innerErr != nil {
+					log.CtxErrorw(t.ctx, "failed to encode ec data", "key", key)
+					return
+				}
+				copy(data[segIdx], encodeData)
+				t.replicateDataSize += int64(len(encodeData[0]))
+
+			} else {
+				for rIdx := 0; rIdx < t.redundancyNumber; rIdx++ {
+					data[segIdx][rIdx] = segmentPieceData
+				}
+				t.replicateDataSize += int64(len(segmentPieceData))
+			}
+			atomic.AddInt64(&succeedNumber, 1)
+			log.CtxDebugw(t.ctx, "succeed to encode payload", "key", key)
+		}(segIdx)
 	}
-	tailIdx := t.segmentPieceNumber - 1
-	tailSize, err := pieceSize(tailIdx)
-	if err != nil {
-		return err
+	wg.Wait()
+	if int(succeedNumber) != t.segmentPieceNumber {
+		return data, fmt.Errorf("failed to encode replicate data")
 	}
-	integralSize := 0
-	if t.segmentPieceNumber > 1 {
-		size, err := pieceSize(1)
-		if err != nil {
-			return err
-		}
-		integralSize = size * (t.segmentPieceNumber - 1)
-	}
-	t.replicateDataSize = int64(tailSize + integralSize)
-	return nil
+	t.pieceSize = int64(len(data[0][0]))
+	log.CtxDebugw(t.ctx, "finish to encode replicate data",
+		"redundancy_number", t.redundancyNumber,
+		"segment_number", t.segmentPieceNumber,
+		"object_size", t.objectInfo.GetPayloadSize(),
+		"replicate_size", t.replicateDataSize,
+		"piece_size", t.pieceSize,
+	)
+	return data, nil
 }

--- a/service/tasknode/stream_replicate_object_task.go
+++ b/service/tasknode/stream_replicate_object_task.go
@@ -1,0 +1,498 @@
+package tasknode
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"errors"
+	"io"
+	"sync"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/bnb-chain/greenfield-common/go/redundancy"
+	"github.com/bnb-chain/greenfield-storage-provider/model"
+	merrors "github.com/bnb-chain/greenfield-storage-provider/model/errors"
+	"github.com/bnb-chain/greenfield-storage-provider/model/piecestore"
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/metrics"
+	p2ptypes "github.com/bnb-chain/greenfield-storage-provider/pkg/p2p/types"
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/rcmgr"
+	gatewayclient "github.com/bnb-chain/greenfield-storage-provider/service/gateway/client"
+	servicetypes "github.com/bnb-chain/greenfield-storage-provider/service/types"
+	"github.com/bnb-chain/greenfield-storage-provider/util/maps"
+	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
+	"github.com/bnb-chain/greenfield/x/storage/types"
+	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+const (
+	// ReplicateFactor defines the redundancy of replication
+	// TODO:: will update to （1, 2] on main net
+	ReplicateFactor = 1
+	// GetApprovalTimeout defines the timeout of getting secondary sp approval
+	GetApprovalTimeout = 10
+	// MaxSealRetryNumber defines max number of retrying seal object
+	MaxSealRetryNumber = 3
+)
+
+// streamReader is used to stream produce/consume piece data stream.
+type streamReader struct {
+	pRead  *io.PipeReader
+	pWrite *io.PipeWriter
+}
+
+// Read populates the given byte slice with data and returns the number of bytes populated and an error value.
+// It returns an io.EOF error when the stream ends.
+func (s *streamReader) Read(buf []byte) (n int, err error) {
+	return s.pRead.Read(buf)
+}
+
+// streamReaderGroup is used to the primary sp replicate object piece data to other secondary sps.
+type streamReaderGroup struct {
+	task            *streamReplicateObjectTask
+	pieceSize       int
+	streamReaderMap map[int]*streamReader
+}
+
+// newStreamReaderGroup returns a streamReaderGroup
+func newStreamReaderGroup(t *streamReplicateObjectTask, excludeIndexMap map[int]bool) (*streamReaderGroup, error) {
+	var atLeastHasOne bool
+	sg := &streamReaderGroup{
+		task:            t,
+		streamReaderMap: make(map[int]*streamReader),
+	}
+	for segmentPieceIdx := 0; segmentPieceIdx < t.segmentPieceNumber; segmentPieceIdx++ {
+		for idx := 0; idx < t.redundancyNumber; idx++ {
+			if excludeIndexMap[idx] {
+				continue
+			}
+			sg.streamReaderMap[idx] = &streamReader{}
+			sg.streamReaderMap[idx].pRead, sg.streamReaderMap[idx].pWrite = io.Pipe()
+			atLeastHasOne = true
+		}
+	}
+	if !atLeastHasOne {
+		return nil, merrors.ErrInvalidParams
+	}
+	return sg, nil
+}
+
+// produceStreamPieceData produce stream piece data
+func (sg *streamReaderGroup) produceStreamPieceData() {
+	ch := make(chan int)
+	go func(pieceSizeCh chan int) {
+		defer close(pieceSizeCh)
+		gotPieceSize := false
+
+		for segmentPieceIdx := 0; segmentPieceIdx < sg.task.segmentPieceNumber; segmentPieceIdx++ {
+			segmentPieceKey := piecestore.EncodeSegmentPieceKey(sg.task.objectInfo.Id.Uint64(), uint32(segmentPieceIdx))
+			segmentPieceData, err := sg.task.taskNode.pieceStore.GetPiece(context.Background(), segmentPieceKey, 0, 0)
+			if err != nil {
+				for idx := range sg.streamReaderMap {
+					sg.streamReaderMap[idx].pWrite.CloseWithError(err)
+				}
+				log.Errorw("failed to get piece data", "piece_key", segmentPieceKey, "error", err)
+				return
+			}
+			if sg.task.objectInfo.GetRedundancyType() == types.REDUNDANCY_EC_TYPE {
+				ecPieceData, err := redundancy.EncodeRawSegment(segmentPieceData,
+					int(sg.task.storageParams.GetRedundantDataChunkNum()),
+					int(sg.task.storageParams.GetRedundantParityChunkNum()))
+				if err != nil {
+					for idx := range sg.streamReaderMap {
+						sg.streamReaderMap[idx].pWrite.CloseWithError(err)
+					}
+					log.Errorw("failed to encode ec piece data", "error", err)
+					return
+				}
+				if !gotPieceSize {
+					pieceSizeCh <- len(ecPieceData[0])
+					gotPieceSize = true
+				}
+				for idx := range sg.streamReaderMap {
+					sg.streamReaderMap[idx].pWrite.Write(ecPieceData[idx])
+					log.Debugw("succeed to produce an ec piece data", "piece_len", len(ecPieceData[idx]), "redundancy_index", idx)
+				}
+			} else {
+				if !gotPieceSize {
+					pieceSizeCh <- len(segmentPieceData)
+					gotPieceSize = true
+				}
+				for idx := range sg.streamReaderMap {
+					sg.streamReaderMap[idx].pWrite.Write(segmentPieceData)
+					log.Debugw("succeed to produce an segment piece data", "piece_len", len(segmentPieceData), "redundancy_index", idx)
+				}
+			}
+		}
+		for idx := range sg.streamReaderMap {
+			sg.streamReaderMap[idx].pWrite.Close()
+			log.Debugw("succeed to finish a piece stream",
+				"redundancy_index", idx, "redundancy_type", sg.task.objectInfo.GetRedundancyType())
+		}
+	}(ch)
+	sg.pieceSize = <-ch
+}
+
+// streamPieceDataReplicator replicates a piece stream to the target sp
+type streamPieceDataReplicator struct {
+	task                  *streamReplicateObjectTask
+	dataSize              int64
+	pieceSize             uint32
+	redundancyIndex       uint32
+	expectedIntegrityHash []byte
+	streamReader          *streamReader
+	sp                    *sptypes.StorageProvider
+	approval              *p2ptypes.GetApprovalResponse
+}
+
+// replicate is used to start replicate the piece stream
+func (r *streamPieceDataReplicator) replicate() (integrityHash []byte, signature []byte, err error) {
+	var (
+		gwClient      *gatewayclient.GatewayClient
+		originMsgHash []byte
+		approvalAddr  sdk.AccAddress
+	)
+
+	gwClient, err = gatewayclient.NewGatewayClient(r.sp.GetEndpoint())
+	if err != nil {
+		log.Errorw("failed to create gateway client",
+			"sp_endpoint", r.sp.GetEndpoint(), "error", err)
+		return
+	}
+	integrityHash, signature, err = gwClient.ReplicateObjectPieceStream(r.task.objectInfo.Id.Uint64(),
+		r.pieceSize, r.dataSize, r.redundancyIndex, r.approval, r.streamReader)
+	if err != nil {
+		log.Errorw("failed to replicate object piece stream",
+			"endpoint", r.sp.GetEndpoint(), "error", err)
+		return
+	}
+	if !bytes.Equal(r.expectedIntegrityHash, integrityHash) {
+		err = merrors.ErrMismatchIntegrityHash
+		log.Errorw("failed to check root hash",
+			"expected", hex.EncodeToString(r.expectedIntegrityHash),
+			"actual", hex.EncodeToString(integrityHash), "error", err)
+		return
+	}
+
+	// verify secondary signature
+	originMsgHash = storagetypes.NewSecondarySpSignDoc(r.sp.GetOperator(), sdkmath.NewUint(r.task.objectInfo.Id.Uint64()), integrityHash).GetSignBytes()
+	approvalAddr, err = sdk.AccAddressFromHexUnsafe(r.sp.GetApprovalAddress())
+	if err != nil {
+		log.Errorw("failed to parse sp operator address",
+			"sp", r.sp.GetApprovalAddress(), "endpoint", r.sp.GetEndpoint(),
+			"error", err)
+		return
+	}
+	err = storagetypes.VerifySignature(approvalAddr, sdk.Keccak256(originMsgHash), signature)
+	if err != nil {
+		log.Errorw("failed to verify sp signature",
+			"sp", r.sp.GetApprovalAddress(), "endpoint", r.sp.GetEndpoint(), "error", err)
+		return
+	}
+
+	return integrityHash, signature, nil
+}
+
+// streamReplicateObjectTask represents the background object replicate task, include replica/ec redundancy type.
+// TODO: Streaming takes up less memory, but in complex network conditions, the transmission is slower.
+// The specific reason needs to be further located and optimized in the future.
+type streamReplicateObjectTask struct {
+	ctx                 context.Context
+	taskNode            *TaskNode
+	objectInfo          *types.ObjectInfo
+	approximateMemSize  int
+	storageParams       *storagetypes.Params
+	segmentPieceNumber  int
+	redundancyNumber    int
+	replicateDataSize   int64
+	mux                 sync.Mutex
+	spMap               map[string]*sptypes.StorageProvider
+	approvalResponseMap map[string]*p2ptypes.GetApprovalResponse
+	sortedSpEndpoints   []string
+}
+
+// newStreamReplicateObjectTask returns a ReplicateObjectTask instance.
+func newStreamReplicateObjectTask(ctx context.Context, task *TaskNode, object *types.ObjectInfo) (*streamReplicateObjectTask, error) {
+	if ctx == nil || task == nil || object == nil {
+		return nil, merrors.ErrInvalidParams
+	}
+	return &streamReplicateObjectTask{
+		ctx:                 ctx,
+		taskNode:            task,
+		objectInfo:          object,
+		spMap:               make(map[string]*sptypes.StorageProvider),
+		approvalResponseMap: make(map[string]*p2ptypes.GetApprovalResponse),
+	}, nil
+}
+
+// updateTaskState is used to update task state.
+func (t *streamReplicateObjectTask) updateTaskState(state servicetypes.JobState) error {
+	return t.taskNode.spDB.UpdateJobState(t.objectInfo.Id.Uint64(), state)
+}
+
+// init is used to synchronize the resources which is needed to initialize the task.
+func (t *streamReplicateObjectTask) init() error {
+	var err error
+	t.storageParams, err = t.taskNode.spDB.GetStorageParams()
+	if err != nil {
+		log.CtxErrorw(t.ctx, "failed to query sp params", "error", err)
+		return err
+	}
+	t.segmentPieceNumber = int(piecestore.ComputeSegmentCount(t.objectInfo.GetPayloadSize(),
+		t.storageParams.GetMaxSegmentSize()))
+	t.redundancyNumber = int(t.storageParams.GetRedundantDataChunkNum() + t.storageParams.GetRedundantParityChunkNum())
+	if t.redundancyNumber+1 != len(t.objectInfo.GetChecksums()) {
+		log.CtxError(t.ctx, "failed to init due to redundancy number is not equal to checksums")
+		return merrors.ErrInvalidParams
+	}
+	t.spMap, t.approvalResponseMap, err = t.taskNode.getApproval(
+		t.objectInfo, t.redundancyNumber, t.redundancyNumber*ReplicateFactor, GetApprovalTimeout)
+	if err != nil {
+		log.CtxErrorw(t.ctx, "failed to get approvals", "error", err)
+		return err
+	}
+	t.sortedSpEndpoints = maps.SortKeys(t.approvalResponseMap)
+	// calculate the reserve memory, which is used in execute time
+	t.approximateMemSize = int(float64(t.storageParams.GetMaxSegmentSize()) *
+		(float64(t.redundancyNumber)/float64(t.storageParams.GetRedundantDataChunkNum()) + 1))
+	if t.objectInfo.GetPayloadSize() < t.storageParams.GetMaxSegmentSize() {
+		t.approximateMemSize = int(float64(t.objectInfo.GetPayloadSize()) *
+			(float64(t.redundancyNumber)/float64(t.storageParams.GetRedundantDataChunkNum()) + 1))
+	}
+	err = t.ComputeReplicatePiecesSizeForOneSP()
+	if err != nil {
+		log.CtxErrorw(t.ctx, "failed to compute replicate pieces data size per sp", "error", err)
+		return err
+	}
+	return nil
+}
+
+// execute is used to start the task, and waitCh is used to wait runtime initialization.
+func (t *streamReplicateObjectTask) execute(waitCh chan error) {
+	var (
+		startTime            time.Time
+		succeedIndexMapMutex sync.RWMutex
+		succeedIndexMap      map[int]bool
+		err                  error
+		scopeSpan            rcmgr.ResourceScopeSpan
+		sealMsg              *storagetypes.MsgSealObject
+		progressInfo         *servicetypes.ReplicatePieceInfo
+	)
+	// runtime initialization
+	startTime = time.Now()
+	succeedIndexMap = make(map[int]bool, t.redundancyNumber)
+	isAllSucceed := func(inputIndexMap map[int]bool) bool {
+		for i := 0; i < t.redundancyNumber; i++ {
+			if !inputIndexMap[i] {
+				return false
+			}
+		}
+		return true
+	}
+	metrics.ReplicateObjectTaskGauge.WithLabelValues(model.TaskNodeService).Inc()
+	t.updateTaskState(servicetypes.JobState_JOB_STATE_REPLICATE_OBJECT_DOING)
+
+	if scopeSpan, err = t.taskNode.rcScope.BeginSpan(); err != nil {
+		log.CtxErrorw(t.ctx, "failed to begin span", "error", err)
+		waitCh <- err
+		return
+	}
+	if err = scopeSpan.ReserveMemory(t.approximateMemSize, rcmgr.ReservationPriorityAlways); err != nil {
+		log.CtxErrorw(t.ctx, "failed to reserve memory from resource manager",
+			"reserve_size", t.approximateMemSize, "error", err)
+		waitCh <- err
+		return
+	}
+	log.CtxDebugw(t.ctx, "reserve memory from resource manager",
+		"reserve_size", t.approximateMemSize, "resource_state", rcmgr.GetServiceState(model.TaskNodeService))
+	waitCh <- nil
+
+	// defer func
+	defer func() {
+		close(waitCh)
+		metrics.ReplicateObjectTaskGauge.WithLabelValues(model.TaskNodeService).Dec()
+		observer := metrics.SealObjectTimeHistogram.WithLabelValues(model.TaskNodeService)
+		observer.Observe(time.Since(startTime).Seconds())
+
+		if isAllSucceed(succeedIndexMap) {
+			metrics.SealObjectTotalCounter.WithLabelValues("success").Inc()
+			log.CtxInfo(t.ctx, "succeed to seal object on chain")
+		} else {
+			t.updateTaskState(servicetypes.JobState_JOB_STATE_REPLICATE_OBJECT_ERROR)
+			metrics.SealObjectTotalCounter.WithLabelValues("failure").Inc()
+			log.CtxErrorw(t.ctx, "failed to replicate object data to sp", "error", err, "succeed_index_map", succeedIndexMap)
+		}
+
+		if scopeSpan != nil {
+			scopeSpan.Done()
+			log.CtxDebugw(t.ctx, "release memory to resource manager",
+				"release_size", t.approximateMemSize, "resource_state", rcmgr.GetServiceState(model.TaskNodeService))
+		}
+	}()
+
+	// execution
+	pickSp := func() (sp *sptypes.StorageProvider, approval *p2ptypes.GetApprovalResponse, err error) {
+		t.mux.Lock()
+		defer t.mux.Unlock()
+		if len(t.approvalResponseMap) == 0 {
+			log.CtxError(t.ctx, "backup storage providers exhausted")
+			err = merrors.ErrExhaustedSP
+			return
+		}
+		endpoint := t.sortedSpEndpoints[0]
+		sp = t.spMap[endpoint]
+		approval = t.approvalResponseMap[endpoint]
+		t.sortedSpEndpoints = t.sortedSpEndpoints[1:]
+		delete(t.spMap, endpoint)
+		delete(t.approvalResponseMap, endpoint)
+		return
+	}
+	sealMsg = &storagetypes.MsgSealObject{
+		Operator:              t.taskNode.config.SpOperatorAddress,
+		BucketName:            t.objectInfo.GetBucketName(),
+		ObjectName:            t.objectInfo.GetObjectName(),
+		SecondarySpAddresses:  make([]string, t.redundancyNumber),
+		SecondarySpSignatures: make([][]byte, t.redundancyNumber),
+	}
+	t.objectInfo.SecondarySpAddresses = make([]string, t.redundancyNumber)
+	progressInfo = &servicetypes.ReplicatePieceInfo{
+		PieceInfos: make([]*servicetypes.PieceInfo, t.redundancyNumber),
+	}
+
+	for {
+		if isAllSucceed(succeedIndexMap) {
+			log.CtxInfo(t.ctx, "succeed to replicate object data")
+			break
+		}
+		var sg *streamReaderGroup
+		sg, err = newStreamReaderGroup(t, succeedIndexMap)
+		if err != nil {
+			log.CtxErrorw(t.ctx, "failed to new stream reader group", "error", err)
+			return
+		}
+		if len(sg.streamReaderMap) > len(t.sortedSpEndpoints) {
+			log.CtxError(t.ctx, "failed to replicate due to sp is not enough")
+			err = merrors.ErrExhaustedSP
+			return
+		}
+		sg.produceStreamPieceData()
+
+		var wg sync.WaitGroup
+		for redundancyIdx := range sg.streamReaderMap {
+			wg.Add(1)
+			go func(rIdx int) {
+				defer wg.Done()
+
+				sp, approval, innerErr := pickSp()
+				if innerErr != nil {
+					log.CtxErrorw(t.ctx, "failed to pick a secondary sp", "redundancy_index", rIdx, "error", innerErr)
+					return
+				}
+				r := &streamPieceDataReplicator{
+					task:                  t,
+					dataSize:              t.replicateDataSize,
+					pieceSize:             uint32(sg.pieceSize),
+					redundancyIndex:       uint32(rIdx),
+					expectedIntegrityHash: sg.task.objectInfo.GetChecksums()[rIdx+1],
+					streamReader:          sg.streamReaderMap[rIdx],
+					sp:                    sp,
+					approval:              approval,
+				}
+				integrityHash, signature, innerErr := r.replicate()
+				if innerErr != nil {
+					log.CtxErrorw(t.ctx, "failed to replicate piece stream", "redundancy_index", rIdx, "error", innerErr)
+					return
+				}
+
+				succeedIndexMapMutex.Lock()
+				succeedIndexMap[rIdx] = true
+				succeedIndexMapMutex.Unlock()
+
+				sealMsg.GetSecondarySpAddresses()[rIdx] = sp.GetOperator().String()
+				sealMsg.GetSecondarySpSignatures()[rIdx] = signature
+				progressInfo.PieceInfos[rIdx] = &servicetypes.PieceInfo{
+					ObjectInfo:    t.objectInfo,
+					Signature:     signature,
+					IntegrityHash: integrityHash,
+				}
+				t.objectInfo.SecondarySpAddresses[rIdx] = sp.GetOperator().String()
+				t.taskNode.spDB.SetObjectInfo(t.objectInfo.Id.Uint64(), t.objectInfo)
+				t.taskNode.cache.Add(t.objectInfo.Id.Uint64(), progressInfo)
+				log.CtxInfow(t.ctx, "succeed to replicate object piece stream to the target sp",
+					"sp", sp.GetOperator(), "endpoint", sp.GetEndpoint(), "redundancy_index", rIdx)
+			}(redundancyIdx)
+		}
+		wg.Wait()
+	}
+
+	// seal onto the greenfield chain
+	if isAllSucceed(succeedIndexMap) {
+		retry := 0
+		for {
+			if retry >= MaxSealRetryNumber {
+				log.CtxErrorw(t.ctx, "failed to seal object", "error", err, "retry", retry)
+				break
+			}
+			retry++
+			t.updateTaskState(servicetypes.JobState_JOB_STATE_SIGN_OBJECT_DOING)
+			_, err = t.taskNode.signer.SealObjectOnChain(context.Background(), sealMsg)
+			if err != nil {
+				t.updateTaskState(servicetypes.JobState_JOB_STATE_SIGN_OBJECT_ERROR)
+				log.CtxErrorw(t.ctx, "failed to sign object by signer", "error", err, "retry", retry)
+				continue
+			}
+			t.updateTaskState(servicetypes.JobState_JOB_STATE_SEAL_OBJECT_DOING)
+			err = t.taskNode.chain.ListenObjectSeal(context.Background(), t.objectInfo.GetBucketName(),
+				t.objectInfo.GetObjectName(), 10)
+			if err != nil {
+				t.updateTaskState(servicetypes.JobState_JOB_STATE_SEAL_OBJECT_ERROR)
+				log.CtxErrorw(t.ctx, "failed to seal object on chain", "error", err, "retry", retry)
+				continue
+			}
+			t.updateTaskState(servicetypes.JobState_JOB_STATE_SEAL_OBJECT_DONE)
+			break
+		}
+	} // the else failed case is in defer func
+}
+
+func (t *streamReplicateObjectTask) ComputeReplicatePiecesSizeForOneSP() error {
+	if t.segmentPieceNumber <= 0 {
+		return errors.New("segment piece number invalid")
+	}
+
+	pieceSize := func(idx int) (int, error) {
+		segmentPieceKey := piecestore.EncodeSegmentPieceKey(t.objectInfo.Id.Uint64(), uint32(idx))
+		segmentPieceData, err := t.taskNode.pieceStore.GetPiece(context.Background(), segmentPieceKey, 0, 0)
+		if err != nil {
+			return 0, err
+		}
+		if t.objectInfo.GetRedundancyType() == types.REDUNDANCY_EC_TYPE {
+			ecPieceData, err := redundancy.EncodeRawSegment(segmentPieceData,
+				int(t.storageParams.GetRedundantDataChunkNum()),
+				int(t.storageParams.GetRedundantParityChunkNum()))
+			if err != nil {
+				return 0, err
+			}
+			return len(ecPieceData[0]), nil
+		} else {
+			return len(segmentPieceData), nil
+		}
+	}
+	tailIdx := t.segmentPieceNumber - 1
+	tailSize, err := pieceSize(tailIdx)
+	if err != nil {
+		return err
+	}
+	integralSize := 0
+	if t.segmentPieceNumber > 1 {
+		size, err := pieceSize(1)
+		if err != nil {
+			return err
+		}
+		integralSize = size * (t.segmentPieceNumber - 1)
+	}
+	t.replicateDataSize = int64(tailSize + integralSize)
+	return nil
+}


### PR DESCRIPTION
### Description

Add full-memory replicate task, which is cherry-picked from [fix-release-v0.1.2](https://github.com/bnb-chain/greenfield-storage-provider/tree/fix-release-v0.1.2).

### Rationale

There are currently two replicate task implementations, full memory and streaming. Streaming takes up less memory, but in complex network conditions, the transmission is slower. The specific reason needs to be further located and optimized in the future. Full memory takes up more memory, but the transmission is faster, and full memory is used by default.

### Example

N/A.

### Changes

Notable changes: 
* p2p: reduce debug log.
* gateway: fix invalid header.
* tasknode: add full-mem replicate task.
