### PR TITLE
feat: add sp filter to ListDeletedObjectsByBlockNumberRange

### DIFF
--- a/base/gfspclient/metadata.go
+++ b/base/gfspclient/metadata.go
@@ -30,22 +30,23 @@ func (s *GfSpClient) GetUserBucketsCount(ctx context.Context, account string, in
 }
 
 func (s *GfSpClient) ListDeletedObjectsByBlockNumberRange(ctx context.Context, spOperatorAddress string, startBlockNumber uint64,
-	endBlockNumber uint64, includePrivate bool, opts ...grpc.DialOption) ([]*types.Object, uint64, error) {
+	endBlockNumber uint64, includePrivate bool, opts ...grpc.DialOption) ([]*types.Object, []*types.Object, uint64, error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
-		return nil, uint64(0), err
+		return nil, nil, uint64(0), err
 	}
 	defer conn.Close()
 	req := &types.GfSpListDeletedObjectsByBlockNumberRangeRequest{
-		StartBlockNumber: int64(startBlockNumber),
-		EndBlockNumber:   int64(endBlockNumber),
-		IncludePrivate:   includePrivate,
+		StartBlockNumber:  int64(startBlockNumber),
+		EndBlockNumber:    int64(endBlockNumber),
+		IncludePrivate:    includePrivate,
+		SpOperatorAddress: spOperatorAddress,
 	}
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpListDeletedObjectsByBlockNumberRange(ctx, req)
 	if err != nil {
-		return nil, uint64(0), ErrRpcUnknown
+		return nil, nil, uint64(0), ErrRpcUnknown
 	}
-	return resp.GetObjects(), uint64(resp.GetEndBlockNumber()), nil
+	return resp.GetPrimarySpObjects(), resp.GetSecondarySpsObjects(), uint64(resp.GetEndBlockNumber()), nil
 }
 
 func (s *GfSpClient) GetUserBuckets(ctx context.Context, account string, includeRemoved bool, opts ...grpc.DialOption) ([]*types.Bucket, error) {

--- a/modular/executor/execute_task.go
+++ b/modular/executor/execute_task.go
@@ -190,7 +190,9 @@ func (e *ExecuteModular) HandleGCObjectTask(ctx context.Context, task coretask.G
 			"task_is_canceled", taskIsCanceled, "has_no_object", hasNoObject, "error", err)
 	}()
 
-	if waitingGCObjects, responseEndBlockID, err = e.baseApp.GfSpClient().ListDeletedObjectsByBlockNumberRange(
+	// TODO: ListDeletedObjectsByBlockNumberRange has been updated to return primary_sp_objects and secondary_sps_objects
+	// please modify the usage accordingly here
+	if waitingGCObjects, _, responseEndBlockID, err = e.baseApp.GfSpClient().ListDeletedObjectsByBlockNumberRange(
 		ctx, e.baseApp.OperateAddress(), task.GetStartBlockNumber(),
 		task.GetEndBlockNumber(), true); err != nil {
 		log.CtxErrorw(ctx, "failed to query deleted object list", "task_info", task.Info(), "error", err)

--- a/proto/modular/metadata/types/metadata.proto
+++ b/proto/modular/metadata/types/metadata.proto
@@ -152,14 +152,18 @@ message GfSpListDeletedObjectsByBlockNumberRangeRequest {
   int64 end_block_number = 2;
   // include_private indicates whether this request can get the private objects information
   bool include_private = 3;
+  // sp_operator_address defines the sp operator address of the returned deleted objects
+  string sp_operator_address = 4;
 }
 
 // GfSpListDeletedObjectsByBlockNumberRangeResponse is response type for the GfSpListDeletedObjectsByBlockNumberRange RPC method.
 message GfSpListDeletedObjectsByBlockNumberRangeResponse {
-  // objects defines the list of object
-  repeated Object objects = 1;
+  // primary_sp_objects defines the list of object that is filtered by primary sp
+  repeated Object primary_sp_objects = 1;
+  // secondary_sps_objects defines the list of object that is filtered by secondary sps
+  repeated Object secondary_sps_objects = 2;
   // latest_block_number defines the response objects latest block number
-  int64 end_block_number = 2;
+  int64 end_block_number = 3;
 }
 
 // GfSpGetUserBucketsCountRequest is request type for the GfSpGetUserBucketsCount RPC method.

--- a/store/bsdb/database.go
+++ b/store/bsdb/database.go
@@ -33,7 +33,7 @@ type Metadata interface {
 	// ListObjectsByBucketName list objects info by a bucket name
 	ListObjectsByBucketName(bucketName, continuationToken, prefix, delimiter string, maxKeys int, includeRemoved bool) ([]*ListObjectsResult, error)
 	// ListDeletedObjectsByBlockNumberRange list deleted objects info by a block number range
-	ListDeletedObjectsByBlockNumberRange(startBlockNumber int64, endBlockNumber int64, includePrivate bool) ([]*Object, error)
+	ListDeletedObjectsByBlockNumberRange(startBlockNumber int64, endBlockNumber int64, includePrivate bool, spOperatorAddress string) (DeletedObjectsLists, error)
 	// ListExpiredBucketsBySp list expired buckets by sp
 	ListExpiredBucketsBySp(createAt int64, primarySpAddress string, limit int64) ([]*Bucket, error)
 	// GetObjectByName get object info by an object name

--- a/store/bsdb/object_schema.go
+++ b/store/bsdb/object_schema.go
@@ -67,3 +67,8 @@ type Object struct {
 func (o *Object) TableName() string {
 	return ObjectTableName
 }
+
+type DeletedObjectsLists struct {
+	PrimarySPObjects    []*Object
+	SecondarySPsObjects []*Object
+}


### PR DESCRIPTION
### Description

Update ListDeletedObjectsByBlockNumberRange method to add spOperatorAddress as input, and separate outputs to primarySpObjects (deleted objects whom the primary sp address matches spOperatorAddress) and secondarySpsObjects (deleted objects whom one of the secondary sp addresses matches spOperatorAddress)

### Rationale

For GC tasks

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
