### PR TITLE
feat: add gc object task db interface impl

### DIFF
--- a/base/types/gfsptask/gc.go
+++ b/base/types/gfsptask/gc.go
@@ -128,21 +128,21 @@ func (m *GfSpGCObjectTask) SetEndBlockNumber(block uint64) {
 	m.EndBlockNumber = block
 }
 
-func (m *GfSpGCObjectTask) GetGCObjectProcess() (uint64, uint64) {
-	return m.GetCurrentBlockNumber(), m.GetDeletingObjectId()
+func (m *GfSpGCObjectTask) GetGCObjectProgress() (uint64, uint64) {
+	return m.GetCurrentBlockNumber(), m.GetLastDeletedObjectId()
 }
 
-func (m *GfSpGCObjectTask) SetGCObjectProcess(block uint64, object uint64) {
+func (m *GfSpGCObjectTask) SetGCObjectProgress(block uint64, object uint64) {
 	m.CurrentBlockNumber = block
-	m.DeletingObjectId = object
+	m.LastDeletedObjectId = object
 }
 
 func (m *GfSpGCObjectTask) SetCurrentBlockNumber(block uint64) {
 	m.CurrentBlockNumber = block
 }
 
-func (m *GfSpGCObjectTask) SetDeletingObjectId(object uint64) {
-	m.DeletingObjectId = object
+func (m *GfSpGCObjectTask) SetLastDeletedObjectId(object uint64) {
+	m.LastDeletedObjectId = object
 }
 
 func (m *GfSpGCZombiePieceTask) Key() coretask.TKey {

--- a/cmd/conf/conf.go
+++ b/cmd/conf/conf.go
@@ -23,7 +23,7 @@ func dumpConfigAction(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if err = os.WriteFile("./config.tomal", bz, os.ModePerm); err != nil {
+	if err = os.WriteFile("./config.toml", bz, os.ModePerm); err != nil {
 		return err
 	}
 	return nil

--- a/core/module/null_modular.go
+++ b/core/module/null_modular.go
@@ -110,7 +110,6 @@ func (*NilModular) HandleChallengePiece(context.Context, task.ChallengePieceTask
 func (*NilModular) AskTask(context.Context, rcmgr.Limit)                              {}
 func (*NilModular) PostChallengePiece(context.Context, task.ChallengePieceTask)       {}
 func (*NilModular) ReportTask(context.Context, task.Task) error                       { return nil }
-func (*NilModular) AskTask(context.Context, rcmgr.Limit)                              {}
 func (*NilModular) HandleReplicatePieceTask(context.Context, task.ReplicatePieceTask) {}
 func (*NilModular) HandleSealObjectTask(context.Context, task.SealObjectTask)         {}
 func (*NilModular) HandleReceivePieceTask(context.Context, task.ReceivePieceTask)     {}

--- a/core/module/null_modular.go
+++ b/core/module/null_modular.go
@@ -63,6 +63,7 @@ func (*NullModular) HandleCreateUploadObjectTask(context.Context, task.UploadObj
 func (*NullModular) HandleDoneUploadObjectTask(context.Context, task.UploadObjectTask) error {
 	return nil
 }
+
 func (*NullModular) HandleReplicatePieceTask(context.Context, task.ReplicatePieceTask) error {
 	return nil
 }
@@ -109,6 +110,7 @@ func (*NilModular) HandleChallengePiece(context.Context, task.ChallengePieceTask
 func (*NilModular) AskTask(context.Context, rcmgr.Limit)                              {}
 func (*NilModular) PostChallengePiece(context.Context, task.ChallengePieceTask)       {}
 func (*NilModular) ReportTask(context.Context, task.Task) error                       { return nil }
+func (*NilModular) AskTask(context.Context, rcmgr.Limit)                              {}
 func (*NilModular) HandleReplicatePieceTask(context.Context, task.ReplicatePieceTask) {}
 func (*NilModular) HandleSealObjectTask(context.Context, task.SealObjectTask)         {}
 func (*NilModular) HandleReceivePieceTask(context.Context, task.ReceivePieceTask)     {}

--- a/core/spdb/gc_object.go
+++ b/core/spdb/gc_object.go
@@ -3,7 +3,7 @@ package spdb
 import "github.com/bnb-chain/greenfield-storage-provider/core/task"
 
 type GCObjectInfoDB interface {
-	SetGCObjectProcess(task string, deletingBlock uint64, deletingObject uint64) error
-	DeleteGCObjectProcess(task string) error
+	SetGCObjectProgress(task string, deletingBlock uint64, deletingObject uint64) error
+	DeleteGCObjectProgress(task string) error
 	GetAllGCObjectTask(task string) []task.GCObjectTask
 }

--- a/core/spdb/gc_object.go
+++ b/core/spdb/gc_object.go
@@ -3,7 +3,7 @@ package spdb
 import "github.com/bnb-chain/greenfield-storage-provider/core/task"
 
 type GCObjectInfoDB interface {
-	SetGCObjectProgress(task string, deletingBlock uint64, deletingObject uint64) error
-	DeleteGCObjectProgress(task string) error
-	GetAllGCObjectTask(task string) []task.GCObjectTask
+	SetGCObjectProgress(taskKey string, deletingBlockID uint64, deletingObjectID uint64) error
+	DeleteGCObjectProgress(taskKey string) error
+	GetAllGCObjectTask(taskKey string) []task.GCObjectTask
 }

--- a/core/task/task.go
+++ b/core/task/task.go
@@ -465,16 +465,16 @@ type GCObjectTask interface {
 	SetCurrentBlockNumber(uint64)
 	// GetCurrentBlockNumber returns the collecting block number.
 	GetCurrentBlockNumber() uint64
-	// GetDeletingObjectId returns the lasted deleting ObjectID.
-	GetDeletingObjectId() uint64
-	// SetDeletingObjectId sets the lasted deleting ObjectID.
-	SetDeletingObjectId(uint64)
-	// GetGCObjectProcess returns the process of collecting object, returns the
+	// GetLastDeletedObjectId returns the last deleted ObjectID.
+	GetLastDeletedObjectId() uint64
+	// SetLastDeletedObjectId sets the last deleted ObjectID.
+	SetLastDeletedObjectId(uint64)
+	// GetGCObjectProgress returns the progress of collecting object, returns the
 	// deleting block number and the last deleted object id.
-	GetGCObjectProcess() (uint64, uint64)
-	// SetGCObjectProcess sets the process of collecting object, params stand
+	GetGCObjectProgress() (uint64, uint64)
+	// SetGCObjectProgress sets the progress of collecting object, params stand
 	// the deleting block number and the last deleted object id.
-	SetGCObjectProcess(uint64, uint64)
+	SetGCObjectProgress(uint64, uint64)
 }
 
 // The GCZombiePieceTask is the interface to record the information for collecting

--- a/core/task/task.go
+++ b/core/task/task.go
@@ -197,7 +197,7 @@ type ApprovalCreateObjectTask interface {
 
 // ApprovalReplicatePieceTask is the interface to record the ask replicate pieces
 // to other SPs(as secondary SP for the object). It is initiated by the primary SP
-// in the replicate pieces phase.  Before the primary SP sends it to other SPs, the
+// in the replicate pieces phase. Before the primary SP sends it to other SPs, the
 // primary SP will sign the task, other SPs will verify it is sent by a legitimate
 // SP. If other SPs approved the approval, they will SetExpiredHeight and signs the
 // ApprovalReplicatePieceTask.
@@ -298,7 +298,7 @@ type ReplicatePieceTask interface {
 	// GetSecondarySignature returns the secondary SP's signatures. It is used to
 	// generate MsgSealObject.
 	GetSecondarySignature() [][]byte
-	// SetSecondarySignature sets the the secondary SP's signatures.
+	// SetSecondarySignature sets the secondary SP's signatures.
 	SetSecondarySignature([][]byte)
 }
 
@@ -383,7 +383,7 @@ type DownloadObjectTask interface {
 	// It is used to Query and calculate bucket read quota.
 	GetBucketInfo() *storagetypes.BucketInfo
 	// GetUserAddress returns the user account of downloading object.
-	// It is used to records the read bucket information.
+	// It is used to record the read bucket information.
 	GetUserAddress() string
 	// SetUserAddress sets the user account of downloading object.
 	SetUserAddress(string)
@@ -412,10 +412,10 @@ type ChallengePieceTask interface {
 		retry int64)
 	// GetBucketInfo returns the BucketInfo of challenging piece
 	GetBucketInfo() *storagetypes.BucketInfo
-	// SetBucketInfo sets the the BucketInfo of challenging piece
+	// SetBucketInfo sets the BucketInfo of challenging piece
 	SetBucketInfo(*storagetypes.BucketInfo)
 	// GetUserAddress returns the user account of challenging object.
-	// It is used to records the read bucket information.
+	// It is used to record the read bucket information.
 	GetUserAddress() string
 	// SetUserAddress sets the user account of challenging object.
 	SetUserAddress(string)

--- a/deployment/localup/localup.sh
+++ b/deployment/localup/localup.sh
@@ -90,44 +90,40 @@ make_config() {
       cd ${sp_dir}
         source db.info
         source sp.info
-        # db
-        sed -i -e "s/root/${USER}/g" config.toml
-        sed -i -e "s/test_pwd/${PWD}/g" config.toml
-        sed -i -e "s/localhost\:3306/${ADDRESS}/g" config.toml
-        sed -i -e "s/storage_provider_db/${DATABASE}/g" config.toml
-        sed -i -e "s/block_syncer_backup/${DATABASE}/g" config.toml
-        sed -i -e "s/block_syncer/${DATABASE}/g" config.toml
+        # app
+        sed -i -e "s/AppID = \'.*\'/SpOperatorAddress = \'sp-${index}\'/g" config.toml
+        sed -i -e "s/Server = \[\]/Server = \[\"uploader\"\]/g" config.toml
+        sed -i -e "s/GrpcAddress = \'.*\'/GrpcAddress = \'127.0.0.1:${cur_port}\'/g" config.toml
 
-        # sp
-        sed -i -e "s/localhost\:9033/${SP_ENDPOINT}/g" config.toml
-        sed -i -e "s/8933/$(($cur_port+33))/g" config.toml
-        sed -i -e "s/9133/$(($cur_port+133))/g" config.toml
-        sed -i -e "s/9233/$(($cur_port+233))/g" config.toml
-        sed -i -e "s/9333/$(($cur_port+333))/g" config.toml
-        sed -i -e "s/9433/$(($cur_port+433))/g" config.toml
-        sed -i -e "s/9533/$(($cur_port+533))/g" config.toml
-        sed -i -e "s/9633/$(($cur_port+633))/g" config.toml
-        sed -i -e "s/9733/$(($cur_port+733))/g" config.toml
-        sed -i -e "s/9833/$(($cur_port+833))/g" config.toml
-        sed -i -e "s/9933/$(($cur_port+933))/g" config.toml
-        sed -i -e "s/24036/$(($cur_port+4036))/g" config.toml
-        sed -i -e "s/25341/$(($cur_port+5341))/g" config.toml
-        sed -i -e "s/SpOperatorAddress = \".*\"/SpOperatorAddress = \"${OPERATOR_ADDRESS}\"/g" config.toml
-        sed -i -e "s/OperatorPrivateKey = \".*\"/OperatorPrivateKey = \"${OPERATOR_PRIVATE_KEY}\"/g" config.toml
-        sed -i -e "s/FundingPrivateKey = \".*\"/FundingPrivateKey = \"${FUNDING_PRIVATE_KEY}\"/g" config.toml
-        sed -i -e "s/SealPrivateKey = \".*\"/SealPrivateKey = \"${SEAL_PRIVATE_KEY}\"/g" config.toml
-        sed -i -e "s/ApprovalPrivateKey = \".*\"/ApprovalPrivateKey = \"${APPROVAL_PRIVATE_KEY}\"/g" config.toml
-        sed -i -e "s/GcPrivateKey = \".*\"/GcPrivateKey = \"${GC_PRIVATE_KEY}\"/g" config.toml
+        # db
+        sed -i -e "s/User = \'.*\'/User = \'${USER}\'/g" config.toml
+        sed -i -e "s/Passwd = \'.*\'/Passwd = \'${PWD}\'/g" config.toml
+        sed -i -e "s/Address = \'.*\'/Address = \'${ADDRESS}\'/g" config.toml
+        sed -i -e "s/Database = \'.*\'/Database = \'${DATABASE}\'/g" config.toml
+
         # chain
-        sed -i -e "s/greenfield_9000-1741/${CHAIN_ID}/g" config.toml
-        sed -i -e "s/localhost\:9090/${CHAIN_GRPC_ENDPOINT}/g" config.toml
-        sed -i -e "s/localhost\:26750/${CHAIN_HTTP_ENDPOINT}/g" config.toml
-        echo "succeed to generate config.toml in "${sp_dir}
+        sed -i -e "s/ChainID = \'.*\'/ChainID = \'${CHAIN_ID}\'/g" config.toml
+        sed -i -e "s/ChainAddress = \[.*\]/ChainAddress = \[\"${CHAIN_HTTP_ENDPOINT}\"\]/g" config.toml
+
+        # sp account
+        sed -i -e "s/SpOperateAddress = \'.*\'/SpOperateAddress = \'${OPERATOR_ADDRESS}\'/g" config.toml
+        sed -i -e "s/OperatorPrivateKey = \'.*\'/OperatorPrivateKey = \'${OPERATOR_PRIVATE_KEY}\'/g" config.toml
+        sed -i -e "s/FundingPrivateKey = \'.*\'/FundingPrivateKey = \'${FUNDING_PRIVATE_KEY}\'/g" config.toml
+        sed -i -e "s/SealPrivateKey = \'.*\'/SealPrivateKey = \'${SEAL_PRIVATE_KEY}\'/g" config.toml
+        sed -i -e "s/ApprovalPrivateKey = \'.*\'/ApprovalPrivateKey = \'${APPROVAL_PRIVATE_KEY}\'/g" config.toml
+        sed -i -e "s/GcPrivateKey = \'.*\'/GcPrivateKey = \'${GC_PRIVATE_KEY}\'/g" config.toml
+
+        # gateway
+        sed -i -e "s/Domain = \'.*\'/Domain = \'gnfd.test-sp.com\'/g" config.toml
+        sed -i -e "s/HttpAddress = \'.*\'/HttpAddress = \'${SP_ENDPOINT}\'/g" config.toml
+
         # p2p
         node=NODE${index}
         boot=BOOT${index}
-        sed -i -e "s/P2PPrivateKey = \".*\"/P2PPrivateKey = \"${!node}\"/g" config.toml
+        sed -i -e "s/P2PPrivateKey = \'.*\'/P2PPrivateKey = \'${!node}\'/g" config.toml
         sed -i -e "s/Bootstrap = \[\]/Bootstrap = \[\"${!boot}\"\]/g" config.toml
+
+        echo "succeed to generate config.toml in "${sp_dir}
       cd - >/dev/null
       index=$(($index+1))
   done

--- a/modular/executor/execute_task.go
+++ b/modular/executor/execute_task.go
@@ -171,7 +171,7 @@ func (e *ExecuteModular) HandleGCObjectTask(
 					"piece_key", pieceKey, "error", err)
 				return
 			}
-			log.CtxDebugw(ctx, "success to delete primary payload", "piece_key", pieceKey)
+			log.CtxDebugw(ctx, "succeed to delete primary payload", "piece_key", pieceKey)
 		}
 		for rIdx, address := range objectInfo.GetSecondarySpAddresses() {
 			if strings.Compare(e.baseApp.OperateAddress(), address) != 0 {
@@ -190,7 +190,7 @@ func (e *ExecuteModular) HandleGCObjectTask(
 						"piece_key", pieceKey, "error", err)
 					return
 				}
-				log.CtxDebugw(ctx, "success to delete secondary piece", "piece_key", pieceKey)
+				log.CtxDebugw(ctx, "succeed to delete secondary piece", "piece_key", pieceKey)
 			}
 			break
 		}

--- a/modular/manager/manage_task.go
+++ b/modular/manager/manage_task.go
@@ -348,14 +348,14 @@ func (m *ManageModular) HandleGCObjectTask(
 	ctx context.Context,
 	task task.GCObjectTask) error {
 	if task == nil {
-		log.CtxErrorw(ctx, "failed to handle gc object, task pointer dangling")
+		log.CtxErrorw(ctx, "failed to handle gc object due to task pointer dangling")
 		return ErrDanglingTask
 	}
 	if !m.gcObjectQueue.Has(task.Key()) {
 		return ErrCanceledTask
 	}
 	if task.GetEndBlockNumber() < task.GetCurrentBlockNumber() {
-		log.CtxInfow(ctx, "success to gc object task", "end_block_number",
+		log.CtxInfow(ctx, "succeed to gc object task", "end_block_number",
 			task.GetEndBlockNumber(), "last_delete_objectId", task.GetDeletingObjectId())
 		m.gcObjectQueue.PopByKey(task.Key())
 		return nil
@@ -363,8 +363,8 @@ func (m *ManageModular) HandleGCObjectTask(
 	task.SetUpdateTime(time.Now().Unix())
 	m.gcObjectQueue.PopByKey(task.Key())
 	m.gcObjectQueue.Push(task)
-	block, object := task.GetGCObjectProcess()
-	err := m.baseApp.GfSpDB().SetGCObjectProcess(task.Key().String(), block, object)
+	block, object := task.GetGCObjectProgress()
+	err := m.baseApp.GfSpDB().SetGCObjectProgress(task.Key().String(), block, object)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to update gc object status", "error", err)
 	}

--- a/proto/base/types/gfsptask/task.proto
+++ b/proto/base/types/gfsptask/task.proto
@@ -103,7 +103,7 @@ message GfSpGCObjectTask {
   uint64 start_block_number = 2;
   uint64 end_block_number = 3;
   uint64 current_block_number = 4;
-  uint64 deleting_object_id = 5;
+  uint64 last_deleted_object_id = 5;
   bool running = 6;
 }
 

--- a/store/sqldb/const.go
+++ b/store/sqldb/const.go
@@ -6,6 +6,8 @@ const (
 	JobTableName = "job"
 	// ObjectTableName defines the object table name
 	ObjectTableName = "object"
+	// GCObjectTaskTableName defines the gc object task table name
+	GCObjectTaskTableName = "gc_object_task"
 	// PieceHashTableName defines the piece hash table name
 	PieceHashTableName = "piece_hash"
 	// IntegrityMetaTableName defines the integrity meta table name

--- a/store/sqldb/gc_object.go
+++ b/store/sqldb/gc_object.go
@@ -2,8 +2,8 @@ package sqldb
 
 import "github.com/bnb-chain/greenfield-storage-provider/core/task"
 
-func (s *SpDBImpl) SetGCObjectProcess(task string, deletingBlock uint64, deletingObject uint64) error {
+func (s *SpDBImpl) SetGCObjectProgress(task string, deletingBlock uint64, deletingObject uint64) error {
 	return nil
 }
-func (s *SpDBImpl) DeleteGCObjectProcess(task string) error            { return nil }
+func (s *SpDBImpl) DeleteGCObjectProgress(task string) error           { return nil }
 func (s *SpDBImpl) GetAllGCObjectTask(task string) []task.GCObjectTask { return nil }

--- a/store/sqldb/gc_object.go
+++ b/store/sqldb/gc_object.go
@@ -1,9 +1,37 @@
 package sqldb
 
-import "github.com/bnb-chain/greenfield-storage-provider/core/task"
+import (
+	"fmt"
 
-func (s *SpDBImpl) SetGCObjectProgress(task string, deletingBlock uint64, deletingObject uint64) error {
+	"github.com/bnb-chain/greenfield-storage-provider/core/task"
+	"gorm.io/gorm"
+)
+
+// SetGCObjectProgress is used to set gc object progress.
+func (s *SpDBImpl) SetGCObjectProgress(taskKey string, curDeletingBlockID uint64, lastDeletedObjectID uint64) error {
+	var (
+		result             *gorm.DB
+		insertGCObjectTask *GCObjectTaskTable
+	)
+	insertGCObjectTask = &GCObjectTaskTable{
+		TaskKey:                taskKey,
+		CurrentDeletingBlockID: curDeletingBlockID,
+		LastDeletedObjectID:    lastDeletedObjectID,
+	}
+	result = s.db.Create(insertGCObjectTask)
+	if result.Error != nil || result.RowsAffected != 1 {
+		return fmt.Errorf("failed to insert gc task record: %s", result.Error)
+	}
 	return nil
 }
-func (s *SpDBImpl) DeleteGCObjectProgress(task string) error           { return nil }
-func (s *SpDBImpl) GetAllGCObjectTask(task string) []task.GCObjectTask { return nil }
+
+// DeleteGCObjectProgress is used to delete gc object task.
+func (s *SpDBImpl) DeleteGCObjectProgress(taskKey string) error {
+	return s.db.Delete(&GCObjectTaskTable{
+		TaskKey: taskKey, // should be the primary key
+	}).Error
+}
+
+// GetAllGCObjectTask is unused.
+// TODO: will be implemented in the future, may be used in startup.
+func (s *SpDBImpl) GetAllGCObjectTask(taskKey string) []task.GCObjectTask { return nil }

--- a/store/sqldb/gc_object_schema.go
+++ b/store/sqldb/gc_object_schema.go
@@ -1,0 +1,13 @@
+package sqldb
+
+// GCObjectTaskTable table schema
+type GCObjectTaskTable struct {
+	TaskKey                string `gorm:"primary_key"`
+	CurrentDeletingBlockID uint64
+	LastDeletedObjectID    uint64
+}
+
+// TableName is used to set JobTable Schema's table name in database
+func (GCObjectTaskTable) TableName() string {
+	return GCObjectTaskTableName
+}

--- a/store/sqldb/store.go
+++ b/store/sqldb/store.go
@@ -59,6 +59,10 @@ func InitDB(config *config.SQLDBConfig) (*gorm.DB, error) {
 		log.Errorw("failed to create object table", "error", err)
 		return nil, err
 	}
+	if err := db.AutoMigrate(&GCObjectTaskTable{}); err != nil {
+		log.Errorw("failed to gc object task table", "error", err)
+		return nil, err
+	}
 	if err := db.AutoMigrate(&SpInfoTable{}); err != nil {
 		log.Errorw("failed to create sp info table", "error", err)
 		return nil, err


### PR DESCRIPTION
### Description

Add gc object task db interface implements and adapt the local-up script.

### Rationale

N/A.

### Example

local-up step:
1.bash deployment/localup/localup.sh --generate /Users/xxx/workspace/greenfield-storage-provider/sp.json user pwd addr
2.bash deployment/localup/localup.sh --reset


### Changes

Notable changes: 
* sp-db: add gc object task impl.
* deployment: adapt local-up script.
