### PR TITLE
fix: getObjectInfo from correct source

### DIFF
--- a/service/gateway/object_handler.go
+++ b/service/gateway/object_handler.go
@@ -412,9 +412,9 @@ func (gateway *Gateway) getObjectByUniversalEndpointHandler(w http.ResponseWrite
 		w.Header().Set(model.ContentDispositionHeader, model.ContentDispositionInlineValue)
 	}
 	w.Header().Set(model.GnfdRequestIDHeader, reqContext.requestID)
-	w.Header().Set(model.ContentTypeHeader, reqContext.objectInfo.GetContentType())
+	w.Header().Set(model.ContentTypeHeader, getObjectInfoRes.GetObject().GetObjectInfo().GetContentType())
 	if !isRange {
-		w.Header().Set(model.ContentLengthHeader, util.Uint64ToString(reqContext.objectInfo.GetPayloadSize()))
+		w.Header().Set(model.ContentLengthHeader, util.Uint64ToString(getObjectInfoRes.GetObject().GetObjectInfo().GetPayloadSize()))
 	}
 
 	for {


### PR DESCRIPTION
### Description

Fixing issue for get object meta info from incorrect source

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* downloader (universal endpoint)
