### PR TITLE
feat: add removed param for metadata service apis

### DIFF
--- a/base/gfspclient/metadata.go
+++ b/base/gfspclient/metadata.go
@@ -381,6 +381,7 @@ func (s *GfSpClient) GetGroupList(
 	sourceType string,
 	limit int64,
 	offset int64,
+	includeRemoved bool,
 	opts ...grpc.DialOption) ([]*types.Group, int64, error) {
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
@@ -389,11 +390,12 @@ func (s *GfSpClient) GetGroupList(
 	}
 	defer conn.Close()
 	req := &types.GfSpGetGroupListRequest{
-		Name:       name,
-		Prefix:     prefix,
-		SourceType: sourceType,
-		Limit:      limit,
-		Offset:     offset,
+		Name:           name,
+		Prefix:         prefix,
+		SourceType:     sourceType,
+		Limit:          limit,
+		Offset:         offset,
+		IncludeRemoved: includeRemoved,
 	}
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetGroupList(ctx, req)
 	if err != nil {

--- a/base/gfspclient/metadata.go
+++ b/base/gfspclient/metadata.go
@@ -47,14 +47,15 @@ func (s *GfSpClient) ListDeletedObjectsByBlockNumberRange(ctx context.Context, s
 	return resp.GetObjects(), uint64(resp.GetEndBlockNumber()), nil
 }
 
-func (s *GfSpClient) GetUserBuckets(ctx context.Context, account string, opts ...grpc.DialOption) ([]*types.Bucket, error) {
+func (s *GfSpClient) GetUserBuckets(ctx context.Context, account string, includeRemoved bool, opts ...grpc.DialOption) ([]*types.Bucket, error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
 		return nil, err
 	}
 	defer conn.Close()
 	req := &types.GfSpGetUserBucketsRequest{
-		AccountId: account,
+		AccountId:      account,
+		IncludeRemoved: includeRemoved,
 	}
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetUserBuckets(ctx, req)
 	if err != nil {

--- a/base/gfspclient/metadata.go
+++ b/base/gfspclient/metadata.go
@@ -12,14 +12,15 @@ import (
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
 )
 
-func (s *GfSpClient) GetUserBucketsCount(ctx context.Context, account string, opts ...grpc.DialOption) (int64, error) {
+func (s *GfSpClient) GetUserBucketsCount(ctx context.Context, account string, includeRemoved bool, opts ...grpc.DialOption) (int64, error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
 		return 0, err
 	}
 	defer conn.Close()
 	req := &types.GfSpGetUserBucketsCountRequest{
-		AccountId: account,
+		AccountId:      account,
+		IncludeRemoved: includeRemoved,
 	}
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetUserBucketsCount(ctx, req)
 	if err != nil {
@@ -66,7 +67,7 @@ func (s *GfSpClient) GetUserBuckets(ctx context.Context, account string, include
 
 // ListObjectsByBucketName list objects info by a bucket name
 func (s *GfSpClient) ListObjectsByBucketName(ctx context.Context, bucketName string, accountId string, maxKeys uint64,
-	startAfter string, continuationToken string, delimiter string, prefix string, opts ...grpc.DialOption) (
+	startAfter string, continuationToken string, delimiter string, prefix string, includeRemoved bool, opts ...grpc.DialOption) (
 	objects []*types.Object, KeyCount uint64, MaxKeys uint64, IsTruncated bool, NextContinuationToken string,
 	Name string, Prefix string, Delimiter string, CommonPrefixes []string, ContinuationToken string, err error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
@@ -83,6 +84,7 @@ func (s *GfSpClient) ListObjectsByBucketName(ctx context.Context, bucketName str
 		ContinuationToken: continuationToken,
 		Delimiter:         delimiter,
 		Prefix:            prefix,
+		IncludeRemoved:    includeRemoved,
 	}
 
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpListObjectsByBucketName(ctx, req)

--- a/base/gfspclient/metadata.go
+++ b/base/gfspclient/metadata.go
@@ -38,7 +38,7 @@ func (s *GfSpClient) ListDeletedObjectsByBlockNumberRange(ctx context.Context, s
 	req := &types.GfSpListDeletedObjectsByBlockNumberRangeRequest{
 		StartBlockNumber: int64(startBlockNumber),
 		EndBlockNumber:   int64(endBlockNumber),
-		IsFullList:       includePrivate,
+		IncludePrivate:   includePrivate,
 	}
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpListDeletedObjectsByBlockNumberRange(ctx, req)
 	if err != nil {
@@ -95,7 +95,7 @@ func (s *GfSpClient) ListObjectsByBucketName(ctx context.Context, bucketName str
 }
 
 // GetBucketByBucketName get bucket info by a bucket name
-func (s *GfSpClient) GetBucketByBucketName(ctx context.Context, bucketName string, isFullList bool,
+func (s *GfSpClient) GetBucketByBucketName(ctx context.Context, bucketName string, includePrivate bool,
 	opts ...grpc.DialOption) (*types.Bucket, error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
@@ -104,8 +104,8 @@ func (s *GfSpClient) GetBucketByBucketName(ctx context.Context, bucketName strin
 	defer conn.Close()
 
 	req := &types.GfSpGetBucketByBucketNameRequest{
-		BucketName: bucketName,
-		IsFullList: isFullList,
+		BucketName:     bucketName,
+		IncludePrivate: includePrivate,
 	}
 
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetBucketByBucketName(ctx, req)
@@ -118,7 +118,7 @@ func (s *GfSpClient) GetBucketByBucketName(ctx context.Context, bucketName strin
 }
 
 // GetBucketByBucketID get bucket info by a bucket id
-func (s *GfSpClient) GetBucketByBucketID(ctx context.Context, bucketId int64, isFullList bool,
+func (s *GfSpClient) GetBucketByBucketID(ctx context.Context, bucketId int64, includePrivate bool,
 	opts ...grpc.DialOption) (*types.GfSpGetBucketByBucketIDResponse, error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
@@ -127,8 +127,8 @@ func (s *GfSpClient) GetBucketByBucketID(ctx context.Context, bucketId int64, is
 	defer conn.Close()
 
 	req := &types.GfSpGetBucketByBucketIDRequest{
-		BucketId:   bucketId,
-		IsFullList: isFullList,
+		BucketId:       bucketId,
+		IncludePrivate: includePrivate,
 	}
 
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetBucketByBucketID(ctx, req)
@@ -166,7 +166,7 @@ func (s *GfSpClient) ListExpiredBucketsBySp(ctx context.Context, createAt int64,
 
 // GetObjectMeta get object metadata
 func (s *GfSpClient) GetObjectMeta(ctx context.Context, objectName string, bucketName string,
-	isFullList bool, opts ...grpc.DialOption) (*types.Object, error) {
+	includePrivate bool, opts ...grpc.DialOption) (*types.Object, error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
 		return nil, err
@@ -174,9 +174,9 @@ func (s *GfSpClient) GetObjectMeta(ctx context.Context, objectName string, bucke
 	defer conn.Close()
 
 	req := &types.GfSpGetObjectMetaRequest{
-		ObjectName: objectName,
-		BucketName: bucketName,
-		IsFullList: isFullList,
+		ObjectName:     objectName,
+		BucketName:     bucketName,
+		IncludePrivate: includePrivate,
 	}
 
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetObjectMeta(ctx, req)
@@ -189,7 +189,7 @@ func (s *GfSpClient) GetObjectMeta(ctx context.Context, objectName string, bucke
 }
 
 // GetPaymentByBucketName get bucket payment info by a bucket name
-func (s *GfSpClient) GetPaymentByBucketName(ctx context.Context, bucketName string, isFullList bool,
+func (s *GfSpClient) GetPaymentByBucketName(ctx context.Context, bucketName string, includePrivate bool,
 	opts ...grpc.DialOption) (*payment_types.StreamRecord, error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
@@ -198,8 +198,8 @@ func (s *GfSpClient) GetPaymentByBucketName(ctx context.Context, bucketName stri
 	defer conn.Close()
 
 	req := &types.GfSpGetPaymentByBucketNameRequest{
-		BucketName: bucketName,
-		IsFullList: isFullList,
+		BucketName:     bucketName,
+		IncludePrivate: includePrivate,
 	}
 
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetPaymentByBucketName(ctx, req)
@@ -212,7 +212,7 @@ func (s *GfSpClient) GetPaymentByBucketName(ctx context.Context, bucketName stri
 }
 
 // GetPaymentByBucketID get bucket payment info by a bucket id
-func (s *GfSpClient) GetPaymentByBucketID(ctx context.Context, bucketID int64, isFullList bool,
+func (s *GfSpClient) GetPaymentByBucketID(ctx context.Context, bucketID int64, includePrivate bool,
 	opts ...grpc.DialOption) (*payment_types.StreamRecord, error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
@@ -221,8 +221,8 @@ func (s *GfSpClient) GetPaymentByBucketID(ctx context.Context, bucketID int64, i
 	defer conn.Close()
 
 	req := &types.GfSpGetPaymentByBucketIDRequest{
-		BucketId:   bucketID,
-		IsFullList: isFullList,
+		BucketId:       bucketID,
+		IncludePrivate: includePrivate,
 	}
 
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetPaymentByBucketID(ctx, req)
@@ -260,7 +260,7 @@ func (s *GfSpClient) VerifyPermission(ctx context.Context, Operator string, buck
 }
 
 // GetBucketMeta get bucket info along with its related info such as payment
-func (s *GfSpClient) GetBucketMeta(ctx context.Context, bucketName string, isFullList bool,
+func (s *GfSpClient) GetBucketMeta(ctx context.Context, bucketName string, includePrivate bool,
 	opts ...grpc.DialOption) (*types.Bucket, *payment_types.StreamRecord, error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
@@ -269,8 +269,8 @@ func (s *GfSpClient) GetBucketMeta(ctx context.Context, bucketName string, isFul
 	defer conn.Close()
 
 	req := &types.GfSpGetBucketMetaRequest{
-		BucketName: bucketName,
-		IsFullList: isFullList,
+		BucketName:     bucketName,
+		IncludePrivate: includePrivate,
 	}
 
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetBucketMeta(ctx, req)

--- a/core/bsdb/metadata.go
+++ b/core/bsdb/metadata.go
@@ -12,15 +12,15 @@ type MetadataDB interface {
 	// GetUserBucketsCount get buckets count by a user address
 	GetUserBucketsCount(accountID common.Address) (int64, error)
 	// GetBucketByName get buckets info by a bucket name
-	GetBucketByName(bucketName string, isFullList bool) (*bsdb.Bucket, error)
+	GetBucketByName(bucketName string, includePrivate bool) (*bsdb.Bucket, error)
 	// GetBucketByID get buckets info by by a bucket id
-	GetBucketByID(bucketID int64, isFullList bool) (*bsdb.Bucket, error)
+	GetBucketByID(bucketID int64, includePrivate bool) (*bsdb.Bucket, error)
 	// GetLatestBlockNumber get current latest block number
 	GetLatestBlockNumber() (int64, error)
 	// GetPaymentByBucketName get bucket payment info by a bucket name
-	GetPaymentByBucketName(bucketName string, isFullList bool) (*bsdb.StreamRecord, error)
+	GetPaymentByBucketName(bucketName string, includePrivate bool) (*bsdb.StreamRecord, error)
 	// GetPaymentByBucketID get bucket payment info by a bucket id
-	GetPaymentByBucketID(bucketID int64, isFullList bool) (*bsdb.StreamRecord, error)
+	GetPaymentByBucketID(bucketID int64, includePrivate bool) (*bsdb.StreamRecord, error)
 	// GetPaymentByPaymentAddress get bucket payment info by a payment address
 	GetPaymentByPaymentAddress(address common.Address) (*bsdb.StreamRecord, error)
 	// GetPermissionByResourceAndPrincipal get permission info by resource type & id, principal type & value
@@ -34,13 +34,13 @@ type MetadataDB interface {
 	// ListObjectsByBucketName list objects info by a bucket name
 	ListObjectsByBucketName(bucketName, continuationToken, prefix, delimiter string, maxKeys int) ([]*bsdb.ListObjectsResult, error)
 	// ListDeletedObjectsByBlockNumberRange list deleted objects info by a block number range
-	ListDeletedObjectsByBlockNumberRange(startBlockNumber int64, endBlockNumber int64, isFullList bool) ([]*bsdb.Object, error)
+	ListDeletedObjectsByBlockNumberRange(startBlockNumber int64, endBlockNumber int64, includePrivate bool) ([]*bsdb.Object, error)
 	// ListExpiredBucketsBySp list expired buckets by sp
 	ListExpiredBucketsBySp(createAt int64, primarySpAddress string, limit int64) ([]*bsdb.Bucket, error)
 	// GetObjectByName get object info by an object name
-	GetObjectByName(objectName string, bucketName string, isFullList bool) (*bsdb.Object, error)
+	GetObjectByName(objectName string, bucketName string, includePrivate bool) (*bsdb.Object, error)
 	// GetSwitchDBSignal check if there is a signal to switch the database
 	GetSwitchDBSignal() (*bsdb.MasterDB, error)
 	// GetBucketMetaByName get bucket info with its related info
-	GetBucketMetaByName(bucketName string, isFullList bool) (*bsdb.BucketFullMeta, error)
+	GetBucketMetaByName(bucketName string, includePrivate bool) (*bsdb.BucketFullMeta, error)
 }

--- a/modular/approver/approve_task.go
+++ b/modular/approver/approve_task.go
@@ -47,7 +47,7 @@ func (a *ApprovalModular) HandleCreateBucketApprovalTask(ctx context.Context, ta
 		log.CtxErrorw(ctx, "repeated create bucket approval task is returned")
 		return true, nil
 	}
-	buckets, err := a.baseApp.GfSpClient().GetUserBucketsCount(ctx, task.GetCreateBucketInfo().GetCreator())
+	buckets, err := a.baseApp.GfSpClient().GetUserBucketsCount(ctx, task.GetCreateBucketInfo().GetCreator(), false)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get account owns max bucket number", "error", err)
 		return false, err

--- a/modular/gater/metadata_handler.go
+++ b/modular/gater/metadata_handler.go
@@ -484,7 +484,7 @@ func (g *GateModular) getGroupListHandler(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	groups, count, err = g.baseApp.GfSpClient().GetGroupList(reqCtx.Context(), name, prefix, sourceType, limit, offset)
+	groups, count, err = g.baseApp.GfSpClient().GetGroupList(reqCtx.Context(), name, prefix, sourceType, limit, offset, false)
 	if err != nil {
 		log.Errorf("failed to get group list", "error", err)
 		return

--- a/modular/gater/metadata_handler.go
+++ b/modular/gater/metadata_handler.go
@@ -193,7 +193,8 @@ func (g *GateModular) listObjectsByBucketNameHandler(w http.ResponseWriter, r *h
 			requestStartAfter,
 			continuationToken,
 			requestDelimiter,
-			requestPrefix)
+			requestPrefix,
+			true)
 	if err != nil {
 		log.Errorf("failed to list objects by bucket name", "error", err)
 		return

--- a/modular/gater/metadata_handler.go
+++ b/modular/gater/metadata_handler.go
@@ -54,7 +54,7 @@ func (g *GateModular) getUserBucketsHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	resp, err := g.baseApp.GfSpClient().GetUserBuckets(reqCtx.Context(), r.Header.Get(GnfdUserAddressHeader))
+	resp, err := g.baseApp.GfSpClient().GetUserBuckets(reqCtx.Context(), r.Header.Get(GnfdUserAddressHeader), true)
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get user buckets", "error", err)
 		return

--- a/modular/metadata/metadata_bucket_service.go
+++ b/modular/metadata/metadata_bucket_service.go
@@ -35,7 +35,7 @@ func (r *MetadataModular) GfSpGetUserBuckets(
 	req *types.GfSpGetUserBucketsRequest) (
 	resp *types.GfSpGetUserBucketsResponse, err error) {
 	ctx = log.Context(ctx, req)
-	buckets, err := r.baseApp.GfBsDB().GetUserBuckets(common.HexToAddress(req.AccountId))
+	buckets, err := r.baseApp.GfBsDB().GetUserBuckets(common.HexToAddress(req.AccountId), req.GetIncludeRemoved())
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get user buckets", "error", err)
 		return
@@ -181,7 +181,7 @@ func (r *MetadataModular) GfSpGetBucketByBucketID(ctx context.Context, req *type
 func (r *MetadataModular) GfSpGetUserBucketsCount(ctx context.Context, req *types.GfSpGetUserBucketsCountRequest) (resp *types.GfSpGetUserBucketsCountResponse, err error) {
 	ctx = log.Context(ctx, req)
 
-	count, err := r.baseApp.GfBsDB().GetUserBucketsCount(common.HexToAddress(req.AccountId))
+	count, err := r.baseApp.GfBsDB().GetUserBucketsCount(common.HexToAddress(req.AccountId), true)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get user buckets count", "error", err)
 		return

--- a/modular/metadata/metadata_bucket_service.go
+++ b/modular/metadata/metadata_bucket_service.go
@@ -181,7 +181,7 @@ func (r *MetadataModular) GfSpGetBucketByBucketID(ctx context.Context, req *type
 func (r *MetadataModular) GfSpGetUserBucketsCount(ctx context.Context, req *types.GfSpGetUserBucketsCountRequest) (resp *types.GfSpGetUserBucketsCountResponse, err error) {
 	ctx = log.Context(ctx, req)
 
-	count, err := r.baseApp.GfBsDB().GetUserBucketsCount(common.HexToAddress(req.AccountId), true)
+	count, err := r.baseApp.GfBsDB().GetUserBucketsCount(common.HexToAddress(req.AccountId), req.GetIncludeRemoved())
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get user buckets count", "error", err)
 		return

--- a/modular/metadata/metadata_bucket_service.go
+++ b/modular/metadata/metadata_bucket_service.go
@@ -89,7 +89,7 @@ func (r *MetadataModular) GfSpGetBucketByBucketName(ctx context.Context, req *ty
 		return nil, err
 	}
 
-	bucket, err = r.baseApp.GfBsDB().GetBucketByName(req.BucketName, req.IsFullList)
+	bucket, err = r.baseApp.GfBsDB().GetBucketByName(req.BucketName, req.IncludePrivate)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get bucket by bucket name", "error", err)
 		return nil, err
@@ -137,7 +137,7 @@ func (r *MetadataModular) GfSpGetBucketByBucketID(ctx context.Context, req *type
 	)
 
 	ctx = log.Context(ctx, req)
-	bucket, err = r.baseApp.GfBsDB().GetBucketByID(req.BucketId, req.IsFullList)
+	bucket, err = r.baseApp.GfBsDB().GetBucketByID(req.BucketId, req.IncludePrivate)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get bucket by bucket id", "error", err)
 		return nil, err
@@ -245,7 +245,7 @@ func (r *MetadataModular) GfSpGetBucketMeta(
 	)
 
 	ctx = log.Context(ctx, req)
-	bucketFullMeta, err := r.baseApp.GfBsDB().GetBucketMetaByName(req.GetBucketName(), req.GetIsFullList())
+	bucketFullMeta, err := r.baseApp.GfBsDB().GetBucketMetaByName(req.GetBucketName(), req.GetIncludePrivate())
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get bucket meta by name", "error", err)
 		return

--- a/modular/metadata/metadata_group_service.go
+++ b/modular/metadata/metadata_group_service.go
@@ -20,7 +20,7 @@ func (r *MetadataModular) GfSpGetGroupList(ctx context.Context, req *types.GfSpG
 	)
 
 	ctx = log.Context(ctx, req)
-	groups, count, err = r.baseApp.GfBsDB().ListGroupsByNameAndSourceType(req.Name, req.Prefix, req.SourceType, int(req.Limit), int(req.Offset))
+	groups, count, err = r.baseApp.GfBsDB().ListGroupsByNameAndSourceType(req.Name, req.Prefix, req.SourceType, int(req.Limit), int(req.Offset), req.IncludeRemoved)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get group list", "error", err)
 		return nil, err

--- a/modular/metadata/metadata_object_service.go
+++ b/modular/metadata/metadata_object_service.go
@@ -120,7 +120,7 @@ func (r *MetadataModular) GfSpListDeletedObjectsByBlockNumberRange(ctx context.C
 		endBlockNumber = req.EndBlockNumber
 	}
 
-	objects, err := r.baseApp.GfBsDB().ListDeletedObjectsByBlockNumberRange(req.StartBlockNumber, endBlockNumber, req.IsFullList)
+	objects, err := r.baseApp.GfBsDB().ListDeletedObjectsByBlockNumberRange(req.StartBlockNumber, endBlockNumber, req.IncludePrivate)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to list deleted objects by block number range", "error", err)
 		return nil, err
@@ -177,7 +177,7 @@ func (r *MetadataModular) GfSpGetObjectMeta(ctx context.Context, req *types.GfSp
 		return nil, err
 	}
 
-	object, err = r.baseApp.GfBsDB().GetObjectByName(req.ObjectName, req.BucketName, req.IsFullList)
+	object, err = r.baseApp.GfBsDB().GetObjectByName(req.ObjectName, req.BucketName, req.IncludePrivate)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get object by object name", "error", err)
 		return nil, err

--- a/modular/metadata/metadata_object_service.go
+++ b/modular/metadata/metadata_object_service.go
@@ -37,7 +37,7 @@ func (r *MetadataModular) GfSpListObjectsByBucketName(ctx context.Context, req *
 	}
 
 	ctx = log.Context(ctx, req)
-	results, err = r.baseApp.GfBsDB().ListObjectsByBucketName(req.BucketName, req.ContinuationToken, req.Prefix, req.Delimiter, int(maxKeys))
+	results, err = r.baseApp.GfBsDB().ListObjectsByBucketName(req.BucketName, req.ContinuationToken, req.Prefix, req.Delimiter, int(maxKeys), req.IncludeRemoved)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to list objects by bucket name", "error", err)
 		return

--- a/modular/metadata/metadata_payment_service.go
+++ b/modular/metadata/metadata_payment_service.go
@@ -22,7 +22,7 @@ func (r *MetadataModular) GfSpGetPaymentByBucketName(ctx context.Context, req *t
 
 	ctx = log.Context(ctx, req)
 
-	streamRecord, err = r.baseApp.GfBsDB().GetPaymentByBucketName(req.BucketName, req.IsFullList)
+	streamRecord, err = r.baseApp.GfBsDB().GetPaymentByBucketName(req.BucketName, req.IncludePrivate)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get payment by bucket name", "error", err)
 		return
@@ -62,7 +62,7 @@ func (r *MetadataModular) GfSpGetPaymentByBucketID(ctx context.Context, req *typ
 
 	ctx = log.Context(ctx, req)
 
-	streamRecord, err = r.baseApp.GfBsDB().GetPaymentByBucketID(req.BucketId, req.IsFullList)
+	streamRecord, err = r.baseApp.GfBsDB().GetPaymentByBucketID(req.BucketId, req.IncludePrivate)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get payment by bucket id", "error", err)
 		return

--- a/modular/metadata/metadata_permission_service.go
+++ b/modular/metadata/metadata_permission_service.go
@@ -216,7 +216,7 @@ func (r *MetadataModular) VerifyPolicy(ctx context.Context, resourceID math.Uint
 
 	if permission != nil {
 		accountPolicyID = append(accountPolicyID, permission.PolicyID)
-		statements, err = r.baseApp.GfBsDB().GetStatementsByPolicyID(accountPolicyID)
+		statements, err = r.baseApp.GfBsDB().GetStatementsByPolicyID(accountPolicyID, false)
 		if err != nil {
 			log.CtxErrorw(ctx, "failed to get statements by policy id", "error", err)
 			return permtypes.EFFECT_DENY, err
@@ -230,7 +230,7 @@ func (r *MetadataModular) VerifyPolicy(ctx context.Context, resourceID math.Uint
 	}
 
 	// verify policy which grant permission to group
-	permissions, err = r.baseApp.GfBsDB().GetPermissionsByResourceAndPrincipleType(resourceType.String(), permtypes.PRINCIPAL_TYPE_GNFD_GROUP.String(), common.BigToHash(resourceID.BigInt()))
+	permissions, err = r.baseApp.GfBsDB().GetPermissionsByResourceAndPrincipleType(resourceType.String(), permtypes.PRINCIPAL_TYPE_GNFD_GROUP.String(), common.BigToHash(resourceID.BigInt()), false)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get permission by resource and principle type", "error", err)
 		return permtypes.EFFECT_DENY, err
@@ -240,7 +240,7 @@ func (r *MetadataModular) VerifyPolicy(ctx context.Context, resourceID math.Uint
 		for i, perm := range permissions {
 			groupIDList[i] = common.BigToHash(math.NewUintFromString(perm.PrincipalValue).BigInt())
 		}
-		groups, err = r.baseApp.GfBsDB().GetGroupsByGroupIDAndAccount(groupIDList, common.HexToAddress(operator.String()))
+		groups, err = r.baseApp.GfBsDB().GetGroupsByGroupIDAndAccount(groupIDList, common.HexToAddress(operator.String()), false)
 		if err != nil {
 			log.CtxErrorw(ctx, "failed to get groups by group id and account", "error", err)
 			return permtypes.EFFECT_DENY, err
@@ -261,7 +261,7 @@ func (r *MetadataModular) VerifyPolicy(ctx context.Context, resourceID math.Uint
 		}
 	}
 
-	statements, err = r.baseApp.GfBsDB().GetStatementsByPolicyID(policyIDList)
+	statements, err = r.baseApp.GfBsDB().GetStatementsByPolicyID(policyIDList, false)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get statements by policy id", "error", err)
 		return permtypes.EFFECT_DENY, err

--- a/proto/modular/metadata/types/metadata.proto
+++ b/proto/modular/metadata/types/metadata.proto
@@ -114,8 +114,8 @@ message GfSpListObjectsByBucketNameResponse {
 message GfSpGetBucketByBucketNameRequest {
   // bucket_name is the name of the bucket
   string bucket_name = 1;
-  // is_full_list indicates whether this request can get the private buckets information
-  bool is_full_list = 2;
+  // include_private indicates whether this request can get the private buckets information
+  bool include_private = 2;
 }
 
 // GfSpGetBucketByBucketNameResponse is response type for the GfSpGetBucketByBucketName RPC method.
@@ -128,8 +128,8 @@ message GfSpGetBucketByBucketNameResponse {
 message GfSpGetBucketByBucketIDRequest {
   // bucket_id is the unique identifier of bucket
   int64 bucket_id = 1;
-  // is_full_list indicates whether this request can get the private buckets information
-  bool is_full_list = 2;
+  // include_private indicates whether this request can get the private buckets information
+  bool include_private = 2;
 }
 
 // GfSpGetBucketByBucketIDResponse is response type for the GfSpGetBucketByBucketID RPC method.
@@ -146,8 +146,8 @@ message GfSpListDeletedObjectsByBlockNumberRangeRequest {
   // end_block_number defines the end of range
   // end_block_number < 0 or start_block_number > end_block_number is invalid
   int64 end_block_number = 2;
-  // is_full_list indicates whether this request can get the private objects information
-  bool is_full_list = 3;
+  // include_private indicates whether this request can get the private objects information
+  bool include_private = 3;
 }
 
 // GfSpListDeletedObjectsByBlockNumberRangeResponse is response type for the GfSpListDeletedObjectsByBlockNumberRange RPC method.
@@ -192,8 +192,8 @@ message GfSpGetObjectMetaRequest {
   string object_name = 1;
   // bucket_name is the name of the bucket
   string bucket_name = 2;
-  // is_full_list indicates whether this request can get the private objects information
-  bool is_full_list = 3;
+  // include_private indicates whether this request can get the private objects information
+  bool include_private = 3;
 }
 
 // GfSpGetObjectMetaResponse is response type for the GfSpGetObjectMeta RPC method.
@@ -206,8 +206,8 @@ message GfSpGetObjectMetaResponse {
 message GfSpGetPaymentByBucketNameRequest {
   // bucket_name is the name of the bucket
   string bucket_name = 1;
-  // is_full_list indicates whether this request can get the private buckets information
-  bool is_full_list = 2;
+  // include_private indicates whether this request can get the private buckets information
+  bool include_private = 2;
 }
 
 // GfSpGetPaymentByBucketNameResponse is response type for the GfSpGetPaymentByBucketName RPC method.
@@ -220,8 +220,8 @@ message GfSpGetPaymentByBucketNameResponse {
 message GfSpGetPaymentByBucketIDRequest {
   // bucket_id is the unique identifier of bucket
   int64 bucket_id = 1;
-  // is_full_list indicates whether this request can get the private buckets information
-  bool is_full_list = 2;
+  // include_private indicates whether this request can get the private buckets information
+  bool include_private = 2;
 }
 
 // GfSpGetPaymentByBucketIDResponse is response type for the GfSpGetPaymentByBucketID RPC method.
@@ -234,8 +234,8 @@ message GfSpGetPaymentByBucketIDResponse {
 message GfSpGetBucketMetaRequest {
   // bucket_name is the name of the bucket
   string bucket_name = 1;
-  // is_full_list indicates whether this request can get the private buckets information
-  bool is_full_list = 2;
+  // include_private indicates whether this request can get the private buckets information
+  bool include_private = 2;
 }
 
 // GfSpGetBucketMetaResponse is response type for the GfSpGetBucketMeta RPC method

--- a/proto/modular/metadata/types/metadata.proto
+++ b/proto/modular/metadata/types/metadata.proto
@@ -86,6 +86,8 @@ message GfSpListObjectsByBucketNameRequest {
   string delimiter = 6;
   // prefix limits the response to keys that begin with the specified prefix
   string prefix = 7;
+  // include_removed indicates whether this request can get the removed objects information
+  bool include_removed = 8;
 }
 
 // GfSpListObjectsByBucketNameResponse is response type for the GfSpListObjectsByBucketName RPC method.
@@ -164,6 +166,8 @@ message GfSpListDeletedObjectsByBlockNumberRangeResponse {
 message GfSpGetUserBucketsCountRequest {
   // account_id is the account address of user
   string account_id = 1;
+  // include_removed indicates whether this request can get the removed buckets information
+  bool include_removed = 2;
 }
 
 // GfSpGetUserBucketsCountResponse is response type for the GfSpGetUserBucketsCount RPC method.

--- a/proto/modular/metadata/types/metadata.proto
+++ b/proto/modular/metadata/types/metadata.proto
@@ -60,6 +60,8 @@ message Object {
 message GfSpGetUserBucketsRequest {
   // account_id is the account address of user
   string account_id = 1;
+  // include_removed indicates whether this request can get the removed buckets information
+  bool include_removed = 2;
 }
 
 // GfSpGetUserBucketsResponse is response type for the GfSpGetUserBuckets RPC method.

--- a/proto/modular/metadata/types/metadata.proto
+++ b/proto/modular/metadata/types/metadata.proto
@@ -361,6 +361,8 @@ message GfSpGetGroupListRequest {
   int64 limit = 4;
   // offset defines the position in the list from where to start returning results
   int64 offset = 5;
+  // include_removed indicates whether this request can get the removed groups information
+  bool include_removed = 6;
 }
 
 // GfSpGetGroupListResponse is response type for the GetGroupList RPC method.

--- a/store/bsdb/bucket.go
+++ b/store/bsdb/bucket.go
@@ -27,13 +27,13 @@ func (b *BsDBImpl) GetUserBuckets(accountID common.Address) ([]*Bucket, error) {
 }
 
 // GetBucketByName get buckets info by a bucket name
-func (b *BsDBImpl) GetBucketByName(bucketName string, isFullList bool) (*Bucket, error) {
+func (b *BsDBImpl) GetBucketByName(bucketName string, includePrivate bool) (*Bucket, error) {
 	var (
 		bucket *Bucket
 		err    error
 	)
 
-	if isFullList {
+	if includePrivate {
 		err = b.db.Take(&bucket, "bucket_name = ?", bucketName).Error
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
@@ -49,7 +49,7 @@ func (b *BsDBImpl) GetBucketByName(bucketName string, isFullList bool) (*Bucket,
 }
 
 // GetBucketByID get buckets info by a bucket id
-func (b *BsDBImpl) GetBucketByID(bucketID int64, isFullList bool) (*Bucket, error) {
+func (b *BsDBImpl) GetBucketByID(bucketID int64, includePrivate bool) (*Bucket, error) {
 	var (
 		bucket       *Bucket
 		err          error
@@ -57,7 +57,7 @@ func (b *BsDBImpl) GetBucketByID(bucketID int64, isFullList bool) (*Bucket, erro
 	)
 
 	bucketIDHash = common.HexToHash(strconv.FormatInt(bucketID, 10))
-	if isFullList {
+	if includePrivate {
 		err = b.db.Take(&bucket, "bucket_id = ?", bucketIDHash).Error
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
@@ -104,13 +104,13 @@ func (b *BsDBImpl) ListExpiredBucketsBySp(createAt int64, primarySpAddress strin
 	return buckets, err
 }
 
-func (b *BsDBImpl) GetBucketMetaByName(bucketName string, isFullList bool) (*BucketFullMeta, error) {
+func (b *BsDBImpl) GetBucketMetaByName(bucketName string, includePrivate bool) (*BucketFullMeta, error) {
 	var (
 		bucketFullMeta *BucketFullMeta
 		err            error
 	)
 
-	if isFullList {
+	if includePrivate {
 		err = b.db.Table((&Bucket{}).TableName()).
 			Select("*").
 			Joins("left join stream_records on buckets.payment_address = stream_records.account").

--- a/store/bsdb/database.go
+++ b/store/bsdb/database.go
@@ -11,15 +11,15 @@ type Metadata interface {
 	// GetUserBucketsCount get buckets count by a user address
 	GetUserBucketsCount(accountID common.Address) (int64, error)
 	// GetBucketByName get buckets info by a bucket name
-	GetBucketByName(bucketName string, isFullList bool) (*Bucket, error)
+	GetBucketByName(bucketName string, includePrivate bool) (*Bucket, error)
 	// GetBucketByID get buckets info by by a bucket id
-	GetBucketByID(bucketID int64, isFullList bool) (*Bucket, error)
+	GetBucketByID(bucketID int64, includePrivate bool) (*Bucket, error)
 	// GetLatestBlockNumber get current latest block number
 	GetLatestBlockNumber() (int64, error)
 	// GetPaymentByBucketName get bucket payment info by a bucket name
-	GetPaymentByBucketName(bucketName string, isFullList bool) (*StreamRecord, error)
+	GetPaymentByBucketName(bucketName string, includePrivate bool) (*StreamRecord, error)
 	// GetPaymentByBucketID get bucket payment info by a bucket id
-	GetPaymentByBucketID(bucketID int64, isFullList bool) (*StreamRecord, error)
+	GetPaymentByBucketID(bucketID int64, includePrivate bool) (*StreamRecord, error)
 	// GetPaymentByPaymentAddress get bucket payment info by a payment address
 	GetPaymentByPaymentAddress(address common.Address) (*StreamRecord, error)
 	// GetPermissionByResourceAndPrincipal get permission info by resource type & id, principal type & value
@@ -33,15 +33,15 @@ type Metadata interface {
 	// ListObjectsByBucketName list objects info by a bucket name
 	ListObjectsByBucketName(bucketName, continuationToken, prefix, delimiter string, maxKeys int) ([]*ListObjectsResult, error)
 	// ListDeletedObjectsByBlockNumberRange list deleted objects info by a block number range
-	ListDeletedObjectsByBlockNumberRange(startBlockNumber int64, endBlockNumber int64, isFullList bool) ([]*Object, error)
+	ListDeletedObjectsByBlockNumberRange(startBlockNumber int64, endBlockNumber int64, includePrivate bool) ([]*Object, error)
 	// ListExpiredBucketsBySp list expired buckets by sp
 	ListExpiredBucketsBySp(createAt int64, primarySpAddress string, limit int64) ([]*Bucket, error)
 	// GetObjectByName get object info by an object name
-	GetObjectByName(objectName string, bucketName string, isFullList bool) (*Object, error)
+	GetObjectByName(objectName string, bucketName string, includePrivate bool) (*Object, error)
 	// GetSwitchDBSignal check if there is a signal to switch the database
 	GetSwitchDBSignal() (*MasterDB, error)
 	// GetBucketMetaByName get bucket info with its related info
-	GetBucketMetaByName(bucketName string, isFullList bool) (*BucketFullMeta, error)
+	GetBucketMetaByName(bucketName string, includePrivate bool) (*BucketFullMeta, error)
 	// ListGroupsByNameAndSourceType get groups list by specific parameters
 	ListGroupsByNameAndSourceType(name, prefix, sourceType string, limit, offset int) ([]*Group, int64, error)
 }

--- a/store/bsdb/database.go
+++ b/store/bsdb/database.go
@@ -7,9 +7,9 @@ import (
 // Metadata contains all the methods required by block syncer db database
 type Metadata interface {
 	// GetUserBuckets get buckets info by a user address
-	GetUserBuckets(accountID common.Address, includeRemoved bool) ([]*Bucket, error)
+	GetUserBuckets(accountID common.Address) ([]*Bucket, error)
 	// GetUserBucketsCount get buckets count by a user address
-	GetUserBucketsCount(accountID common.Address, includeRemoved bool) (int64, error)
+	GetUserBucketsCount(accountID common.Address) (int64, error)
 	// GetBucketByName get buckets info by a bucket name
 	GetBucketByName(bucketName string, includePrivate bool) (*Bucket, error)
 	// GetBucketByID get buckets info by by a bucket id

--- a/store/bsdb/database.go
+++ b/store/bsdb/database.go
@@ -7,9 +7,9 @@ import (
 // Metadata contains all the methods required by block syncer db database
 type Metadata interface {
 	// GetUserBuckets get buckets info by a user address
-	GetUserBuckets(accountID common.Address) ([]*Bucket, error)
+	GetUserBuckets(accountID common.Address, includeRemoved bool) ([]*Bucket, error)
 	// GetUserBucketsCount get buckets count by a user address
-	GetUserBucketsCount(accountID common.Address) (int64, error)
+	GetUserBucketsCount(accountID common.Address, includeRemoved bool) (int64, error)
 	// GetBucketByName get buckets info by a bucket name
 	GetBucketByName(bucketName string, includePrivate bool) (*Bucket, error)
 	// GetBucketByID get buckets info by by a bucket id

--- a/store/bsdb/database.go
+++ b/store/bsdb/database.go
@@ -7,9 +7,9 @@ import (
 // Metadata contains all the methods required by block syncer db database
 type Metadata interface {
 	// GetUserBuckets get buckets info by a user address
-	GetUserBuckets(accountID common.Address) ([]*Bucket, error)
+	GetUserBuckets(accountID common.Address, includeRemoved bool) ([]*Bucket, error)
 	// GetUserBucketsCount get buckets count by a user address
-	GetUserBucketsCount(accountID common.Address) (int64, error)
+	GetUserBucketsCount(accountID common.Address, includeRemoved bool) (int64, error)
 	// GetBucketByName get buckets info by a bucket name
 	GetBucketByName(bucketName string, includePrivate bool) (*Bucket, error)
 	// GetBucketByID get buckets info by by a bucket id
@@ -25,13 +25,13 @@ type Metadata interface {
 	// GetPermissionByResourceAndPrincipal get permission info by resource type & id, principal type & value
 	GetPermissionByResourceAndPrincipal(resourceType, principalType, principalValue string, resourceID common.Hash) (*Permission, error)
 	// GetStatementsByPolicyID get statements info by a policy id
-	GetStatementsByPolicyID(policyIDList []common.Hash) ([]*Statement, error)
+	GetStatementsByPolicyID(policyIDList []common.Hash, includeRemoved bool) ([]*Statement, error)
 	// GetPermissionsByResourceAndPrincipleType get permissions info by resource type & id, principal type
-	GetPermissionsByResourceAndPrincipleType(resourceType, principalType string, resourceID common.Hash) ([]*Permission, error)
+	GetPermissionsByResourceAndPrincipleType(resourceType, principalType string, resourceID common.Hash, includeRemoved bool) ([]*Permission, error)
 	// GetGroupsByGroupIDAndAccount get groups info by group id list and account id
-	GetGroupsByGroupIDAndAccount(groupIDList []common.Hash, account common.Address) ([]*Group, error)
+	GetGroupsByGroupIDAndAccount(groupIDList []common.Hash, account common.Address, includeRemoved bool) ([]*Group, error)
 	// ListObjectsByBucketName list objects info by a bucket name
-	ListObjectsByBucketName(bucketName, continuationToken, prefix, delimiter string, maxKeys int) ([]*ListObjectsResult, error)
+	ListObjectsByBucketName(bucketName, continuationToken, prefix, delimiter string, maxKeys int, includeRemoved bool) ([]*ListObjectsResult, error)
 	// ListDeletedObjectsByBlockNumberRange list deleted objects info by a block number range
 	ListDeletedObjectsByBlockNumberRange(startBlockNumber int64, endBlockNumber int64, includePrivate bool) ([]*Object, error)
 	// ListExpiredBucketsBySp list expired buckets by sp
@@ -43,7 +43,7 @@ type Metadata interface {
 	// GetBucketMetaByName get bucket info with its related info
 	GetBucketMetaByName(bucketName string, includePrivate bool) (*BucketFullMeta, error)
 	// ListGroupsByNameAndSourceType get groups list by specific parameters
-	ListGroupsByNameAndSourceType(name, prefix, sourceType string, limit, offset int) ([]*Group, int64, error)
+	ListGroupsByNameAndSourceType(name, prefix, sourceType string, limit, offset int, includeRemoved bool) ([]*Group, int64, error)
 }
 
 // BSDB contains all the methods required by block syncer database

--- a/store/bsdb/database_mock.go
+++ b/store/bsdb/database_mock.go
@@ -35,48 +35,48 @@ func (m *MockMetadata) EXPECT() *MockMetadataMockRecorder {
 }
 
 // GetBucketByID mocks base method.
-func (m *MockMetadata) GetBucketByID(bucketID int64, isFullList bool) (*Bucket, error) {
+func (m *MockMetadata) GetBucketByID(bucketID int64, includePrivate bool) (*Bucket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBucketByID", bucketID, isFullList)
+	ret := m.ctrl.Call(m, "GetBucketByID", bucketID, includePrivate)
 	ret0, _ := ret[0].(*Bucket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetBucketByID indicates an expected call of GetBucketByID.
-func (mr *MockMetadataMockRecorder) GetBucketByID(bucketID, isFullList interface{}) *gomock.Call {
+func (mr *MockMetadataMockRecorder) GetBucketByID(bucketID, includePrivate interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketByID", reflect.TypeOf((*MockMetadata)(nil).GetBucketByID), bucketID, isFullList)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketByID", reflect.TypeOf((*MockMetadata)(nil).GetBucketByID), bucketID, includePrivate)
 }
 
 // GetBucketByName mocks base method.
-func (m *MockMetadata) GetBucketByName(bucketName string, isFullList bool) (*Bucket, error) {
+func (m *MockMetadata) GetBucketByName(bucketName string, includePrivate bool) (*Bucket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBucketByName", bucketName, isFullList)
+	ret := m.ctrl.Call(m, "GetBucketByName", bucketName, includePrivate)
 	ret0, _ := ret[0].(*Bucket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetBucketByName indicates an expected call of GetBucketByName.
-func (mr *MockMetadataMockRecorder) GetBucketByName(bucketName, isFullList interface{}) *gomock.Call {
+func (mr *MockMetadataMockRecorder) GetBucketByName(bucketName, includePrivate interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketByName", reflect.TypeOf((*MockMetadata)(nil).GetBucketByName), bucketName, isFullList)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketByName", reflect.TypeOf((*MockMetadata)(nil).GetBucketByName), bucketName, includePrivate)
 }
 
 // GetBucketMetaByName mocks base method.
-func (m *MockMetadata) GetBucketMetaByName(bucketName string, isFullList bool) (*BucketFullMeta, error) {
+func (m *MockMetadata) GetBucketMetaByName(bucketName string, includePrivate bool) (*BucketFullMeta, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBucketMetaByName", bucketName, isFullList)
+	ret := m.ctrl.Call(m, "GetBucketMetaByName", bucketName, includePrivate)
 	ret0, _ := ret[0].(*BucketFullMeta)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetBucketMetaByName indicates an expected call of GetBucketMetaByName.
-func (mr *MockMetadataMockRecorder) GetBucketMetaByName(bucketName, isFullList interface{}) *gomock.Call {
+func (mr *MockMetadataMockRecorder) GetBucketMetaByName(bucketName, includePrivate interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketMetaByName", reflect.TypeOf((*MockMetadata)(nil).GetBucketMetaByName), bucketName, isFullList)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketMetaByName", reflect.TypeOf((*MockMetadata)(nil).GetBucketMetaByName), bucketName, includePrivate)
 }
 
 // GetGroupsByGroupIDAndAccount mocks base method.
@@ -110,48 +110,48 @@ func (mr *MockMetadataMockRecorder) GetLatestBlockNumber() *gomock.Call {
 }
 
 // GetObjectByName mocks base method.
-func (m *MockMetadata) GetObjectByName(objectName, bucketName string, isFullList bool) (*Object, error) {
+func (m *MockMetadata) GetObjectByName(objectName, bucketName string, includePrivate bool) (*Object, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetObjectByName", objectName, bucketName, isFullList)
+	ret := m.ctrl.Call(m, "GetObjectByName", objectName, bucketName, includePrivate)
 	ret0, _ := ret[0].(*Object)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetObjectByName indicates an expected call of GetObjectByName.
-func (mr *MockMetadataMockRecorder) GetObjectByName(objectName, bucketName, isFullList interface{}) *gomock.Call {
+func (mr *MockMetadataMockRecorder) GetObjectByName(objectName, bucketName, includePrivate interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObjectByName", reflect.TypeOf((*MockMetadata)(nil).GetObjectByName), objectName, bucketName, isFullList)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObjectByName", reflect.TypeOf((*MockMetadata)(nil).GetObjectByName), objectName, bucketName, includePrivate)
 }
 
 // GetPaymentByBucketID mocks base method.
-func (m *MockMetadata) GetPaymentByBucketID(bucketID int64, isFullList bool) (*StreamRecord, error) {
+func (m *MockMetadata) GetPaymentByBucketID(bucketID int64, includePrivate bool) (*StreamRecord, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPaymentByBucketID", bucketID, isFullList)
+	ret := m.ctrl.Call(m, "GetPaymentByBucketID", bucketID, includePrivate)
 	ret0, _ := ret[0].(*StreamRecord)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPaymentByBucketID indicates an expected call of GetPaymentByBucketID.
-func (mr *MockMetadataMockRecorder) GetPaymentByBucketID(bucketID, isFullList interface{}) *gomock.Call {
+func (mr *MockMetadataMockRecorder) GetPaymentByBucketID(bucketID, includePrivate interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPaymentByBucketID", reflect.TypeOf((*MockMetadata)(nil).GetPaymentByBucketID), bucketID, isFullList)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPaymentByBucketID", reflect.TypeOf((*MockMetadata)(nil).GetPaymentByBucketID), bucketID, includePrivate)
 }
 
 // GetPaymentByBucketName mocks base method.
-func (m *MockMetadata) GetPaymentByBucketName(bucketName string, isFullList bool) (*StreamRecord, error) {
+func (m *MockMetadata) GetPaymentByBucketName(bucketName string, includePrivate bool) (*StreamRecord, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPaymentByBucketName", bucketName, isFullList)
+	ret := m.ctrl.Call(m, "GetPaymentByBucketName", bucketName, includePrivate)
 	ret0, _ := ret[0].(*StreamRecord)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPaymentByBucketName indicates an expected call of GetPaymentByBucketName.
-func (mr *MockMetadataMockRecorder) GetPaymentByBucketName(bucketName, isFullList interface{}) *gomock.Call {
+func (mr *MockMetadataMockRecorder) GetPaymentByBucketName(bucketName, includePrivate interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPaymentByBucketName", reflect.TypeOf((*MockMetadata)(nil).GetPaymentByBucketName), bucketName, isFullList)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPaymentByBucketName", reflect.TypeOf((*MockMetadata)(nil).GetPaymentByBucketName), bucketName, includePrivate)
 }
 
 // GetPaymentByPaymentAddress mocks base method.
@@ -260,18 +260,18 @@ func (mr *MockMetadataMockRecorder) GetUserBucketsCount(accountID interface{}) *
 }
 
 // ListDeletedObjectsByBlockNumberRange mocks base method.
-func (m *MockMetadata) ListDeletedObjectsByBlockNumberRange(startBlockNumber, endBlockNumber int64, isFullList bool) ([]*Object, error) {
+func (m *MockMetadata) ListDeletedObjectsByBlockNumberRange(startBlockNumber, endBlockNumber int64, includePrivate bool) ([]*Object, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListDeletedObjectsByBlockNumberRange", startBlockNumber, endBlockNumber, isFullList)
+	ret := m.ctrl.Call(m, "ListDeletedObjectsByBlockNumberRange", startBlockNumber, endBlockNumber, includePrivate)
 	ret0, _ := ret[0].([]*Object)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListDeletedObjectsByBlockNumberRange indicates an expected call of ListDeletedObjectsByBlockNumberRange.
-func (mr *MockMetadataMockRecorder) ListDeletedObjectsByBlockNumberRange(startBlockNumber, endBlockNumber, isFullList interface{}) *gomock.Call {
+func (mr *MockMetadataMockRecorder) ListDeletedObjectsByBlockNumberRange(startBlockNumber, endBlockNumber, includePrivate interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDeletedObjectsByBlockNumberRange", reflect.TypeOf((*MockMetadata)(nil).ListDeletedObjectsByBlockNumberRange), startBlockNumber, endBlockNumber, isFullList)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDeletedObjectsByBlockNumberRange", reflect.TypeOf((*MockMetadata)(nil).ListDeletedObjectsByBlockNumberRange), startBlockNumber, endBlockNumber, includePrivate)
 }
 
 // ListExpiredBucketsBySp mocks base method.
@@ -328,48 +328,48 @@ func (m *MockBSDB) EXPECT() *MockBSDBMockRecorder {
 }
 
 // GetBucketByID mocks base method.
-func (m *MockBSDB) GetBucketByID(bucketID int64, isFullList bool) (*Bucket, error) {
+func (m *MockBSDB) GetBucketByID(bucketID int64, includePrivate bool) (*Bucket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBucketByID", bucketID, isFullList)
+	ret := m.ctrl.Call(m, "GetBucketByID", bucketID, includePrivate)
 	ret0, _ := ret[0].(*Bucket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetBucketByID indicates an expected call of GetBucketByID.
-func (mr *MockBSDBMockRecorder) GetBucketByID(bucketID, isFullList interface{}) *gomock.Call {
+func (mr *MockBSDBMockRecorder) GetBucketByID(bucketID, includePrivate interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketByID", reflect.TypeOf((*MockBSDB)(nil).GetBucketByID), bucketID, isFullList)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketByID", reflect.TypeOf((*MockBSDB)(nil).GetBucketByID), bucketID, includePrivate)
 }
 
 // GetBucketByName mocks base method.
-func (m *MockBSDB) GetBucketByName(bucketName string, isFullList bool) (*Bucket, error) {
+func (m *MockBSDB) GetBucketByName(bucketName string, includePrivate bool) (*Bucket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBucketByName", bucketName, isFullList)
+	ret := m.ctrl.Call(m, "GetBucketByName", bucketName, includePrivate)
 	ret0, _ := ret[0].(*Bucket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetBucketByName indicates an expected call of GetBucketByName.
-func (mr *MockBSDBMockRecorder) GetBucketByName(bucketName, isFullList interface{}) *gomock.Call {
+func (mr *MockBSDBMockRecorder) GetBucketByName(bucketName, includePrivate interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketByName", reflect.TypeOf((*MockBSDB)(nil).GetBucketByName), bucketName, isFullList)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketByName", reflect.TypeOf((*MockBSDB)(nil).GetBucketByName), bucketName, includePrivate)
 }
 
 // GetBucketMetaByName mocks base method.
-func (m *MockBSDB) GetBucketMetaByName(bucketName string, isFullList bool) (*BucketFullMeta, error) {
+func (m *MockBSDB) GetBucketMetaByName(bucketName string, includePrivate bool) (*BucketFullMeta, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBucketMetaByName", bucketName, isFullList)
+	ret := m.ctrl.Call(m, "GetBucketMetaByName", bucketName, includePrivate)
 	ret0, _ := ret[0].(*BucketFullMeta)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetBucketMetaByName indicates an expected call of GetBucketMetaByName.
-func (mr *MockBSDBMockRecorder) GetBucketMetaByName(bucketName, isFullList interface{}) *gomock.Call {
+func (mr *MockBSDBMockRecorder) GetBucketMetaByName(bucketName, includePrivate interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketMetaByName", reflect.TypeOf((*MockBSDB)(nil).GetBucketMetaByName), bucketName, isFullList)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketMetaByName", reflect.TypeOf((*MockBSDB)(nil).GetBucketMetaByName), bucketName, includePrivate)
 }
 
 // GetGroupsByGroupIDAndAccount mocks base method.
@@ -403,48 +403,48 @@ func (mr *MockBSDBMockRecorder) GetLatestBlockNumber() *gomock.Call {
 }
 
 // GetObjectByName mocks base method.
-func (m *MockBSDB) GetObjectByName(objectName, bucketName string, isFullList bool) (*Object, error) {
+func (m *MockBSDB) GetObjectByName(objectName, bucketName string, includePrivate bool) (*Object, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetObjectByName", objectName, bucketName, isFullList)
+	ret := m.ctrl.Call(m, "GetObjectByName", objectName, bucketName, includePrivate)
 	ret0, _ := ret[0].(*Object)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetObjectByName indicates an expected call of GetObjectByName.
-func (mr *MockBSDBMockRecorder) GetObjectByName(objectName, bucketName, isFullList interface{}) *gomock.Call {
+func (mr *MockBSDBMockRecorder) GetObjectByName(objectName, bucketName, includePrivate interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObjectByName", reflect.TypeOf((*MockBSDB)(nil).GetObjectByName), objectName, bucketName, isFullList)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObjectByName", reflect.TypeOf((*MockBSDB)(nil).GetObjectByName), objectName, bucketName, includePrivate)
 }
 
 // GetPaymentByBucketID mocks base method.
-func (m *MockBSDB) GetPaymentByBucketID(bucketID int64, isFullList bool) (*StreamRecord, error) {
+func (m *MockBSDB) GetPaymentByBucketID(bucketID int64, includePrivate bool) (*StreamRecord, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPaymentByBucketID", bucketID, isFullList)
+	ret := m.ctrl.Call(m, "GetPaymentByBucketID", bucketID, includePrivate)
 	ret0, _ := ret[0].(*StreamRecord)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPaymentByBucketID indicates an expected call of GetPaymentByBucketID.
-func (mr *MockBSDBMockRecorder) GetPaymentByBucketID(bucketID, isFullList interface{}) *gomock.Call {
+func (mr *MockBSDBMockRecorder) GetPaymentByBucketID(bucketID, includePrivate interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPaymentByBucketID", reflect.TypeOf((*MockBSDB)(nil).GetPaymentByBucketID), bucketID, isFullList)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPaymentByBucketID", reflect.TypeOf((*MockBSDB)(nil).GetPaymentByBucketID), bucketID, includePrivate)
 }
 
 // GetPaymentByBucketName mocks base method.
-func (m *MockBSDB) GetPaymentByBucketName(bucketName string, isFullList bool) (*StreamRecord, error) {
+func (m *MockBSDB) GetPaymentByBucketName(bucketName string, includePrivate bool) (*StreamRecord, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPaymentByBucketName", bucketName, isFullList)
+	ret := m.ctrl.Call(m, "GetPaymentByBucketName", bucketName, includePrivate)
 	ret0, _ := ret[0].(*StreamRecord)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPaymentByBucketName indicates an expected call of GetPaymentByBucketName.
-func (mr *MockBSDBMockRecorder) GetPaymentByBucketName(bucketName, isFullList interface{}) *gomock.Call {
+func (mr *MockBSDBMockRecorder) GetPaymentByBucketName(bucketName, includePrivate interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPaymentByBucketName", reflect.TypeOf((*MockBSDB)(nil).GetPaymentByBucketName), bucketName, isFullList)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPaymentByBucketName", reflect.TypeOf((*MockBSDB)(nil).GetPaymentByBucketName), bucketName, includePrivate)
 }
 
 // GetPaymentByPaymentAddress mocks base method.
@@ -553,18 +553,18 @@ func (mr *MockBSDBMockRecorder) GetUserBucketsCount(accountID interface{}) *gomo
 }
 
 // ListDeletedObjectsByBlockNumberRange mocks base method.
-func (m *MockBSDB) ListDeletedObjectsByBlockNumberRange(startBlockNumber, endBlockNumber int64, isFullList bool) ([]*Object, error) {
+func (m *MockBSDB) ListDeletedObjectsByBlockNumberRange(startBlockNumber, endBlockNumber int64, includePrivate bool) ([]*Object, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListDeletedObjectsByBlockNumberRange", startBlockNumber, endBlockNumber, isFullList)
+	ret := m.ctrl.Call(m, "ListDeletedObjectsByBlockNumberRange", startBlockNumber, endBlockNumber, includePrivate)
 	ret0, _ := ret[0].([]*Object)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListDeletedObjectsByBlockNumberRange indicates an expected call of ListDeletedObjectsByBlockNumberRange.
-func (mr *MockBSDBMockRecorder) ListDeletedObjectsByBlockNumberRange(startBlockNumber, endBlockNumber, isFullList interface{}) *gomock.Call {
+func (mr *MockBSDBMockRecorder) ListDeletedObjectsByBlockNumberRange(startBlockNumber, endBlockNumber, includePrivate interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDeletedObjectsByBlockNumberRange", reflect.TypeOf((*MockBSDB)(nil).ListDeletedObjectsByBlockNumberRange), startBlockNumber, endBlockNumber, isFullList)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDeletedObjectsByBlockNumberRange", reflect.TypeOf((*MockBSDB)(nil).ListDeletedObjectsByBlockNumberRange), startBlockNumber, endBlockNumber, includePrivate)
 }
 
 // ListExpiredBucketsBySp mocks base method.

--- a/store/bsdb/group.go
+++ b/store/bsdb/group.go
@@ -6,16 +6,23 @@ import (
 )
 
 // GetGroupsByGroupIDAndAccount get groups info by group id list and account id
-func (b *BsDBImpl) GetGroupsByGroupIDAndAccount(groupIDList []common.Hash, account common.Address) ([]*Group, error) {
+func (b *BsDBImpl) GetGroupsByGroupIDAndAccount(groupIDList []common.Hash, account common.Address, includeRemoved bool) ([]*Group, error) {
 	var (
 		groups []*Group
 		err    error
 	)
 
-	err = b.db.Table((&Group{}).TableName()).
-		Select("*").
-		Where("group_id in (?) and account_id = ?", groupIDList, account).
-		Find(&groups).Error
+	if includeRemoved {
+		err = b.db.Table((&Group{}).TableName()).
+			Select("*").
+			Where("group_id in (?) and account_id = ?", groupIDList, account).
+			Find(&groups).Error
+	} else {
+		err = b.db.Table((&Group{}).TableName()).
+			Select("*").
+			Where("group_id in (?) and account_id = ? and removed =false", groupIDList, account).
+			Find(&groups).Error
+	}
 	return groups, err
 }
 

--- a/store/bsdb/object.go
+++ b/store/bsdb/object.go
@@ -54,13 +54,13 @@ func (b *BsDBImpl) ListObjectsByBucketName(bucketName, continuationToken, prefix
 }
 
 // ListDeletedObjectsByBlockNumberRange list deleted objects info by a block number range
-func (b *BsDBImpl) ListDeletedObjectsByBlockNumberRange(startBlockNumber int64, endBlockNumber int64, isFullList bool) ([]*Object, error) {
+func (b *BsDBImpl) ListDeletedObjectsByBlockNumberRange(startBlockNumber int64, endBlockNumber int64, includePrivate bool) ([]*Object, error) {
 	var (
 		objects []*Object
 		err     error
 	)
 
-	if isFullList {
+	if includePrivate {
 		err = b.db.Table((&Object{}).TableName()).
 			Select("*").
 			Where("update_at >= ? and update_at <= ? and removed = ?", startBlockNumber, endBlockNumber, true).
@@ -82,13 +82,13 @@ func (b *BsDBImpl) ListDeletedObjectsByBlockNumberRange(startBlockNumber int64, 
 }
 
 // GetObjectByName get object info by an object name
-func (b *BsDBImpl) GetObjectByName(objectName string, bucketName string, isFullList bool) (*Object, error) {
+func (b *BsDBImpl) GetObjectByName(objectName string, bucketName string, includePrivate bool) (*Object, error) {
 	var (
 		object *Object
 		err    error
 	)
 
-	if isFullList {
+	if includePrivate {
 		err = b.db.Table((&Object{}).TableName()).
 			Select("*").
 			Where("object_name = ? and bucket_name = ? and removed = false", objectName, bucketName).

--- a/store/bsdb/payment.go
+++ b/store/bsdb/payment.go
@@ -8,14 +8,14 @@ import (
 )
 
 // GetPaymentByBucketName get payment info by a bucket name
-func (b *BsDBImpl) GetPaymentByBucketName(bucketName string, isFullList bool) (*StreamRecord, error) {
+func (b *BsDBImpl) GetPaymentByBucketName(bucketName string, includePrivate bool) (*StreamRecord, error) {
 	var (
 		streamRecord *StreamRecord
 		err          error
 		bucket       *Bucket
 	)
 
-	bucket, err = b.GetBucketByName(bucketName, isFullList)
+	bucket, err = b.GetBucketByName(bucketName, includePrivate)
 	if err != nil {
 		return nil, err
 	}
@@ -29,14 +29,14 @@ func (b *BsDBImpl) GetPaymentByBucketName(bucketName string, isFullList bool) (*
 }
 
 // GetPaymentByBucketID get payment info by a bucket id
-func (b *BsDBImpl) GetPaymentByBucketID(bucketID int64, isFullList bool) (*StreamRecord, error) {
+func (b *BsDBImpl) GetPaymentByBucketID(bucketID int64, includePrivate bool) (*StreamRecord, error) {
 	var (
 		streamRecord *StreamRecord
 		err          error
 		bucket       *Bucket
 	)
 
-	bucket, err = b.GetBucketByID(bucketID, isFullList)
+	bucket, err = b.GetBucketByID(bucketID, includePrivate)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description

Adding "removed" param for metadata service apis 

### Rationale
1. For metadata service apis returning single object, we default removed = false into the db query 
2. For metadata service apis returning a list, we add input param "removed" for users to filter the list

### Example

N/A

### Changes

Notable changes: 
* metadata service