### PR TITLE
fix: request cannot be nil in latestBlockHeight

### DIFF
--- a/modular/signer/signer_client.go
+++ b/modular/signer/signer_client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"cosmossdk.io/errors"
+	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkErrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/tx"
@@ -432,7 +433,7 @@ func waitForNextBlock(ctx context.Context, client *client.GreenfieldClient) erro
 }
 
 func latestBlockHeight(ctx context.Context, client *client.GreenfieldClient) (int64, error) {
-	block, err := client.GetLatestBlock(ctx, nil)
+	block, err := client.GetLatestBlock(ctx, &tmservice.GetLatestBlockRequest{})
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
### Description

```
{"t":"2023-06-21T06:57:28.625Z","l":"error","caller":"signer/signer_client.go:353","msg":"failed to get seal account nonce","error":"request cannot be nil: invalid request","errorVerbose":"\ngithub.com/cosmos/cosmos-sdk/client.Context.Invoke\n\t/go/pkg/mod/github.com/bnb-chain/greenfield-cosmos-sdk@v0.2.2-alpha.1/client/grpc_query.go:42\ngithub.com/cosmos/cosmos-sdk/client/grpc/tmservice.(*serviceClient).GetLatestBlock\n\t/go/pkg/mod/github.com/bnb-chain/greenfield-cosmos-sdk@v0.2.2-alpha.1/client/grpc/tmservice/query.pb.go:1348\ngithub.com/bnb-chain/greenfield-storage-provider/modular/signer.latestBlockHeight\n\t/greenfield-storage-provider/modular/signer/signer_client.go:435\ngithub.com/bnb-chain/greenfield-storage-provider/modular/signer.waitForNextBlock\n\t/greenfield-storage-provider/modular/signer/signer_client.go:411\ngithub.com/bnb-chain/greenfield-storage-provider/modular/signer.(*GreenfieldChainSignClient).getNonceOnChain\n\t/greenfield-storage-provider/modular/signer/signer_client.go:373\ngithub.com/bnb-chain/greenfield-storage-provider/modular/signer.(*GreenfieldChainSignClient).DiscontinueBucket\n\t/greenfield-storage-provider/modular/signer/signer_client.go:351\ngithub.com/bnb-chain/greenfield-storage-provider/modular/signer.(*SignModular).DiscontinueBucket\n\t/greenfield-storage-provider/modular/signer/signer.go:172\ngithub.com/bnb-chain/greenfield-storage-provider/base/gfspapp.(*GfSpBaseApp).GfSpSign\n\t/greenfield-storage-provider/base/gfspapp/sign_server.go:50\ngithub.com/bnb-chain/greenfield-storage-provider/base/types/gfspserver._GfSpSignService_GfSpSign_Handler.func1\n\t/greenfield-storage-provider/base/types/gfspserver/sign.pb.go:452\ngithub.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors.UnaryServerInterceptor.func1\n\t/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.0.0-rc.3/interceptors/server.go:22\ngithub.com/bnb-chain/greenfield-storage-provider/base/types/gfspserver._GfSpSignService_GfSpSign_Handler\n\t/greenfield-storage-provider/base/types/gfspserver/sign.pb.go:454\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\t/go/pkg/mod/google.golang.org/grpc@v1.54.0/server.go:1345\ngoogle.golang.org/grpc.(*Server).handleStream\n\t/go/pkg/mod/google.golang.org/grpc@v1.54.0/server.go:1722\ngoogle.golang.org/grpc.(*Server).serveStreams.func1.2\n\t/go/pkg/mod/google.golang.org/grpc@v1.54.0/server.go:966\nrequest cannot be nil: invalid request"}

```

### Rationale

missing request body in latestBlockHeight

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* signer
