### PR TITLE
fix: update juno version to fix group handler when no members included 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ replace (
 	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v0.0.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.1-alpha.2
-	github.com/forbole/juno/v4 => github.com/bnb-chain/juno/v4 v4.0.0-20230531095434-52daa6bf3a57
+	github.com/forbole/juno/v4 => github.com/bnb-chain/juno/v4 v4.0.0-20230608034928-d7470bdb24c2
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )
@@ -29,6 +29,7 @@ require (
 	github.com/ethereum/go-ethereum v1.10.26
 	github.com/felixge/fgprof v0.9.3
 	github.com/forbole/juno/v4 v4.0.0-00010101000000-000000000000
+	github.com/gogo/protobuf v1.3.3
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/openmetrics/v2 v2.0.0-rc.3
@@ -80,7 +81,6 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
-	github.com/gogo/protobuf v1.3.3 // indirect
 	github.com/golang-jwt/jwt/v4 v4.3.0 // indirect
 	github.com/google/orderedcode v0.0.1 // indirect
 	github.com/gorilla/handlers v1.5.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ replace (
 	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v0.0.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.1-alpha.2
-	github.com/forbole/juno/v4 => github.com/bnb-chain/juno/v4 v4.0.0-20230608034928-d7470bdb24c2
+	github.com/forbole/juno/v4 => github.com/bnb-chain/juno/v4 v4.0.0-20230608053739-30bdfe1a1244
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9/go.mod h1:rbc4o84RSEvhf09o2+4Qiazsv0snRJLiEZdk17HeIDw=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230425074444-eb5869b05fe9 h1:1ZdK+iR1Up02bOa2YTZCml7PBpP//kcdamOcK6aWO/s=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230425074444-eb5869b05fe9/go.mod h1:Ygz4wBHrgc7g0N+8+MrnTfS9LLn9aaTGa9hKopuym5k=
-github.com/bnb-chain/juno/v4 v4.0.0-20230608034928-d7470bdb24c2 h1:L9csdwm7VTok8Krib1rbWb2qkQUSZ0O2ScpiNM8i/j0=
-github.com/bnb-chain/juno/v4 v4.0.0-20230608034928-d7470bdb24c2/go.mod h1:EyZFqV+s8JckllSsMKQRLNBGwWterYYVBfJQl3PssaA=
+github.com/bnb-chain/juno/v4 v4.0.0-20230608053739-30bdfe1a1244 h1:IKda5sFglTzOZN5e2rOTNNLmtrvIPqZvcWNltoQMviE=
+github.com/bnb-chain/juno/v4 v4.0.0-20230608053739-30bdfe1a1244/go.mod h1:EyZFqV+s8JckllSsMKQRLNBGwWterYYVBfJQl3PssaA=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/bradfitz/gomemcache v0.0.0-20170208213004-1952afaa557d/go.mod h1:PmM6Mmwb0LSuEubjR8N7PtNe1KxZLtOUHtbeikc5h60=

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9/go.mod h1:rbc4o84RSEvhf09o2+4Qiazsv0snRJLiEZdk17HeIDw=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230425074444-eb5869b05fe9 h1:1ZdK+iR1Up02bOa2YTZCml7PBpP//kcdamOcK6aWO/s=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230425074444-eb5869b05fe9/go.mod h1:Ygz4wBHrgc7g0N+8+MrnTfS9LLn9aaTGa9hKopuym5k=
-github.com/bnb-chain/juno/v4 v4.0.0-20230531095434-52daa6bf3a57 h1:kiph9HH0Zh1fMHOUvzGZAAY43mTXnVg+QzIfu+8g0O8=
-github.com/bnb-chain/juno/v4 v4.0.0-20230531095434-52daa6bf3a57/go.mod h1:EyZFqV+s8JckllSsMKQRLNBGwWterYYVBfJQl3PssaA=
+github.com/bnb-chain/juno/v4 v4.0.0-20230608034928-d7470bdb24c2 h1:L9csdwm7VTok8Krib1rbWb2qkQUSZ0O2ScpiNM8i/j0=
+github.com/bnb-chain/juno/v4 v4.0.0-20230608034928-d7470bdb24c2/go.mod h1:EyZFqV+s8JckllSsMKQRLNBGwWterYYVBfJQl3PssaA=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/bradfitz/gomemcache v0.0.0-20170208213004-1952afaa557d/go.mod h1:PmM6Mmwb0LSuEubjR8N7PtNe1KxZLtOUHtbeikc5h60=


### PR DESCRIPTION
### Description

group cannot be created when no members included in blocksyncer, while this is inconsistent with chain side.
This PR fix this by update juno version.

### Rationale

Keep group creation logic consistent with chain side

### Example

N/A

### Changes

Notable changes: 
* juno version updated
