### PR TITLE
feat: add p2p ant address config

### DIFF
--- a/base/gfspconfig/config.go
+++ b/base/gfspconfig/config.go
@@ -135,6 +135,7 @@ type ExecutorConfig struct {
 type P2PConfig struct {
 	P2PPrivateKey string
 	P2PAddress    string
+	P2PAntAddress string
 	P2PBootstrap  []string
 	P2PPingPeriod int
 }

--- a/modular/p2p/p2p_options.go
+++ b/modular/p2p/p2p_options.go
@@ -39,8 +39,9 @@ func DefaultP2POptions(p2p *P2PModular, cfg *gfspconfig.GfSpConfig) error {
 	if cfg.P2P.P2PAddress == "" {
 		cfg.P2P.P2PAddress = DefaultP2PProtocolAddress
 	}
-	node, err := p2pnode.NewNode(p2p.baseApp, cfg.P2P.P2PPrivateKey, cfg.P2P.P2PAddress,
-		cfg.P2P.P2PBootstrap, cfg.P2P.P2PPingPeriod, cfg.Approval.ReplicatePieceTimeoutHeight)
+	node, err := p2pnode.NewNode(p2p.baseApp, cfg.P2P.P2PPrivateKey,
+		cfg.P2P.P2PAddress, cfg.P2P.P2PBootstrap, cfg.P2P.P2PPingPeriod,
+		cfg.Approval.ReplicatePieceTimeoutHeight, cfg.P2P.P2PAntAddress)
 	if err != nil {
 		return err
 	}

--- a/modular/p2p/p2pnode/node.go
+++ b/modular/p2p/p2pnode/node.go
@@ -43,11 +43,13 @@ type Node struct {
 	p2pPingPeriod                  int
 	secondaryApprovalExpiredHeight uint64
 	p2pBootstrap                   []string
+	p2pAntAddress                  string
 }
 
 // NewNode return an instance of Node
 func NewNode(baseApp *gfspapp.GfSpBaseApp, privateKey string, address string,
-	bootstrap []string, pingPeriod int, secondaryApprovalExpiredHeight uint64) (*Node, error) {
+	bootstrap []string, pingPeriod int, secondaryApprovalExpiredHeight uint64,
+	p2pAntAddress string) (*Node, error) {
 	if pingPeriod < PingPeriodMin {
 		pingPeriod = PingPeriodMin
 	}
@@ -127,6 +129,7 @@ func NewNode(baseApp *gfspapp.GfSpBaseApp, privateKey string, address string,
 		p2pProtocolAddress:             hostAddr,
 		p2pPingPeriod:                  pingPeriod,
 		p2pBootstrap:                   bootstrap,
+		p2pAntAddress:                  p2pAntAddress,
 		secondaryApprovalExpiredHeight: secondaryApprovalExpiredHeight,
 		stopCh:                         make(chan struct{}),
 	}

--- a/modular/p2p/p2pnode/node_options.go
+++ b/modular/p2p/p2pnode/node_options.go
@@ -68,7 +68,7 @@ func MakeMultiaddr(address string) (ma.Multiaddr, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Infow("parser p2p node address", "ip", host, "port", port)
+	//log.Infow("parser p2p node address", "address", address, "ip", host, "port", port)
 	return ma.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", host, port))
 }
 

--- a/modular/p2p/p2pnode/ping.go
+++ b/modular/p2p/p2pnode/ping.go
@@ -69,6 +69,21 @@ func (n *Node) onPing(s network.Stream) {
 		pong.Nodes = append(pong.Nodes, nodeInfo)
 		//log.Debugw("send node to remote", "node_id", pID.String(), "remote_node", s.Conn().RemotePeer())
 	}
+	// add self ant address
+	if len(n.p2pAntAddress) > 0 {
+		selfAntAddr, err := MakeMultiaddr(n.p2pAntAddress)
+		if err != nil {
+			log.Errorw("failed to parser self ant address",
+				"ant_address", n.p2pAntAddress, "error", err)
+		} else {
+			nodeInfo := &gfspp2p.GfSpNode{
+				NodeId:    n.node.ID().String(),
+				MultiAddr: []string{selfAntAddr.String()},
+			}
+			pong.Nodes = append(pong.Nodes, nodeInfo)
+		}
+	}
+
 	pong.SpOperatorAddress = n.baseApp.OperateAddress()
 	signature, err := n.baseApp.GfSpClient().SignP2PPongMsg(context.Background(), pong)
 	if err != nil {


### PR DESCRIPTION
### Description

Add p2p ant config, response will parser self ant address to multiaddr to sync.

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 

N/A
