### PR TITLE
fix:  fix nil pointer and update db config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -171,6 +171,8 @@ var DefaultMetricsConfig = &metrics.MetricsConfig{
 
 // DefaultMetadataConfig defines the default configuration of Metadata service
 var DefaultMetadataConfig = &metadata.MetadataConfig{
+	BsDBConfig:                 DefaultBsDBConfig,
+	BsDBSwitchedConfig:         DefaultBsDBSwitchedConfig,
 	IsMasterDB:                 true,
 	BsDBSwitchCheckIntervalSec: 3600,
 }


### PR DESCRIPTION
### Description

fix nil db config error 

### Rationale
When I run it locally, there's no issue. However, when I run 7 service providers (sp) locally, the configuration file's metadata doesn't assign values to the 'bsdb' and 'switched db' within each service provider's 'config.toml'.
```
bash deployment/localup/localup.sh --stop
bash deployment/localup/localup.sh --generate /Users/barry/testbarry/greenfield-storage-provider/deployment/localup/sp.json root root1234 localhost:3306
bash deployment/localup/localup.sh --reset
bash deployment/localup/localup.sh --start
```

![image](https://github.com/bnb-chain/greenfield-storage-provider/assets/122767193/7184e92f-3467-4bf9-9824-60ff5977d577)


### Example

add an example CLI or API response...

### Changes

Notable changes: 
*  add db config in config.go