### PR TITLE
fix: modify the default gc opt to a suitable value v0.2.2

### DIFF
--- a/modular/executor/execute_task.go
+++ b/modular/executor/execute_task.go
@@ -221,9 +221,13 @@ func (e *ExecuteModular) HandleGCObjectTask(ctx context.Context, task coretask.G
 		objectInfo := object.GetObjectInfo()
 		currentGCObjectID = objectInfo.Id.Uint64()
 		if currentGCBlockID < task.GetCurrentBlockNumber() {
+			log.Errorw("skip gc object", "object_info", objectInfo,
+				"task_current_gc_block_id", task.GetCurrentBlockNumber())
 			continue
 		}
 		if currentGCObjectID <= task.GetLastDeletedObjectId() {
+			log.Errorw("skip gc object", "object_info", objectInfo,
+				"task_last_deleted_object_id", task.GetLastDeletedObjectId())
 			continue
 		}
 		segmentCount := e.baseApp.PieceOp().SegmentPieceCount(

--- a/modular/manager/manager_options.go
+++ b/modular/manager/manager_options.go
@@ -40,10 +40,10 @@ const (
 	DefaultGlobalChallengePieceTaskCacheSize int = 4096
 	// DefaultGlobalBatchGcObjectTimeInterval defines the default interval for generating
 	// gc object task.
-	DefaultGlobalBatchGcObjectTimeInterval int = 30 * 60
+	DefaultGlobalBatchGcObjectTimeInterval int = 1 * 60
 	// DefaultGlobalGcObjectBlockInterval defines the default blocks number for getting
 	// deleted objects.
-	DefaultGlobalGcObjectBlockInterval uint64 = 500
+	DefaultGlobalGcObjectBlockInterval uint64 = 1000
 	// DefaultGlobalGcObjectSafeBlockDistance defines the default distance form current block
 	// height to gc the deleted object.
 	DefaultGlobalGcObjectSafeBlockDistance uint64 = 1000


### PR DESCRIPTION
### Description

Modify the default gc opt to a suitable value which is cherry-picked from https://github.com/bnb-chain/greenfield-storage-provider/pull/613.

### Rationale

Previously, a gc task of 500 blocks was generated every half hour, but the blockchain generated 900 blocks every half hour; resulting in the gc task not being able to keep up with the latest high speed.

### Example

N/A.

### Changes

Notable changes: 
* Manager default opt.
