### PR TITLE
feat:  blocksyncer adapt latest changes for sp meta from chain side( with juno version updated)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ replace (
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-0.20230626091810-fa69f41ddfc5
 	// TODO: Temporary succeed to compile
-	github.com/forbole/juno/v4 => github.com/bnb-chain/juno/v4 v4.0.0-20230628062411-67d19406d07d
+	github.com/forbole/juno/v4 => github.com/bnb-chain/juno/v4 v4.0.0-20230629134244-950c0e459a80
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )
@@ -20,7 +20,7 @@ require (
 	cosmossdk.io/errors v1.0.0-beta.7
 	cosmossdk.io/math v1.0.1
 	github.com/aws/aws-sdk-go v1.44.159
-	github.com/bnb-chain/greenfield v0.2.3-0.20230628024113-2609d081ee4d
+	github.com/bnb-chain/greenfield v0.2.3-0.20230629054947-b6d6df29e268
 	github.com/bnb-chain/greenfield-common/go v0.0.0-20230512062756-5d7790d0ccbf
 	github.com/bytedance/gopkg v0.0.0-20221122125632-68358b8ecec6
 	github.com/cometbft/cometbft v0.37.1
@@ -58,7 +58,10 @@ require (
 	gorm.io/gorm v1.24.5
 )
 
-require github.com/forbole/juno/v4 v4.0.0-00010101000000-000000000000
+require (
+	github.com/forbole/juno/v4 v4.0.0-00010101000000-000000000000
+	github.com/gogo/protobuf v1.3.3
+)
 
 require (
 	cosmossdk.io/api v0.4.0 // indirect
@@ -85,7 +88,6 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
-	github.com/gogo/protobuf v1.3.3 // indirect
 	github.com/golang-jwt/jwt/v4 v4.3.0 // indirect
 	github.com/google/orderedcode v0.0.1 // indirect
 	github.com/gorilla/handlers v1.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9/go.mod h1:rbc4o84RSEvhf09o2+4Qiazsv0snRJLiEZdk17HeIDw=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230425074444-eb5869b05fe9 h1:1ZdK+iR1Up02bOa2YTZCml7PBpP//kcdamOcK6aWO/s=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230425074444-eb5869b05fe9/go.mod h1:Ygz4wBHrgc7g0N+8+MrnTfS9LLn9aaTGa9hKopuym5k=
-github.com/bnb-chain/juno/v4 v4.0.0-20230628062411-67d19406d07d h1:CSTbvF1LsWOWVpxv7oL22l9ursZv4jF+dhTCWeVk5mY=
-github.com/bnb-chain/juno/v4 v4.0.0-20230628062411-67d19406d07d/go.mod h1:5I2NP+mbdW44IVZk5VUwVhSsfYgwqkvii42Evc8RkiU=
+github.com/bnb-chain/juno/v4 v4.0.0-20230629134244-950c0e459a80 h1:T9/78KvuVVCjWk0q+rn+XDf7RMvxsTseaEfyec9gN1c=
+github.com/bnb-chain/juno/v4 v4.0.0-20230629134244-950c0e459a80/go.mod h1:ICZfZMJ49Ll8BgcoAosGsS8p/hWQI7VIpV3LvWl4KV4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/bradfitz/gomemcache v0.0.0-20170208213004-1952afaa557d/go.mod h1:PmM6Mmwb0LSuEubjR8N7PtNe1KxZLtOUHtbeikc5h60=


### PR DESCRIPTION
### Description

blocksyncer adapt latest changes for sp meta from chain side

### Rationale

sp data structure chaged(replace operatore address with spId), we adapted this change in juno and this PR is to update dependency
 
### Example

N/A

### Changes

Notable changes: 
*  juno version updated