### PR TITLE
fix: blocksyncer fix data index with juno version update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ replace (
 	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v0.0.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.0
-	github.com/forbole/juno/v4 => github.com/bnb-chain/juno/v4 v4.0.0-20230519091839-83376738961a
+	github.com/forbole/juno/v4 => github.com/bnb-chain/juno/v4 v4.0.0-20230524100435-96e3d88a7e6c
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )
@@ -57,6 +57,7 @@ require (
 
 require (
 	github.com/cometbft/cometbft v0.37.1
+	github.com/gogo/protobuf v1.3.3
 	golang.org/x/time v0.3.0
 )
 
@@ -71,7 +72,6 @@ require (
 	github.com/cosmos/gogogateway v1.2.0 // indirect
 	github.com/frankban/quicktest v1.14.4 // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
-	github.com/gogo/protobuf v1.3.3 // indirect
 	github.com/huandu/skiplist v1.2.0 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9/go.mod h1:rbc4o84RSEvhf09o2+4Qiazsv0snRJLiEZdk17HeIDw=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230425074444-eb5869b05fe9 h1:1ZdK+iR1Up02bOa2YTZCml7PBpP//kcdamOcK6aWO/s=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230425074444-eb5869b05fe9/go.mod h1:Ygz4wBHrgc7g0N+8+MrnTfS9LLn9aaTGa9hKopuym5k=
-github.com/bnb-chain/juno/v4 v4.0.0-20230519091839-83376738961a h1:PKiZ4F1lknRrWIcLxGwJgRZTlbVXkdTOmOO2s0zk8ps=
-github.com/bnb-chain/juno/v4 v4.0.0-20230519091839-83376738961a/go.mod h1:4qLwLiWSSOIoGRsA8dUiDIQ51M8w07wXYNhn83tqowk=
+github.com/bnb-chain/juno/v4 v4.0.0-20230524100435-96e3d88a7e6c h1:uxK5xzYQrrm/UvzFFw62w0tKvSind/5SFUXdq+rXIUE=
+github.com/bnb-chain/juno/v4 v4.0.0-20230524100435-96e3d88a7e6c/go.mod h1:4qLwLiWSSOIoGRsA8dUiDIQ51M8w07wXYNhn83tqowk=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/bradfitz/gomemcache v0.0.0-20170208213004-1952afaa557d/go.mod h1:PmM6Mmwb0LSuEubjR8N7PtNe1KxZLtOUHtbeikc5h60=


### PR DESCRIPTION

### Description

blocksyncer changes index type(object table) from unique to normal for object recreate scenario

### Rationale

blocksyncer uses unique union index(bucketname-objectname) while ignored the scenario that an object can be recreated with the same name after deletion. we fix this in this PR with juno version updated.

### Example

N/A

### Changes

Notable changes: 
*  juno version updated with DB index type changed
