### PR TITLE
fix: fix missing gc object

### DIFF
--- a/modular/executor/execute_task.go
+++ b/modular/executor/execute_task.go
@@ -225,11 +225,6 @@ func (e *ExecuteModular) HandleGCObjectTask(ctx context.Context, task coretask.G
 				"task_current_gc_block_id", task.GetCurrentBlockNumber())
 			continue
 		}
-		if currentGCObjectID <= task.GetLastDeletedObjectId() {
-			log.Errorw("skip gc object", "object_info", objectInfo,
-				"task_last_deleted_object_id", task.GetLastDeletedObjectId())
-			continue
-		}
 		segmentCount := e.baseApp.PieceOp().SegmentPieceCount(
 			objectInfo.GetPayloadSize(), storageParams.VersionedParams.GetMaxSegmentSize())
 		for segIdx := uint32(0); segIdx < segmentCount; segIdx++ {


### PR DESCRIPTION
### Description

Fix missing gc object.

### Rationale

When objects are in different blocks, object ids are unordered. The check order may cause some objects not to be gc.

### Example

N/A.

### Changes

Notable changes: 
* GC object workflow, fix check conditions. 
