### PR TITLE
fix: fix missing gc object v0.2.2

### DIFF
--- a/modular/executor/execute_task.go
+++ b/modular/executor/execute_task.go
@@ -226,11 +226,6 @@ func (e *ExecuteModular) HandleGCObjectTask(ctx context.Context, task coretask.G
 				"task_current_gc_block_id", task.GetCurrentBlockNumber())
 			continue
 		}
-		if currentGCObjectID <= task.GetLastDeletedObjectId() {
-			log.Errorw("skip gc object", "object_info", objectInfo,
-				"task_last_deleted_object_id", task.GetLastDeletedObjectId())
-			continue
-		}
 		segmentCount := e.baseApp.PieceOp().SegmentPieceCount(
 			objectInfo.GetPayloadSize(), storageParams.VersionedParams.GetMaxSegmentSize())
 		for segIdx := uint32(0); segIdx < segmentCount; segIdx++ {


### PR DESCRIPTION
### Description

Fix missing gc object, which is cherry-picked from https://github.com/bnb-chain/greenfield-storage-provider/pull/621.

### Rationale

When objects are in different blocks, object ids are unordered. The check order may cause some objects not to be gc.

### Example

N/A.

### Changes

Notable changes: 
* GC object workflow, fix check conditions. 
