### PR TITLE
perf: add more metrics to perf get approval v0.2.2

### DIFF
--- a/base/gnfd/gnfd_service.go
+++ b/base/gnfd/gnfd_service.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/metrics"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -19,6 +20,8 @@ import (
 
 // CurrentHeight the block height sub one as the stable height.
 func (g *Gnfd) CurrentHeight(ctx context.Context) (uint64, error) {
+	startTime := time.Now()
+	defer metrics.GnfdChainHistogram.WithLabelValues("query_height").Observe(time.Since(startTime).Seconds())
 	resp, err := g.getCurrentWsClient().ABCIInfo(ctx)
 	if err != nil {
 		log.CtxErrorw(ctx, "get latest block height failed", "node_addr",
@@ -30,6 +33,8 @@ func (g *Gnfd) CurrentHeight(ctx context.Context) (uint64, error) {
 
 // HasAccount returns an indication of the existence of address.
 func (g *Gnfd) HasAccount(ctx context.Context, address string) (bool, error) {
+	startTime := time.Now()
+	defer metrics.GnfdChainHistogram.WithLabelValues("query_account").Observe(time.Since(startTime).Seconds())
 	client := g.getCurrentClient().GnfdClient()
 	resp, err := client.Account(ctx, &authtypes.QueryAccountRequest{Address: address})
 	if err != nil {
@@ -41,6 +46,8 @@ func (g *Gnfd) HasAccount(ctx context.Context, address string) (bool, error) {
 
 // ListSPs returns the list of storage provider info.
 func (g *Gnfd) ListSPs(ctx context.Context) ([]*sptypes.StorageProvider, error) {
+	startTime := time.Now()
+	defer metrics.GnfdChainHistogram.WithLabelValues("list_sps").Observe(time.Since(startTime).Seconds())
 	client := g.getCurrentClient().GnfdClient()
 	var spInfos []*sptypes.StorageProvider
 	resp, err := client.StorageProviders(ctx, &sptypes.QueryStorageProvidersRequest{
@@ -61,6 +68,8 @@ func (g *Gnfd) ListSPs(ctx context.Context) ([]*sptypes.StorageProvider, error) 
 
 // ListBondedValidators returns the list of bonded validators.
 func (g *Gnfd) ListBondedValidators(ctx context.Context) ([]stakingtypes.Validator, error) {
+	startTime := time.Now()
+	defer metrics.GnfdChainHistogram.WithLabelValues("list_bonded_validators").Observe(time.Since(startTime).Seconds())
 	client := g.getCurrentClient().GnfdClient()
 	var validators []stakingtypes.Validator
 	resp, err := client.Validators(ctx, &stakingtypes.QueryValidatorsRequest{Status: "BOND_STATUS_BONDED"})
@@ -76,6 +85,8 @@ func (g *Gnfd) ListBondedValidators(ctx context.Context) ([]stakingtypes.Validat
 
 // QueryStorageParams returns storage params
 func (g *Gnfd) QueryStorageParams(ctx context.Context) (params *storagetypes.Params, err error) {
+	startTime := time.Now()
+	defer metrics.GnfdChainHistogram.WithLabelValues("query_storage_params").Observe(time.Since(startTime).Seconds())
 	client := g.getCurrentClient().GnfdClient()
 	resp, err := client.StorageQueryClient.Params(ctx, &storagetypes.QueryParamsRequest{})
 	if err != nil {
@@ -86,10 +97,9 @@ func (g *Gnfd) QueryStorageParams(ctx context.Context) (params *storagetypes.Par
 }
 
 // QueryStorageParamsByTimestamp returns storage params by block create time.
-func (g *Gnfd) QueryStorageParamsByTimestamp(
-	ctx context.Context,
-	timestamp int64) (
-	params *storagetypes.Params, err error) {
+func (g *Gnfd) QueryStorageParamsByTimestamp(ctx context.Context, timestamp int64) (params *storagetypes.Params, err error) {
+	startTime := time.Now()
+	defer metrics.GnfdChainHistogram.WithLabelValues("query_storage_params_by_timestamp").Observe(time.Since(startTime).Seconds())
 	client := g.getCurrentClient().GnfdClient()
 	resp, err := client.StorageQueryClient.QueryParamsByTimestamp(ctx,
 		&storagetypes.QueryParamsByTimestampRequest{Timestamp: timestamp})
@@ -102,6 +112,8 @@ func (g *Gnfd) QueryStorageParamsByTimestamp(
 
 // QueryBucketInfo returns the bucket info by name.
 func (g *Gnfd) QueryBucketInfo(ctx context.Context, bucket string) (*storagetypes.BucketInfo, error) {
+	startTime := time.Now()
+	defer metrics.GnfdChainHistogram.WithLabelValues("query_bucket").Observe(time.Since(startTime).Seconds())
 	client := g.getCurrentClient().GnfdClient()
 	resp, err := client.HeadBucket(ctx, &storagetypes.QueryHeadBucketRequest{BucketName: bucket})
 	if err != nil {
@@ -113,6 +125,8 @@ func (g *Gnfd) QueryBucketInfo(ctx context.Context, bucket string) (*storagetype
 
 // QueryObjectInfo returns the object info by name.
 func (g *Gnfd) QueryObjectInfo(ctx context.Context, bucket, object string) (*storagetypes.ObjectInfo, error) {
+	startTime := time.Now()
+	defer metrics.GnfdChainHistogram.WithLabelValues("query_object").Observe(time.Since(startTime).Seconds())
 	client := g.getCurrentClient().GnfdClient()
 	resp, err := client.HeadObject(ctx, &storagetypes.QueryHeadObjectRequest{
 		BucketName: bucket,
@@ -127,6 +141,8 @@ func (g *Gnfd) QueryObjectInfo(ctx context.Context, bucket, object string) (*sto
 
 // QueryObjectInfoByID returns the object info by name.
 func (g *Gnfd) QueryObjectInfoByID(ctx context.Context, objectID string) (*storagetypes.ObjectInfo, error) {
+	startTime := time.Now()
+	defer metrics.GnfdChainHistogram.WithLabelValues("query_object_by_id").Observe(time.Since(startTime).Seconds())
 	client := g.getCurrentClient().GnfdClient()
 	resp, err := client.HeadObjectById(ctx, &storagetypes.QueryHeadObjectByIdRequest{
 		ObjectId: objectID,
@@ -155,6 +171,8 @@ func (g *Gnfd) QueryBucketInfoAndObjectInfo(ctx context.Context, bucket, object 
 // ListenObjectSeal returns an indication of the object is sealed.
 // TODO:: retrieve service support seal event subscription
 func (g *Gnfd) ListenObjectSeal(ctx context.Context, objectID uint64, timeoutHeight int) (bool, error) {
+	startTime := time.Now()
+	defer metrics.GnfdChainHistogram.WithLabelValues("wait_object_seal").Observe(time.Since(startTime).Seconds())
 	var (
 		objectInfo *storagetypes.ObjectInfo
 		err        error
@@ -180,6 +198,8 @@ func (g *Gnfd) ListenObjectSeal(ctx context.Context, objectID uint64, timeoutHei
 
 // QueryPaymentStreamRecord returns the steam record info by account.
 func (g *Gnfd) QueryPaymentStreamRecord(ctx context.Context, account string) (*paymenttypes.StreamRecord, error) {
+	startTime := time.Now()
+	defer metrics.GnfdChainHistogram.WithLabelValues("query_payment_stream_record").Observe(time.Since(startTime).Seconds())
 	client := g.getCurrentClient().GnfdClient()
 	resp, err := client.StreamRecord(ctx, &paymenttypes.QueryGetStreamRecordRequest{
 		Account: account,
@@ -193,6 +213,8 @@ func (g *Gnfd) QueryPaymentStreamRecord(ctx context.Context, account string) (*p
 
 // VerifyGetObjectPermission verifies get object permission.
 func (g *Gnfd) VerifyGetObjectPermission(ctx context.Context, account, bucket, object string) (bool, error) {
+	startTime := time.Now()
+	defer metrics.GnfdChainHistogram.WithLabelValues("verify_get_object_permission").Observe(time.Since(startTime).Seconds())
 	client := g.getCurrentClient().GnfdClient()
 	resp, err := client.VerifyPermission(ctx, &storagetypes.QueryVerifyPermissionRequest{
 		Operator:   account,
@@ -212,6 +234,8 @@ func (g *Gnfd) VerifyGetObjectPermission(ctx context.Context, account, bucket, o
 
 // VerifyPutObjectPermission verifies put object permission.
 func (g *Gnfd) VerifyPutObjectPermission(ctx context.Context, account, bucket, object string) (bool, error) {
+	startTime := time.Now()
+	defer metrics.GnfdChainHistogram.WithLabelValues("verify_put_object_permission").Observe(time.Since(startTime).Seconds())
 	_ = object
 	client := g.getCurrentClient().GnfdClient()
 	resp, err := client.VerifyPermission(ctx, &storagetypes.QueryVerifyPermissionRequest{

--- a/modular/approver/approve_task.go
+++ b/modular/approver/approve_task.go
@@ -3,12 +3,14 @@ package approver
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsperrors"
 	"github.com/bnb-chain/greenfield-storage-provider/core/module"
 	coretask "github.com/bnb-chain/greenfield-storage-provider/core/task"
 	"github.com/bnb-chain/greenfield-storage-provider/core/taskqueue"
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/metrics"
 )
 
 var (
@@ -29,7 +31,7 @@ func (a *ApprovalModular) HandleCreateBucketApprovalTask(ctx context.Context, ta
 		currentHeight uint64
 	)
 	if task == nil || task.GetCreateBucketInfo() == nil {
-		log.CtxErrorw(ctx, "failed to pre create bucket approval, pointer nil")
+		log.CtxErrorw(ctx, "failed to pre create bucket approval due to pointer nil")
 		return false, ErrDanglingPointer
 	}
 	defer func() {
@@ -38,18 +40,29 @@ func (a *ApprovalModular) HandleCreateBucketApprovalTask(ctx context.Context, ta
 		}
 		log.CtxDebugw(ctx, task.Info())
 	}()
+	startQueryQueue := time.Now()
 	if a.bucketQueue.Has(task.Key()) {
 		shadowTask := a.bucketQueue.PopByKey(task.Key())
 		task.SetCreateBucketInfo(shadowTask.(coretask.ApprovalCreateBucketTask).GetCreateBucketInfo())
 		_ = a.bucketQueue.Push(shadowTask)
+		metrics.GnfdChainHistogram.WithLabelValues("check_repeated_in_create_bucket_approval").
+			Observe(time.Since(startQueryQueue).Seconds())
 		log.CtxErrorw(ctx, "repeated create bucket approval task is returned")
 		return true, nil
 	}
+	metrics.GnfdChainHistogram.WithLabelValues("check_repeated_in_create_bucket_approval").
+		Observe(time.Since(startQueryQueue).Seconds())
+
+	startQueryMetadata := time.Now()
 	buckets, err := a.baseApp.GfSpClient().GetUserBucketsCount(ctx, task.GetCreateBucketInfo().GetCreator(), false)
 	if err != nil {
+		metrics.GnfdChainHistogram.WithLabelValues("check_counter_in_create_bucket_approval").
+			Observe(time.Since(startQueryMetadata).Seconds())
 		log.CtxErrorw(ctx, "failed to get account owns max bucket number", "error", err)
 		return false, err
 	}
+	metrics.GnfdChainHistogram.WithLabelValues("check_counter_in_create_bucket_approval").
+		Observe(time.Since(startQueryMetadata).Seconds())
 	if buckets >= a.accountBucketNumber {
 		log.CtxErrorw(ctx, "account owns bucket number exceed")
 		err = ErrExceedBucketNumber
@@ -57,22 +70,33 @@ func (a *ApprovalModular) HandleCreateBucketApprovalTask(ctx context.Context, ta
 	}
 
 	// begin to sign the new approval task
+	startQueryChain := time.Now()
 	currentHeight, err = a.baseApp.Consensus().CurrentHeight(ctx)
+	metrics.GnfdChainHistogram.WithLabelValues("query_current_height_in_create_bucket_approval").
+		Observe(time.Since(startQueryChain).Seconds())
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get current height", "error", err)
 		return false, ErrConsensus
 	}
 	task.SetExpiredHeight(currentHeight + a.bucketApprovalTimeoutHeight)
+	startSignApproval := time.Now()
 	signature, err = a.baseApp.GfSpClient().SignCreateBucketApproval(ctx, task.GetCreateBucketInfo())
+	metrics.GnfdChainHistogram.WithLabelValues("sign_in_create_bucket_approval").
+		Observe(time.Since(startSignApproval).Seconds())
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to sign the create bucket approval", "error", err)
 		return false, ErrSigner
 	}
 	task.GetCreateBucketInfo().GetPrimarySpApproval().Sig = signature
+	startPushQueue := time.Now()
 	if err = a.bucketQueue.Push(task); err != nil {
+		metrics.GnfdChainHistogram.WithLabelValues("update_queue_in_create_bucket_approval").
+			Observe(time.Since(startPushQueue).Seconds())
 		log.CtxErrorw(ctx, "failed to push the create bucket approval to queue", "error", err)
 		return false, err
 	}
+	metrics.GnfdChainHistogram.WithLabelValues("update_queue_in_create_bucket_approval").
+		Observe(time.Since(startPushQueue).Seconds())
 	return true, nil
 }
 
@@ -90,7 +114,7 @@ func (a *ApprovalModular) HandleCreateObjectApprovalTask(ctx context.Context, ta
 		currentHeight uint64
 	)
 	if task == nil || task.GetCreateObjectInfo() == nil {
-		log.CtxErrorw(ctx, "failed to pre create object approval, pointer nil")
+		log.CtxErrorw(ctx, "failed to pre create object approval due to pointer nil")
 		return false, ErrDanglingPointer
 	}
 	defer func() {
@@ -99,31 +123,48 @@ func (a *ApprovalModular) HandleCreateObjectApprovalTask(ctx context.Context, ta
 		}
 		log.CtxDebugw(ctx, task.Info())
 	}()
+
+	startQueryQueue := time.Now()
 	if a.objectQueue.Has(task.Key()) {
 		shadowTask := a.objectQueue.PopByKey(task.Key())
 		task.SetCreateObjectInfo(shadowTask.(coretask.ApprovalCreateObjectTask).GetCreateObjectInfo())
 		_ = a.objectQueue.Push(shadowTask)
+		metrics.GnfdChainHistogram.WithLabelValues("check_repeated_in_create_object_approval").
+			Observe(time.Since(startQueryQueue).Seconds())
 		log.CtxErrorw(ctx, "repeated create object approval task is returned")
 		return true, nil
 	}
+	metrics.GnfdChainHistogram.WithLabelValues("check_repeated_in_create_object_approval").
+		Observe(time.Since(startQueryQueue).Seconds())
 
 	// begin to sign the new approval task
+	startQueryChain := time.Now()
 	currentHeight, err = a.baseApp.Consensus().CurrentHeight(ctx)
+	metrics.GnfdChainHistogram.WithLabelValues("query_current_height_in_create_object_approval").
+		Observe(time.Since(startQueryChain).Seconds())
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get current height", "error", err)
 		return false, ErrConsensus
 	}
 	task.SetExpiredHeight(currentHeight + a.objectApprovalTimeoutHeight)
+	startSignApproval := time.Now()
 	signature, err = a.baseApp.GfSpClient().SignCreateObjectApproval(ctx, task.GetCreateObjectInfo())
+	metrics.GnfdChainHistogram.WithLabelValues("sign_in_create_object_approval").
+		Observe(time.Since(startSignApproval).Seconds())
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to sign the create object approval", "error", err)
 		return false, err
 	}
 	task.GetCreateObjectInfo().GetPrimarySpApproval().Sig = signature
+	startPushQueue := time.Now()
 	if err = a.objectQueue.Push(task); err != nil {
+		metrics.GnfdChainHistogram.WithLabelValues("update_queue_in_create_object_approval").
+			Observe(time.Since(startPushQueue).Seconds())
 		log.CtxErrorw(ctx, "failed to push the create object task to queue", "error", err)
 		return false, err
 	}
+	metrics.GnfdChainHistogram.WithLabelValues("update_queue_in_create_object_approval").
+		Observe(time.Since(startPushQueue).Seconds())
 	return true, nil
 }
 

--- a/modular/executor/execute_task.go
+++ b/modular/executor/execute_task.go
@@ -253,7 +253,7 @@ func (e *ExecuteModular) HandleGCObjectTask(ctx context.Context, task coretask.G
 		task.SetLastDeletedObjectId(currentGCObjectID)
 		metrics.GCObjectCounter.WithLabelValues(e.Name()).Inc()
 		if taskIsCanceled = reportProgress(); taskIsCanceled {
-			log.CtxErrorw(ctx, "gc object task has been canceled", "task_info", task.Info())
+			log.CtxErrorw(ctx, "gc object task has been canceled", "current_gc_object_info", objectInfo, "task_info", task.Info())
 			return
 		}
 		log.CtxDebugw(ctx, "succeed to gc an object", "object_info", objectInfo, "deleted_at_block_id", currentGCBlockID)

--- a/pkg/metrics/metric_items.go
+++ b/pkg/metrics/metric_items.go
@@ -7,8 +7,6 @@ import (
 	metricshttp "github.com/bnb-chain/greenfield-storage-provider/pkg/metrics/http"
 )
 
-// const serviceLabelName = "service"
-
 var MetricsItems = []prometheus.Collector{
 	// Grpc metrics category
 	DefaultGRPCServerMetrics,
@@ -17,6 +15,7 @@ var MetricsItems = []prometheus.Collector{
 	DefaultHTTPServerMetrics,
 	// Perf workflow category
 	PerfUploadTimeHistogram,
+	PerfGetApprovalTimeHistogram,
 	// TaskQueue metrics category
 	QueueSizeGauge,
 	QueueCapGauge,
@@ -82,6 +81,8 @@ var MetricsItems = []prometheus.Collector{
 	SPDBTimeHistogram,
 	// BlockSyncer metrics category
 	BlockHeightLagGauge,
+	// the greenfield chain metrics.
+	GnfdChainHistogram,
 }
 
 var (
@@ -93,12 +94,18 @@ var (
 	// DefaultHTTPServerMetrics defines default HTTP server metrics
 	DefaultHTTPServerMetrics = metricshttp.NewServerMetrics()
 
-	// perf upload workflow
+	// PerfUploadTimeHistogram is used to perf upload workflow.
 	PerfUploadTimeHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "perf_upload_time",
 		Help:    "Track upload workflow costs.",
 		Buckets: prometheus.DefBuckets,
 	}, []string{"perf_upload_time"})
+	// PerfGetApprovalTimeHistogram is used to perf get approval workflow
+	PerfGetApprovalTimeHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "perf_get_approval_time",
+		Help:    "Track get approval workflow costs.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"perf_get_approval_time"})
 
 	// task queue metrics
 	QueueSizeGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -358,11 +365,18 @@ var (
 		Name:    "sp_db_handling_seconds",
 		Help:    "Track the latency for spdb requests",
 		Buckets: prometheus.DefBuckets,
-	}, []string{"method_name"})
+	}, []string{"sp_db_handling_seconds"})
 
 	// BlockHeightLagGauge records the current block height of block syncer service
 	BlockHeightLagGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "block_syncer_height",
 		Help: "Current block number of block syncer progress.",
-	}, []string{"service"})
+	}, []string{"block_syncer_height"})
+
+	// GnfdChainHistogram is used to record greenfield chain cost.
+	GnfdChainHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "gnfd_chain_time",
+		Help:    "Track the greenfield chain api costs.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"gnfd_chain_time"})
 )


### PR DESCRIPTION
### Description

Add more metrics to perf get approval, which is cherry-picked from https://github.com/bnb-chain/greenfield-storage-provider/pull/573.

### Rationale

N/A.

### Example

N/A.

### Changes

Notable changes: 
* Add the greenfield chain metrics and get approval workflow metrics.
