### PR TITLE
feat: add prefix for segment and ec piece key

### DIFF
--- a/base/gfsppieceop/pieceop.go
+++ b/base/gfsppieceop/pieceop.go
@@ -12,11 +12,11 @@ type GfSpPieceOp struct {
 }
 
 func (p *GfSpPieceOp) SegmentPieceKey(objectID uint64, segmentIdx uint32) string {
-	return fmt.Sprintf("%d_s%d", objectID, segmentIdx)
+	return fmt.Sprintf("seg_%d_s%d", objectID, segmentIdx)
 }
 
 func (p *GfSpPieceOp) ECPieceKey(objectID uint64, segmentIdx uint32, replicateIdx uint32) string {
-	return fmt.Sprintf("%d_s%d_p%d", objectID, segmentIdx, replicateIdx)
+	return fmt.Sprintf("ec_%d_s%d_p%d", objectID, segmentIdx, replicateIdx)
 }
 
 func (p *GfSpPieceOp) ChallengePieceKey(objectID uint64, segmentIdx uint32, replicateIdx int32) string {

--- a/base/gfsppieceop/pieceop.go
+++ b/base/gfsppieceop/pieceop.go
@@ -12,11 +12,11 @@ type GfSpPieceOp struct {
 }
 
 func (p *GfSpPieceOp) SegmentPieceKey(objectID uint64, segmentIdx uint32) string {
-	return fmt.Sprintf("seg_%d_s%d", objectID, segmentIdx)
+	return fmt.Sprintf("s%d_s%d", objectID, segmentIdx)
 }
 
 func (p *GfSpPieceOp) ECPieceKey(objectID uint64, segmentIdx uint32, replicateIdx uint32) string {
-	return fmt.Sprintf("ec_%d_s%d_p%d", objectID, segmentIdx, replicateIdx)
+	return fmt.Sprintf("e%d_s%d_p%d", objectID, segmentIdx, replicateIdx)
 }
 
 func (p *GfSpPieceOp) ChallengePieceKey(objectID uint64, segmentIdx uint32, replicateIdx int32) string {


### PR DESCRIPTION
### Description

This pr will add a different prefix for the segment and ec piece key.

### Rationale

The reason is if we add a different prefix for the segment and ec piece key, we can add filter by prefix for the segments and ec chunks stored in s3 and we can apply different rules to save cost (ie, we can store the segments in intelligent tierring which is more expensive, and store the ec chunks in glacier which is cheaper). Another reason is that s3 doesn't allow regex for the prefix, so we need to add a prefix for the stored pieces.

This change allows us to store all the pieces in one bucket and we don't need to create multiple buckets for the cost saving.

### Example

n/a

### Changes

Notable changes: 
* add prefix for segment and ec piece key
