### PR TITLE
fix: add default db switch interval

### DIFF
--- a/modular/metadata/metadata_options.go
+++ b/modular/metadata/metadata_options.go
@@ -14,6 +14,8 @@ import (
 const (
 	// DefaultQuerySPParallelPerNode defines the max parallel for retrieving request
 	DefaultQuerySPParallelPerNode int64 = 10240
+	// DefaultBsDBSwitchCheckIntervalSec defines the default db switch check interval in seconds
+	DefaultBsDBSwitchCheckIntervalSec = 30
 )
 
 func NewMetadataModular(app *gfspapp.GfSpBaseApp, cfg *gfspconfig.GfSpConfig) (coremodule.Modular, error) {
@@ -32,6 +34,9 @@ func DefaultMetadataOptions(metadata *MetadataModular, cfg *gfspconfig.GfSpConfi
 	}
 	if cfg.Bucket.FreeQuotaPerBucket == 0 {
 		cfg.Bucket.FreeQuotaPerBucket = downloader.DefaultBucketFreeQuota
+	}
+	if cfg.Metadata.BsDBSwitchCheckIntervalSec == 0 {
+		cfg.Metadata.BsDBSwitchCheckIntervalSec = DefaultBsDBSwitchCheckIntervalSec
 	}
 	metadata.freeQuotaPerBucket = cfg.Bucket.FreeQuotaPerBucket
 	metadata.maxMetadataRequest = cfg.Parallel.QuerySPParallelPerNode


### PR DESCRIPTION
### Description

add default db switch interval

### Rationale

![image](https://github.com/bnb-chain/greenfield-storage-provider/assets/122767193/18b4a8fe-f3d0-4a16-8475-5fed5196a939)

### Example

N/A

### Changes

Notable changes: 
* add default db switch interval

