### PR TITLE
feat: SP database sharding

### DIFF
--- a/modular/blocksyncer/database/database.go
+++ b/modular/blocksyncer/database/database.go
@@ -5,14 +5,15 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
+
 	"github.com/forbole/juno/v4/database"
 	"github.com/forbole/juno/v4/database/mysql"
 	"github.com/forbole/juno/v4/database/sqlclient"
+	"github.com/forbole/juno/v4/log"
 	"gorm.io/gorm"
 	"gorm.io/gorm/schema"
 
-	"github.com/forbole/juno/v4/log"
+	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
 )
 
 var _ database.Database = &DB{}
@@ -58,7 +59,7 @@ func (db *DB) AutoMigrate(ctx context.Context, tables []schema.Tabler) error {
 	m := db.Db.Migrator()
 	for _, t := range tables {
 		if t.TableName() == bsdb.PrefixTreeTableName || t.TableName() == bsdb.ObjectTableName {
-			for i := 0; i < 64; i++ {
+			for i := 0; i < bsdb.ObjectsNumberOfShards; i++ {
 				shardTableName := fmt.Sprintf(t.TableName()+"_%02d", i)
 				if err := q.Table(shardTableName).AutoMigrate(t); err != nil {
 					log.Errorw("migrate table failed", "table", t.TableName(), "err", err)
@@ -81,7 +82,7 @@ func (db *DB) PrepareTables(ctx context.Context, tables []schema.Tabler) error {
 
 	for _, t := range tables {
 		if t.TableName() == bsdb.PrefixTreeTableName || t.TableName() == bsdb.ObjectTableName {
-			for i := 0; i < 64; i++ {
+			for i := 0; i < bsdb.ObjectsNumberOfShards; i++ {
 				shardTableName := fmt.Sprintf(t.TableName()+"_%02d", i)
 				if m.HasTable(shardTableName) {
 					continue

--- a/modular/blocksyncer/database/database.go
+++ b/modular/blocksyncer/database/database.go
@@ -1,14 +1,18 @@
 package database
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
-
+	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
 	"github.com/forbole/juno/v4/database"
 	"github.com/forbole/juno/v4/database/mysql"
 	"github.com/forbole/juno/v4/database/sqlclient"
 	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+
+	"github.com/forbole/juno/v4/log"
 )
 
 var _ database.Database = &DB{}
@@ -47,4 +51,57 @@ func Cast(db database.Database) *DB {
 // errIsNotFound check if the error is not found
 func errIsNotFound(err error) bool {
 	return errors.Is(err, sql.ErrNoRows) || errors.Is(err, gorm.ErrRecordNotFound)
+}
+
+func (db *DB) AutoMigrate(ctx context.Context, tables []schema.Tabler) error {
+	q := db.Db.WithContext(ctx)
+	m := db.Db.Migrator()
+	for _, t := range tables {
+		if t.TableName() == bsdb.PrefixTreeTableName || t.TableName() == bsdb.ObjectTableName {
+			for i := 0; i < 64; i++ {
+				shardTableName := fmt.Sprintf(t.TableName()+"_%02d", i)
+				if err := q.Table(shardTableName).AutoMigrate(t); err != nil {
+					log.Errorw("migrate table failed", "table", t.TableName(), "err", err)
+					return err
+				}
+			}
+		} else {
+			if err := m.AutoMigrate(t); err != nil {
+				log.Errorw("migrate table failed", "table", t.TableName(), "err", err)
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (db *DB) PrepareTables(ctx context.Context, tables []schema.Tabler) error {
+	q := db.Db.WithContext(ctx)
+	m := db.Db.Migrator()
+
+	for _, t := range tables {
+		if t.TableName() == bsdb.PrefixTreeTableName || t.TableName() == bsdb.ObjectTableName {
+			for i := 0; i < 64; i++ {
+				shardTableName := fmt.Sprintf(t.TableName()+"_%02d", i)
+				if m.HasTable(shardTableName) {
+					continue
+				}
+				if err := q.Table(shardTableName).AutoMigrate(t); err != nil {
+					log.Errorw("migrate table failed", "table", shardTableName, "err", err)
+					return err
+				}
+			}
+		} else {
+			if m.HasTable(t.TableName()) {
+				continue
+			}
+			if err := q.Table(t.TableName()).AutoMigrate(t); err != nil {
+				log.Errorw("migrate table failed", "table", t.TableName(), "err", err)
+				return err
+			}
+		}
+
+	}
+
+	return nil
 }

--- a/modular/blocksyncer/database/object.go
+++ b/modular/blocksyncer/database/object.go
@@ -2,10 +2,12 @@ package database
 
 import (
 	"context"
-	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
+
 	"github.com/forbole/juno/v4/common"
 	"github.com/forbole/juno/v4/models"
 	"gorm.io/gorm/clause"
+
+	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
 )
 
 func (db *DB) SaveObject(ctx context.Context, object *models.Object) error {

--- a/modular/blocksyncer/database/object.go
+++ b/modular/blocksyncer/database/object.go
@@ -2,14 +2,14 @@ package database
 
 import (
 	"context"
+	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
+	"github.com/forbole/juno/v4/common"
 	"github.com/forbole/juno/v4/models"
 	"gorm.io/gorm/clause"
-
-	"github.com/forbole/juno/v4/common"
 )
 
 func (db *DB) SaveObject(ctx context.Context, object *models.Object) error {
-	err := db.Db.WithContext(ctx).Table((&models.Object{}).TableName()).Clauses(clause.OnConflict{
+	err := db.Db.WithContext(ctx).Scopes(bsdb.ReadObjectsTable(object.BucketName)).Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "object_id"}},
 		UpdateAll: true,
 	}).Create(object).Error
@@ -17,14 +17,14 @@ func (db *DB) SaveObject(ctx context.Context, object *models.Object) error {
 }
 
 func (db *DB) UpdateObject(ctx context.Context, object *models.Object) error {
-	err := db.Db.WithContext(ctx).Table((&models.Object{}).TableName()).Where("object_id = ?", object.ObjectID).Updates(object).Error
+	err := db.Db.WithContext(ctx).Scopes(bsdb.ReadObjectsTable(object.BucketName)).Where("object_id = ?", object.ObjectID).Updates(object).Error
 	return err
 }
 
 func (db *DB) GetObject(ctx context.Context, objectId common.Hash) (*models.Object, error) {
 	var object models.Object
 
-	err := db.Db.WithContext(ctx).Where(
+	err := db.Db.WithContext(ctx).Scopes(bsdb.ReadObjectsTable(object.BucketName)).Where(
 		"object_id = ? AND removed IS NOT TRUE", objectId).Find(&object).Error
 	if err != nil {
 		return nil, err

--- a/modular/blocksyncer/database/object.go
+++ b/modular/blocksyncer/database/object.go
@@ -1,0 +1,33 @@
+package database
+
+import (
+	"context"
+	"github.com/forbole/juno/v4/models"
+	"gorm.io/gorm/clause"
+
+	"github.com/forbole/juno/v4/common"
+)
+
+func (db *DB) SaveObject(ctx context.Context, object *models.Object) error {
+	err := db.Db.WithContext(ctx).Table((&models.Object{}).TableName()).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "object_id"}},
+		UpdateAll: true,
+	}).Create(object).Error
+	return err
+}
+
+func (db *DB) UpdateObject(ctx context.Context, object *models.Object) error {
+	err := db.Db.WithContext(ctx).Table((&models.Object{}).TableName()).Where("object_id = ?", object.ObjectID).Updates(object).Error
+	return err
+}
+
+func (db *DB) GetObject(ctx context.Context, objectId common.Hash) (*models.Object, error) {
+	var object models.Object
+
+	err := db.Db.WithContext(ctx).Where(
+		"object_id = ? AND removed IS NOT TRUE", objectId).Find(&object).Error
+	if err != nil {
+		return nil, err
+	}
+	return &object, nil
+}

--- a/modular/blocksyncer/database/objectidmap.go
+++ b/modular/blocksyncer/database/objectidmap.go
@@ -1,0 +1,17 @@
+package database
+
+import (
+	"context"
+	"gorm.io/gorm/clause"
+
+	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
+)
+
+// CreateObjectIDMap create object id map table entry
+func (db *DB) CreateObjectIDMap(ctx context.Context, objectIDMap *bsdb.ObjectIDMap) error {
+	err := db.Db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "object_id"}},
+		UpdateAll: true,
+	}).Create(objectIDMap).Error
+	return err
+}

--- a/modular/blocksyncer/database/objectidmap.go
+++ b/modular/blocksyncer/database/objectidmap.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+
 	"gorm.io/gorm/clause"
 
 	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"

--- a/modular/blocksyncer/database/prefixtree.go
+++ b/modular/blocksyncer/database/prefixtree.go
@@ -11,7 +11,9 @@ import (
 
 // CreatePrefixTree create prefix tree nodes by input slice
 func (db *DB) CreatePrefixTree(ctx context.Context, prefixTree []*bsdb.SlashPrefixTreeNode) error {
-	err := db.Db.WithContext(ctx).Table(bsdb.GetPrefixesTableName(prefixTree[0].BucketName)).Create(&prefixTree).Error
+	// because the passed in prefixTree is one object, the array members have same bucketName, we can use the first one
+	shardTableName := bsdb.GetPrefixesTableName(prefixTree[0].BucketName)
+	err := db.Db.WithContext(ctx).Table(shardTableName).Create(&prefixTree).Error
 	if err != nil {
 		return err
 	}
@@ -23,7 +25,9 @@ func (db *DB) DeletePrefixTree(ctx context.Context, prefixTree []*bsdb.SlashPref
 	if len(prefixTree) == 0 {
 		return nil
 	}
-	tx := db.Db.WithContext(ctx).Table(bsdb.GetPrefixesTableName(prefixTree[0].BucketName))
+	// because the passed in prefixTree is one object, the array members have same bucketName, we can use the first one
+	shardTableName := bsdb.GetPrefixesTableName(prefixTree[0].BucketName)
+	tx := db.Db.WithContext(ctx).Table(shardTableName)
 	stmt := tx.Where("bucket_name = ? AND full_name = ? AND is_object = ?",
 		prefixTree[0].BucketName,
 		prefixTree[0].FullName,
@@ -42,11 +46,11 @@ func (db *DB) DeletePrefixTree(ctx context.Context, prefixTree []*bsdb.SlashPref
 	return nil
 }
 
-// same tree?
 // GetPrefixTree get prefix tree node by full name and bucket name
 func (db *DB) GetPrefixTree(ctx context.Context, fullName, bucketName string) (*bsdb.SlashPrefixTreeNode, error) {
 	var prefixTreeNode *bsdb.SlashPrefixTreeNode
-	err := db.Db.WithContext(ctx).Table(bsdb.GetPrefixesTableName(bucketName)).
+	shardTableName := bsdb.GetPrefixesTableName(bucketName)
+	err := db.Db.WithContext(ctx).Table(shardTableName).
 		Where("full_name = ? AND bucket_name = ? AND is_object = ?", fullName, bucketName, false).Take(&prefixTreeNode).Error
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
@@ -58,16 +62,10 @@ func (db *DB) GetPrefixTree(ctx context.Context, fullName, bucketName string) (*
 }
 
 // GetPrefixTreeObject get prefix tree node object by object id
-func (db *DB) GetPrefixTreeObject(ctx context.Context, objectID common.Hash) (*bsdb.SlashPrefixTreeNode, error) {
+func (db *DB) GetPrefixTreeObject(ctx context.Context, objectID common.Hash, bucketName string) (*bsdb.SlashPrefixTreeNode, error) {
 	var prefixTreeNode *bsdb.SlashPrefixTreeNode
-	bucketName, err := db.GetBucketNameByObjectID(objectID)
-	if err != nil {
-		if err == gorm.ErrRecordNotFound {
-			return nil, nil
-		}
-		return nil, err
-	}
-	err = db.Db.WithContext(ctx).Table(bsdb.GetPrefixesTableName(bucketName)).
+	shardTableName := bsdb.GetPrefixesTableName(bucketName)
+	err := db.Db.WithContext(ctx).Table(shardTableName).
 		Where("object_id = ?", objectID).Take(&prefixTreeNode).Error
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
@@ -81,7 +79,8 @@ func (db *DB) GetPrefixTreeObject(ctx context.Context, objectID common.Hash) (*b
 // GetPrefixTreeCount get prefix tree nodes count by path and bucket name
 func (db *DB) GetPrefixTreeCount(ctx context.Context, pathName, bucketName string) (int64, error) {
 	var count int64
-	err := db.Db.WithContext(ctx).Table(bsdb.GetPrefixesTableName(bucketName)).Where("bucket_name = ? AND path_name = ?", bucketName, pathName).Count(&count).Error
+	shardTableName := bsdb.GetPrefixesTableName(bucketName)
+	err := db.Db.WithContext(ctx).Table(shardTableName).Where("bucket_name = ? AND path_name = ?", bucketName, pathName).Count(&count).Error
 	if err != nil {
 		return 0, err
 	}

--- a/modular/blocksyncer/modules/object/module.go
+++ b/modular/blocksyncer/modules/object/module.go
@@ -2,8 +2,8 @@ package object
 
 import (
 	"context"
-	"github.com/forbole/juno/v4/models"
 
+	"github.com/forbole/juno/v4/models"
 	"github.com/forbole/juno/v4/modules"
 	"gorm.io/gorm/schema"
 

--- a/modular/blocksyncer/modules/object/module.go
+++ b/modular/blocksyncer/modules/object/module.go
@@ -43,5 +43,5 @@ func (m *Module) PrepareTables() error {
 
 // AutoMigrate implements
 func (m *Module) AutoMigrate() error {
-	return m.db.AutoMigrate(context.TODO(), []schema.Tabler{&models.Object{}})
+	return m.db.AutoMigrate(context.TODO(), []schema.Tabler{&models.Object{}, &models.Object{}})
 }

--- a/modular/blocksyncer/modules/object/module.go
+++ b/modular/blocksyncer/modules/object/module.go
@@ -1,0 +1,47 @@
+package object
+
+import (
+	"context"
+	"github.com/forbole/juno/v4/models"
+
+	"github.com/forbole/juno/v4/modules"
+	"gorm.io/gorm/schema"
+
+	"github.com/bnb-chain/greenfield-storage-provider/modular/blocksyncer/database"
+)
+
+const (
+	ModuleName = "object"
+)
+
+var (
+	_ modules.Module              = &Module{}
+	_ modules.PrepareTablesModule = &Module{}
+)
+
+// Module represents the object module
+type Module struct {
+	db *database.DB
+}
+
+// NewModule builds a new Module instance
+func NewModule(db *database.DB) *Module {
+	return &Module{
+		db: db,
+	}
+}
+
+// Name implements modules.Module
+func (m *Module) Name() string {
+	return ModuleName
+}
+
+// PrepareTables implements
+func (m *Module) PrepareTables() error {
+	return m.db.PrepareTables(context.TODO(), []schema.Tabler{&models.Object{}})
+}
+
+// AutoMigrate implements
+func (m *Module) AutoMigrate() error {
+	return m.db.AutoMigrate(context.TODO(), []schema.Tabler{&models.Object{}})
+}

--- a/modular/blocksyncer/modules/object/object_handler.go
+++ b/modular/blocksyncer/modules/object/object_handler.go
@@ -1,0 +1,263 @@
+package object
+
+import (
+	"context"
+	"errors"
+	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
+	abci "github.com/cometbft/cometbft/abci/types"
+	tmctypes "github.com/cometbft/cometbft/rpc/core/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/gogoproto/proto"
+
+	"github.com/forbole/juno/v4/common"
+	"github.com/forbole/juno/v4/log"
+	"github.com/forbole/juno/v4/models"
+)
+
+var (
+	EventCreateObject       = proto.MessageName(&storagetypes.EventCreateObject{})
+	EventCancelCreateObject = proto.MessageName(&storagetypes.EventCancelCreateObject{})
+	EventSealObject         = proto.MessageName(&storagetypes.EventSealObject{})
+	EventCopyObject         = proto.MessageName(&storagetypes.EventCopyObject{})
+	EventDeleteObject       = proto.MessageName(&storagetypes.EventDeleteObject{})
+	EventRejectSealObject   = proto.MessageName(&storagetypes.EventRejectSealObject{})
+	EventDiscontinueObject  = proto.MessageName(&storagetypes.EventDiscontinueObject{})
+	EventUpdateObjectInfo   = proto.MessageName(&storagetypes.EventUpdateObjectInfo{})
+)
+
+var objectEvents = map[string]bool{
+	EventCreateObject:       true,
+	EventCancelCreateObject: true,
+	EventSealObject:         true,
+	EventCopyObject:         true,
+	EventDeleteObject:       true,
+	EventRejectSealObject:   true,
+	EventDiscontinueObject:  true,
+	EventUpdateObjectInfo:   true,
+}
+
+func (m *Module) HandleEvent(ctx context.Context, block *tmctypes.ResultBlock, txHash common.Hash, event sdk.Event) error {
+	if !objectEvents[event.Type] {
+		return nil
+	}
+
+	typedEvent, err := sdk.ParseTypedEvent(abci.Event(event))
+	if err != nil {
+		log.Errorw("parse typed events error", "module", m.Name(), "event", event, "err", err)
+		return err
+	}
+
+	switch event.Type {
+	case EventCreateObject:
+		createObject, ok := typedEvent.(*storagetypes.EventCreateObject)
+		if !ok {
+			log.Errorw("type assert error", "type", "EventCreateObject", "event", typedEvent)
+			return errors.New("create object event assert error")
+		}
+		return m.handleCreateObject(ctx, block, txHash, createObject)
+	case EventCancelCreateObject:
+		cancelCreateObject, ok := typedEvent.(*storagetypes.EventCancelCreateObject)
+		if !ok {
+			log.Errorw("type assert error", "type", "EventCancelCreateObject", "event", typedEvent)
+			return errors.New("cancel create object event assert error")
+		}
+		return m.handleCancelCreateObject(ctx, block, txHash, cancelCreateObject)
+	case EventSealObject:
+		sealObject, ok := typedEvent.(*storagetypes.EventSealObject)
+		if !ok {
+			log.Errorw("type assert error", "type", "EventSealObject", "event", typedEvent)
+			return errors.New("seal object event assert error")
+		}
+		return m.handleSealObject(ctx, block, txHash, sealObject)
+	case EventCopyObject:
+		copyObject, ok := typedEvent.(*storagetypes.EventCopyObject)
+		if !ok {
+			log.Errorw("type assert error", "type", "EventCopyObject", "event", typedEvent)
+			return errors.New("copy object event assert error")
+		}
+		return m.handleCopyObject(ctx, block, txHash, copyObject)
+	case EventDeleteObject:
+		deleteObject, ok := typedEvent.(*storagetypes.EventDeleteObject)
+		if !ok {
+			log.Errorw("type assert error", "type", "EventDeleteObject", "event", typedEvent)
+			return errors.New("delete object event assert error")
+		}
+		return m.handleDeleteObject(ctx, block, txHash, deleteObject)
+	case EventRejectSealObject:
+		rejectSealObject, ok := typedEvent.(*storagetypes.EventRejectSealObject)
+		if !ok {
+			log.Errorw("type assert error", "type", "EventRejectSealObject", "event", typedEvent)
+			return errors.New("reject seal object event assert error")
+		}
+		return m.handleRejectSealObject(ctx, block, txHash, rejectSealObject)
+	case EventDiscontinueObject:
+		discontinueObject, ok := typedEvent.(*storagetypes.EventDiscontinueObject)
+		if !ok {
+			log.Errorw("type assert error", "type", "EventDiscontinueObject", "event", typedEvent)
+			return errors.New("discontinue object event assert error")
+		}
+		return m.handleEventDiscontinueObject(ctx, block, txHash, discontinueObject)
+	case EventUpdateObjectInfo:
+		updateObjectInfo, ok := typedEvent.(*storagetypes.EventUpdateObjectInfo)
+		if !ok {
+			log.Errorw("type assert error", "type", "EventUpdateObjectInfo", "event", typedEvent)
+			return errors.New("update object event assert error")
+		}
+		return m.handleUpdateObjectInfo(ctx, block, txHash, updateObjectInfo)
+	}
+
+	return nil
+}
+
+func (m *Module) handleCreateObject(ctx context.Context, block *tmctypes.ResultBlock, txHash common.Hash, createObject *storagetypes.EventCreateObject) error {
+	object := &models.Object{
+		BucketID:         common.BigToHash(createObject.BucketId.BigInt()),
+		BucketName:       createObject.BucketName,
+		ObjectID:         common.BigToHash(createObject.ObjectId.BigInt()),
+		ObjectName:       createObject.ObjectName,
+		Creator:          common.HexToAddress(createObject.Creator),
+		Owner:            common.HexToAddress(createObject.Owner),
+		PrimarySpAddress: common.HexToAddress(createObject.PrimarySpAddress),
+		PayloadSize:      createObject.PayloadSize,
+		Visibility:       createObject.Visibility.String(),
+		ContentType:      createObject.ContentType,
+		Status:           createObject.Status.String(),
+		RedundancyType:   createObject.RedundancyType.String(),
+		SourceType:       createObject.SourceType.String(),
+		CheckSums:        createObject.Checksums,
+
+		CreateTxHash: txHash,
+		CreateAt:     block.Block.Height,
+		CreateTime:   createObject.CreateAt,
+		UpdateAt:     block.Block.Height,
+		UpdateTxHash: txHash,
+		UpdateTime:   createObject.CreateAt,
+		Removed:      false,
+	}
+
+	return m.db.SaveObject(ctx, object)
+}
+
+func (m *Module) handleSealObject(ctx context.Context, block *tmctypes.ResultBlock, txHash common.Hash, sealObject *storagetypes.EventSealObject) error {
+	object := &models.Object{
+		BucketName:           sealObject.BucketName,
+		ObjectName:           sealObject.ObjectName,
+		ObjectID:             common.BigToHash(sealObject.ObjectId.BigInt()),
+		Operator:             common.HexToAddress(sealObject.Operator),
+		SecondarySpAddresses: sealObject.SecondarySpAddresses,
+		Status:               sealObject.Status.String(),
+		SealedTxHash:         txHash,
+
+		UpdateAt:     block.Block.Height,
+		UpdateTxHash: txHash,
+		UpdateTime:   block.Block.Time.UTC().Unix(),
+		Removed:      false,
+	}
+
+	return m.db.UpdateObject(ctx, object)
+}
+
+func (m *Module) handleCancelCreateObject(ctx context.Context, block *tmctypes.ResultBlock, txHash common.Hash, cancelCreateObject *storagetypes.EventCancelCreateObject) error {
+	object := &models.Object{
+		BucketName:       cancelCreateObject.BucketName,
+		ObjectName:       cancelCreateObject.ObjectName,
+		ObjectID:         common.BigToHash(cancelCreateObject.ObjectId.BigInt()),
+		Operator:         common.HexToAddress(cancelCreateObject.Operator),
+		PrimarySpAddress: common.HexToAddress(cancelCreateObject.PrimarySpAddress),
+		UpdateAt:         block.Block.Height,
+		UpdateTxHash:     txHash,
+		UpdateTime:       block.Block.Time.UTC().Unix(),
+		Removed:          true,
+	}
+
+	return m.db.UpdateObject(ctx, object)
+}
+
+func (m *Module) handleCopyObject(ctx context.Context, block *tmctypes.ResultBlock, txHash common.Hash, copyObject *storagetypes.EventCopyObject) error {
+	destObject, err := m.db.GetObject(ctx, common.BigToHash(copyObject.SrcObjectId.BigInt()))
+	if err != nil {
+		return err
+	}
+
+	destObject.ObjectID = common.BigToHash(copyObject.DstObjectId.BigInt())
+	destObject.ObjectName = copyObject.DstObjectName
+	destObject.BucketName = copyObject.DstBucketName
+	destObject.Operator = common.HexToAddress(copyObject.Operator)
+	destObject.CreateAt = block.Block.Height
+	destObject.CreateTxHash = txHash
+	destObject.CreateTime = block.Block.Time.UTC().Unix()
+	destObject.UpdateAt = block.Block.Height
+	destObject.UpdateTxHash = txHash
+	destObject.UpdateTime = block.Block.Time.UTC().Unix()
+	destObject.Removed = false
+
+	return m.db.UpdateObject(ctx, destObject)
+}
+
+func (m *Module) handleDeleteObject(ctx context.Context, block *tmctypes.ResultBlock, txHash common.Hash, deleteObject *storagetypes.EventDeleteObject) error {
+	object := &models.Object{
+		BucketName:           deleteObject.BucketName,
+		ObjectName:           deleteObject.ObjectName,
+		ObjectID:             common.BigToHash(deleteObject.ObjectId.BigInt()),
+		PrimarySpAddress:     common.HexToAddress(deleteObject.PrimarySpAddress),
+		SecondarySpAddresses: deleteObject.SecondarySpAddresses,
+
+		UpdateAt:     block.Block.Height,
+		UpdateTxHash: txHash,
+		UpdateTime:   block.Block.Time.UTC().Unix(),
+		Removed:      true,
+	}
+
+	return m.db.UpdateObject(ctx, object)
+}
+
+// RejectSeal event won't emit a delete event, need to be deleted manually here in metadata service
+// handle logic is set as removed, no need to set status
+func (m *Module) handleRejectSealObject(ctx context.Context, block *tmctypes.ResultBlock, txHash common.Hash, rejectSealObject *storagetypes.EventRejectSealObject) error {
+	object := &models.Object{
+		BucketName: rejectSealObject.BucketName,
+		ObjectName: rejectSealObject.ObjectName,
+		ObjectID:   common.BigToHash(rejectSealObject.ObjectId.BigInt()),
+		Operator:   common.HexToAddress(rejectSealObject.Operator),
+
+		UpdateAt:     block.Block.Height,
+		UpdateTxHash: txHash,
+		UpdateTime:   block.Block.Time.UTC().Unix(),
+		Removed:      true,
+	}
+
+	return m.db.UpdateObject(ctx, object)
+}
+
+func (m *Module) handleEventDiscontinueObject(ctx context.Context, block *tmctypes.ResultBlock, txHash common.Hash, discontinueObject *storagetypes.EventDiscontinueObject) error {
+	object := &models.Object{
+		BucketName:   discontinueObject.BucketName,
+		ObjectID:     common.BigToHash(discontinueObject.ObjectId.BigInt()),
+		DeleteReason: discontinueObject.Reason,
+		DeleteAt:     discontinueObject.DeleteAt,
+		Status:       storagetypes.OBJECT_STATUS_DISCONTINUED.String(),
+
+		UpdateAt:     block.Block.Height,
+		UpdateTxHash: txHash,
+		UpdateTime:   block.Block.Time.UTC().Unix(),
+		Removed:      false,
+	}
+
+	return m.db.UpdateObject(ctx, object)
+}
+
+func (m *Module) handleUpdateObjectInfo(ctx context.Context, block *tmctypes.ResultBlock, txHash common.Hash, updateObject *storagetypes.EventUpdateObjectInfo) error {
+	object := &models.Object{
+		BucketName: updateObject.BucketName,
+		ObjectID:   common.BigToHash(updateObject.ObjectId.BigInt()),
+		ObjectName: updateObject.ObjectName,
+		Operator:   common.HexToAddress(updateObject.Operator),
+		Visibility: updateObject.Visibility.String(),
+
+		UpdateAt:     block.Block.Height,
+		UpdateTxHash: txHash,
+		UpdateTime:   block.Block.Time.UTC().Unix(),
+	}
+
+	return m.db.UpdateObject(ctx, object)
+}

--- a/modular/blocksyncer/modules/object/object_handler.go
+++ b/modular/blocksyncer/modules/object/object_handler.go
@@ -3,12 +3,12 @@ package object
 import (
 	"context"
 	"errors"
+
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 	abci "github.com/cometbft/cometbft/abci/types"
 	tmctypes "github.com/cometbft/cometbft/rpc/core/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/gogoproto/proto"
-
 	"github.com/forbole/juno/v4/common"
 	"github.com/forbole/juno/v4/log"
 	"github.com/forbole/juno/v4/models"

--- a/modular/blocksyncer/modules/objectidmap/module.go
+++ b/modular/blocksyncer/modules/objectidmap/module.go
@@ -1,0 +1,46 @@
+package objectidmap
+
+import (
+	"context"
+
+	"github.com/forbole/juno/v4/modules"
+	"gorm.io/gorm/schema"
+
+	"github.com/bnb-chain/greenfield-storage-provider/modular/blocksyncer/database"
+	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
+)
+
+const (
+	ModuleName = "object_id_map"
+)
+
+var (
+	_ modules.Module              = &Module{}
+	_ modules.PrepareTablesModule = &Module{}
+)
+
+// Module represents the object module
+type Module struct {
+	db *database.DB
+}
+
+// NewModule builds a new Module instance
+func NewModule(db *database.DB) *Module {
+	return &Module{
+		db: db,
+	}
+}
+
+// Name implements modules.Module
+func (m *Module) Name() string {
+	return ModuleName
+}
+
+// PrepareTables implements
+func (m *Module) PrepareTables() error {
+	return m.db.PrepareTables(context.TODO(), []schema.Tabler{&bsdb.ObjectIDMap{}})
+}
+
+func (m *Module) AutoMigrate() error {
+	return m.db.AutoMigrate(context.TODO(), []schema.Tabler{&bsdb.ObjectIDMap{}})
+}

--- a/modular/blocksyncer/modules/objectidmap/object_id_map.go
+++ b/modular/blocksyncer/modules/objectidmap/object_id_map.go
@@ -1,0 +1,62 @@
+package objectidmap
+
+import (
+	"context"
+	"errors"
+	abci "github.com/cometbft/cometbft/abci/types"
+	tmctypes "github.com/cometbft/cometbft/rpc/core/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/gogoproto/proto"
+	"github.com/forbole/juno/v4/common"
+	"github.com/forbole/juno/v4/log"
+
+	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
+	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
+)
+
+var (
+	EventCreateObject = proto.MessageName(&storagetypes.EventCreateObject{})
+)
+
+// buildPrefixTreeEvents maps event types that trigger the creation or deletion of prefix tree nodes.
+// If an event type is present and set to true in this map,
+// it means that event will result in changes to the prefix tree structure.
+var buildPrefixTreeEvents = map[string]bool{
+	EventCreateObject: true,
+}
+
+// HandleEvent handles the events relevant to the building of the PrefixTree.
+// It checks the type of the event and calls the appropriate handler for it.
+func (m *Module) HandleEvent(ctx context.Context, block *tmctypes.ResultBlock, txHash common.Hash, event sdk.Event) error {
+	if !buildPrefixTreeEvents[event.Type] {
+		return nil
+	}
+
+	typedEvent, err := sdk.ParseTypedEvent(abci.Event(event))
+	if err != nil {
+		log.Errorw("parse typed events error", "module", m.Name(), "event", event, "err", err)
+		return err
+	}
+
+	switch event.Type {
+	case EventCreateObject:
+		createObject, ok := typedEvent.(*storagetypes.EventCreateObject)
+		if !ok {
+			log.Errorw("type assert error", "type", "EventCreateObject", "event", typedEvent)
+			return errors.New("create object event assert error")
+		}
+		return m.handleCreateObject(ctx, createObject)
+	default:
+		return nil
+	}
+}
+
+// handleCreateObject handles EventCreateObject.
+func (m *Module) handleCreateObject(ctx context.Context, createObject *storagetypes.EventCreateObject) error {
+	objectIDMap := &bsdb.ObjectIDMap{
+		ObjectID:   common.BigToHash(createObject.ObjectId.BigInt()),
+		BucketName: createObject.BucketName,
+	}
+
+	return m.db.CreateObjectIDMap(ctx, objectIDMap)
+}

--- a/modular/blocksyncer/modules/objectidmap/object_id_map.go
+++ b/modular/blocksyncer/modules/objectidmap/object_id_map.go
@@ -3,6 +3,8 @@ package objectidmap
 import (
 	"context"
 	"errors"
+
+	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 	abci "github.com/cometbft/cometbft/abci/types"
 	tmctypes "github.com/cometbft/cometbft/rpc/core/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -11,7 +13,6 @@ import (
 	"github.com/forbole/juno/v4/log"
 
 	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
-	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 )
 
 var (

--- a/modular/blocksyncer/modules/prefixtree/prefix_tree.go
+++ b/modular/blocksyncer/modules/prefixtree/prefix_tree.go
@@ -118,7 +118,7 @@ func (m *Module) handleCreateObject(ctx context.Context, sealObject *storagetype
 		}
 	}
 
-	object, err := m.db.GetPrefixTreeObject(ctx, common.BigToHash(objectID.BigInt()))
+	object, err := m.db.GetPrefixTreeObject(ctx, common.BigToHash(objectID.BigInt()), bucketName)
 	if err != nil {
 		log.Errorw("failed to get prefix tree object", "error", err)
 		return err

--- a/modular/blocksyncer/modules/registrar.go
+++ b/modular/blocksyncer/modules/registrar.go
@@ -7,13 +7,13 @@ import (
 	"github.com/forbole/juno/v4/modules/epoch"
 	"github.com/forbole/juno/v4/modules/group"
 	"github.com/forbole/juno/v4/modules/messages"
-	"github.com/forbole/juno/v4/modules/object"
 	"github.com/forbole/juno/v4/modules/payment"
 	"github.com/forbole/juno/v4/modules/permission"
 	"github.com/forbole/juno/v4/modules/registrar"
 	sp "github.com/forbole/juno/v4/modules/storage_provider"
 
 	"github.com/bnb-chain/greenfield-storage-provider/modular/blocksyncer/database"
+	"github.com/bnb-chain/greenfield-storage-provider/modular/blocksyncer/modules/object"
 	"github.com/bnb-chain/greenfield-storage-provider/modular/blocksyncer/modules/prefixtree"
 )
 

--- a/modular/blocksyncer/modules/registrar.go
+++ b/modular/blocksyncer/modules/registrar.go
@@ -1,7 +1,6 @@
 package registrar
 
 import (
-	"github.com/bnb-chain/greenfield-storage-provider/modular/blocksyncer/modules/objectidmap"
 	"github.com/forbole/juno/v4/modules"
 	"github.com/forbole/juno/v4/modules/block"
 	"github.com/forbole/juno/v4/modules/bucket"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/bnb-chain/greenfield-storage-provider/modular/blocksyncer/database"
 	"github.com/bnb-chain/greenfield-storage-provider/modular/blocksyncer/modules/object"
+	"github.com/bnb-chain/greenfield-storage-provider/modular/blocksyncer/modules/objectidmap"
 	"github.com/bnb-chain/greenfield-storage-provider/modular/blocksyncer/modules/prefixtree"
 )
 

--- a/modular/blocksyncer/modules/registrar.go
+++ b/modular/blocksyncer/modules/registrar.go
@@ -1,6 +1,7 @@
 package registrar
 
 import (
+	"github.com/bnb-chain/greenfield-storage-provider/modular/blocksyncer/modules/objectidmap"
 	"github.com/forbole/juno/v4/modules"
 	"github.com/forbole/juno/v4/modules/block"
 	"github.com/forbole/juno/v4/modules/bucket"
@@ -47,5 +48,6 @@ func (r *BlockSyncerRegistrar) BuildModules(ctx registrar.Context) modules.Modul
 		group.NewModule(db),
 		sp.NewModule(db),
 		prefixtree.NewModule(db),
+		objectidmap.NewModule(db),
 	}
 }

--- a/modular/gater/router.go
+++ b/modular/gater/router.go
@@ -70,11 +70,6 @@ func (g *GateModular) RegisterHandler(router *mux.Router) {
 		Methods(http.MethodPost).
 		HandlerFunc(g.updateUserPublicKeyHandler)
 
-	router.Name("listDeletedObjectsByBlockNumberRangeRouterName").
-		Methods(http.MethodGet).
-		Path("/delete/{start:.+}/{end:.+}/{is_full_list:.+}").
-		HandlerFunc(g.listDeletedObjectsByBlockNumberRangeHandler)
-
 	// verify permission router
 	router.Path("/permission/{operator:.+}/{bucket:[^/]*}/{action-type:.+}").Name(verifyPermissionRouterName).Methods(http.MethodGet).HandlerFunc(g.verifyPermissionHandler)
 

--- a/modular/gater/router.go
+++ b/modular/gater/router.go
@@ -70,6 +70,11 @@ func (g *GateModular) RegisterHandler(router *mux.Router) {
 		Methods(http.MethodPost).
 		HandlerFunc(g.updateUserPublicKeyHandler)
 
+	router.Name("listDeletedObjectsByBlockNumberRangeRouterName").
+		Methods(http.MethodGet).
+		Path("/delete/{start:.+}/{end:.+}/{is_full_list:.+}").
+		HandlerFunc(g.listDeletedObjectsByBlockNumberRangeHandler)
+
 	// verify permission router
 	router.Path("/permission/{operator:.+}/{bucket:[^/]*}/{action-type:.+}").Name(verifyPermissionRouterName).Methods(http.MethodGet).HandlerFunc(g.verifyPermissionHandler)
 

--- a/modular/metadata/metadata.go
+++ b/modular/metadata/metadata.go
@@ -37,8 +37,6 @@ func (r *MetadataModular) Name() string {
 }
 
 func (r *MetadataModular) Start(ctx context.Context) error {
-	// Default the bsDB to master db at start
-	r.baseApp.SetGfBsDB(r.baseApp.GfBsDBMaster())
 	scope, err := r.baseApp.ResourceManager().OpenService(r.Name())
 	if err != nil {
 		return err

--- a/modular/metadata/metadata_options.go
+++ b/modular/metadata/metadata_options.go
@@ -59,8 +59,6 @@ func DefaultMetadataOptions(metadata *MetadataModular, cfg *gfspconfig.GfSpConfi
 func startDBSwitchListener(switchInterval time.Duration, cfg *gfspconfig.GfSpConfig, metadata *MetadataModular) {
 	// create a ticker to periodically check for a new database name
 	dbSwitchTicker := time.NewTicker(switchInterval)
-	// set the bsdb to be master db at start
-	cfg.Metadata.IsMasterDB = true
 	checkSignal(cfg, metadata)
 	// launch a goroutine to handle the ticker events
 	go func() {

--- a/store/bsdb/const.go
+++ b/store/bsdb/const.go
@@ -32,6 +32,8 @@ const (
 	MasterDBTableName = "master_db"
 	// PrefixTreeTableName defines the name of prefix tree node table
 	PrefixTreeTableName = "slash_prefix_tree_nodes"
+	// ObjectIDMapTableName defines the name of object id map table
+	ObjectIDMapTableName = "object_id_map"
 )
 
 // define the list objects const

--- a/store/bsdb/object.go
+++ b/store/bsdb/object.go
@@ -77,9 +77,9 @@ func (a ByUpdateAtAndObjectID) Len() int { return len(a) }
 // Less we want to sort as ascending here
 func (a ByUpdateAtAndObjectID) Less(i, j int) bool {
 	if a[i].UpdateAt == a[j].UpdateAt {
-		return a[i].ObjectID.Big().Uint64() > a[j].ObjectID.Big().Uint64()
+		return a[i].ObjectID.Big().Uint64() < a[j].ObjectID.Big().Uint64()
 	}
-	return a[i].UpdateAt > a[j].UpdateAt
+	return a[i].UpdateAt < a[j].UpdateAt
 }
 func (a ByUpdateAtAndObjectID) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 

--- a/store/bsdb/object.go
+++ b/store/bsdb/object.go
@@ -7,6 +7,8 @@ import (
 	"github.com/forbole/juno/v4/common"
 	"github.com/spaolacci/murmur3"
 	"gorm.io/gorm"
+
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
 )
 
 const ObjectsNumberOfShards = 64
@@ -170,6 +172,7 @@ func (b *BsDBImpl) ListObjectsByObjectID(ids []common.Hash, includeRemoved bool)
 		var object *Object
 		bucketName, err := b.GetBucketNameByObjectID(id)
 		if err != nil {
+			log.Errorw("failed to get bucket name by object id in ListObjectsByObjectID", "error", err)
 			continue
 		}
 		err = b.db.Table(GetObjectsTableName(bucketName)).
@@ -178,6 +181,7 @@ func (b *BsDBImpl) ListObjectsByObjectID(ids []common.Hash, includeRemoved bool)
 			Scopes(filters...).
 			Take(&object).Error
 		if err != nil {
+			log.Errorw("failed to get object by object id in ListObjectsByObjectID", "error", err)
 			continue
 		}
 		objects = append(objects, object)

--- a/store/bsdb/object.go
+++ b/store/bsdb/object.go
@@ -1,9 +1,14 @@
 package bsdb
 
 import (
+	"fmt"
 	"github.com/forbole/juno/v4/common"
+	"github.com/spaolacci/murmur3"
 	"gorm.io/gorm"
+	"sort"
 )
+
+const ObjectsNumberOfShards = 64
 
 // ListObjectsByBucketName lists objects information by a bucket name.
 // The function takes the following parameters:
@@ -44,7 +49,7 @@ func (b *BsDBImpl) ListObjectsByBucketName(bucketName, continuationToken, prefix
 		}
 
 		if includeRemoved {
-			err = b.db.Table((&Object{}).TableName()).
+			err = b.db.Scopes(ReadObjectsTable(bucketName)).
 				Select("*").
 				Where("bucket_name = ?", bucketName).
 				Scopes(filters...).
@@ -52,7 +57,7 @@ func (b *BsDBImpl) ListObjectsByBucketName(bucketName, continuationToken, prefix
 				Order("object_name asc").
 				Find(&results).Error
 		} else {
-			err = b.db.Table((&Object{}).TableName()).
+			err = b.db.Scopes(ReadObjectsTable(bucketName)).
 				Select("*").
 				Where("bucket_name = ? and removed = false", bucketName).
 				Scopes(filters...).
@@ -64,32 +69,62 @@ func (b *BsDBImpl) ListObjectsByBucketName(bucketName, continuationToken, prefix
 	return results, err
 }
 
+type ByUpdateAtAndID []*Object
+
+func (a ByUpdateAtAndID) Len() int { return len(a) }
+func (a ByUpdateAtAndID) Less(i, j int) bool {
+	if a[i].UpdateAt == a[j].UpdateAt {
+		return a[i].ID < a[j].ID
+	}
+	return a[i].UpdateAt < a[j].UpdateAt
+}
+func (a ByUpdateAtAndID) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+
 // ListDeletedObjectsByBlockNumberRange list deleted objects info by a block number range
 func (b *BsDBImpl) ListDeletedObjectsByBlockNumberRange(startBlockNumber int64, endBlockNumber int64, includePrivate bool) ([]*Object, error) {
 	var (
-		objects []*Object
-		err     error
+		totalObjects []*Object
+		objects      []*Object
+		err          error
 	)
 
 	if includePrivate {
-		err = b.db.Table((&Object{}).TableName()).
-			Select("*").
-			Where("update_at >= ? and update_at <= ? and removed = ?", startBlockNumber, endBlockNumber, true).
-			Limit(DeletedObjectsDefaultSize).
-			Order("update_at,object_id asc").
-			Find(&objects).Error
-		return objects, err
+		for i := 0; i < ObjectsNumberOfShards; i++ {
+			err = b.db.Table(GetObjectsTableNameByShardNumber(i)).
+				Select("*").
+				Where("update_at >= ? and update_at <= ? and removed = ?", startBlockNumber, endBlockNumber, true).
+				Limit(DeletedObjectsDefaultSize).
+				Order("update_at,object_id asc").
+				Find(&objects).Error
+			totalObjects = append(totalObjects, objects...)
+		}
+	} else {
+		for i := 0; i < ObjectsNumberOfShards; i++ {
+			objectTableName := GetObjectsTableNameByShardNumber(i)
+			joins := fmt.Sprintf("right join buckets on buckets.bucket_id = %s.bucket_id", objectTableName)
+			order := fmt.Sprintf("%s.update_at, %s.object_id asc", objectTableName, objectTableName)
+			where := fmt.Sprintf("%s.update_at >= ? and %s.update_at <= ? and %s.removed = ? and "+
+				"((%s.visibility='VISIBILITY_TYPE_PUBLIC_READ') or "+
+				"(%s.visibility='VISIBILITY_TYPE_INHERIT' and buckets.visibility='VISIBILITY_TYPE_PUBLIC_READ'))",
+				objectTableName, objectTableName, objectTableName, objectTableName, objectTableName)
+
+			err = b.db.Table(objectTableName).
+				Select(objectTableName+".*").
+				Joins(joins).
+				Where(where, startBlockNumber, endBlockNumber, true).
+				Limit(DeletedObjectsDefaultSize).
+				Order(order).
+				Find(&objects).Error
+			totalObjects = append(totalObjects, objects...)
+		}
 	}
-	err = b.db.Table((&Bucket{}).TableName()).
-		Select("objects.*").
-		Joins("left join objects on buckets.bucket_id = objects.bucket_id").
-		Where("objects.update_at >= ? and objects.update_at <= ? and objects.removed = ? and "+
-			"((objects.visibility='VISIBILITY_TYPE_PUBLIC_READ') or (objects.visibility='VISIBILITY_TYPE_INHERIT' and buckets.visibility='VISIBILITY_TYPE_PUBLIC_READ'))",
-			startBlockNumber, endBlockNumber, true).
-		Limit(DeletedObjectsDefaultSize).
-		Order("objects.update_at, objects.object_id asc").
-		Find(&objects).Error
-	return objects, err
+
+	sort.Sort(ByUpdateAtAndID(totalObjects))
+
+	if len(totalObjects) > DeletedObjectsDefaultSize {
+		totalObjects = totalObjects[0:DeletedObjectsDefaultSize]
+	}
+	return totalObjects, err
 }
 
 // GetObjectByName get object info by an object name
@@ -100,14 +135,14 @@ func (b *BsDBImpl) GetObjectByName(objectName string, bucketName string, include
 	)
 
 	if includePrivate {
-		err = b.db.Table((&Object{}).TableName()).
+		err = b.db.Scopes(ReadObjectsTable(bucketName)).
 			Select("*").
 			Where("object_name = ? and bucket_name = ? and removed = false", objectName, bucketName).
 			Take(&object).Error
 		return object, err
 	}
 
-	err = b.db.Table((&Bucket{}).TableName()).
+	err = b.db.Scopes(ReadObjectsTable(bucketName)).
 		Select("objects.*").
 		Joins("left join objects on buckets.bucket_id = objects.bucket_id").
 		Where("objects.object_name = ? and objects.bucket_name = ? and objects.removed = false and "+
@@ -128,6 +163,10 @@ func (b *BsDBImpl) ListObjectsByObjectID(ids []common.Hash, includeRemoved bool)
 	if !includeRemoved {
 		filters = append(filters, RemovedFilter(includeRemoved))
 	}
+	//
+	//for idx, id := range ids {
+	//	getobjectbyid
+	//}
 
 	err = b.db.Table((&Object{}).TableName()).
 		Select("*").
@@ -135,4 +174,22 @@ func (b *BsDBImpl) ListObjectsByObjectID(ids []common.Hash, includeRemoved bool)
 		Scopes(filters...).
 		Find(&objects).Error
 	return objects, err
+}
+
+func GetObjectsTableName(bucketName string) string {
+	return GetObjectsTableNameByShardNumber(int(GetObjectsShardNumberByUID(bucketName)))
+}
+
+func GetObjectsShardNumberByUID(bucketName string) uint32 {
+	return murmur3.Sum32([]byte(bucketName)) % ObjectsNumberOfShards
+}
+
+func GetObjectsTableNameByShardNumber(shard int) string {
+	return fmt.Sprintf("objects_%02d", shard)
+}
+
+var ReadObjectsTable = func(uid string) func(db *gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		return db.Table(GetObjectsTableName(uid))
+	}
 }

--- a/store/bsdb/object_id_map.go
+++ b/store/bsdb/object_id_map.go
@@ -1,0 +1,38 @@
+package bsdb
+
+import (
+	"github.com/forbole/juno/v4/common"
+)
+
+// GetBucketNameByObjectID get bucket name info by an object id
+func (b *BsDBImpl) GetBucketNameByObjectID(objectID common.Hash) (string, error) {
+	var (
+		objectIdMap *ObjectIDMap
+		err         error
+	)
+
+	err = b.db.Table((&ObjectIDMap{}).TableName()).
+		Select("*").
+		Where("object_id = ?", objectID).
+		Take(&objectIdMap).Error
+
+	return objectIdMap.BucketName, err
+}
+
+//func GetObjectIDMapsTableName(objectID common.Hash) string {
+//	return GetObjectsTableNameByShardNumber(int(GetObjectIDMapsShardNumberByUID(objectID)))
+//}
+//
+//func GetObjectIDMapsShardNumberByUID(objectID common.Hash) uint64 {
+//	return objectID.Big().Uint64() / 4;
+//}
+//
+//func GetObjectIDMapsTableNameByShardNumber(shard int) string {
+//	return fmt.Sprintf("object_id_maps_%02d", shard)
+//}
+
+//var ReadObjectsTable = func(uid string) func(db *gorm.DB) *gorm.DB {
+//	return func(db *gorm.DB) *gorm.DB {
+//		return db.Table(GetObjectsTableName(uid))
+//	}
+//}

--- a/store/bsdb/object_id_map.go
+++ b/store/bsdb/object_id_map.go
@@ -18,21 +18,3 @@ func (b *BsDBImpl) GetBucketNameByObjectID(objectID common.Hash) (string, error)
 
 	return objectIdMap.BucketName, err
 }
-
-//func GetObjectIDMapsTableName(objectID common.Hash) string {
-//	return GetObjectsTableNameByShardNumber(int(GetObjectIDMapsShardNumberByUID(objectID)))
-//}
-//
-//func GetObjectIDMapsShardNumberByUID(objectID common.Hash) uint64 {
-//	return objectID.Big().Uint64() / 4;
-//}
-//
-//func GetObjectIDMapsTableNameByShardNumber(shard int) string {
-//	return fmt.Sprintf("object_id_maps_%02d", shard)
-//}
-
-//var ReadObjectsTable = func(uid string) func(db *gorm.DB) *gorm.DB {
-//	return func(db *gorm.DB) *gorm.DB {
-//		return db.Table(GetObjectsTableName(uid))
-//	}
-//}

--- a/store/bsdb/object_id_map_schema.go
+++ b/store/bsdb/object_id_map_schema.go
@@ -1,0 +1,16 @@
+package bsdb
+
+import (
+	"github.com/forbole/juno/v4/common"
+)
+
+// ObjectIDMap is a mapping table for objectID and bucketName
+type ObjectIDMap struct {
+	ObjectID   common.Hash `gorm:"column:object_id;type:BINARY(32);index:idx_object_id;primaryKey"`
+	BucketName string      `gorm:"column:bucket_name;type:varchar(64);index:idx_bucket_full_object,priority:1;index:idx_bucket_path,priority:1"`
+}
+
+// TableName is used to set ObjectIDMap table name in database
+func (*ObjectIDMap) TableName() string {
+	return ObjectIDMapTableName
+}

--- a/store/bsdb/prefix.go
+++ b/store/bsdb/prefix.go
@@ -2,11 +2,11 @@ package bsdb
 
 import (
 	"fmt"
-	"github.com/spaolacci/murmur3"
 	"path/filepath"
 	"strings"
 
 	"github.com/forbole/juno/v4/common"
+	"github.com/spaolacci/murmur3"
 	"gorm.io/gorm"
 )
 
@@ -135,5 +135,5 @@ func GetPrefixesShardNumberByBucketName(bucketName string) uint32 {
 }
 
 func GetPrefixesTableNameByShardNumber(shard int) string {
-	return fmt.Sprintf("slash_prefix_tree_nodes_%02d", shard)
+	return fmt.Sprintf("%s_%02d", PrefixTreeTableName, shard)
 }

--- a/store/bsdb/prefix.go
+++ b/store/bsdb/prefix.go
@@ -1,12 +1,16 @@
 package bsdb
 
 import (
+	"fmt"
+	"github.com/spaolacci/murmur3"
 	"path/filepath"
 	"strings"
 
 	"github.com/forbole/juno/v4/common"
 	"gorm.io/gorm"
 )
+
+const PrefixesNumberOfShards = 64
 
 // ListObjects List objects by bucket name
 func (b *BsDBImpl) ListObjects(bucketName, continuationToken, prefix string, maxKeys int) ([]*ListObjectsResult, error) {
@@ -32,7 +36,7 @@ func (b *BsDBImpl) ListObjects(bucketName, continuationToken, prefix string, max
 	if continuationToken != "" {
 		filters = append(filters, FullNameFilter(continuationToken))
 	}
-	err = b.db.Table((&SlashPrefixTreeNode{}).TableName()).
+	err = b.db.Table(GetPrefixesTableName(bucketName)).
 		Where("bucket_name = ?", bucketName).
 		Scopes(filters...).
 		Order("full_name").
@@ -69,11 +73,12 @@ func processPath(pathName string) (string, string) {
 // Returns a slice of ListObjectsResult containing filtered object data or an error if something goes wrong.
 func (b *BsDBImpl) filterObjects(nodes []*SlashPrefixTreeNode) ([]*ListObjectsResult, error) {
 	var (
-		objectIDs  []common.Hash
-		objects    []*Object
-		res        []*ListObjectsResult
-		objectsMap map[common.Hash]*Object
-		err        error
+		objectIDs    []common.Hash
+		totalObjects []*Object
+		objects      []*Object
+		res          []*ListObjectsResult
+		objectsMap   map[common.Hash]*Object
+		err          error
 	)
 
 	//filter objects and query the info
@@ -83,15 +88,19 @@ func (b *BsDBImpl) filterObjects(nodes []*SlashPrefixTreeNode) ([]*ListObjectsRe
 		}
 	}
 
-	err = b.db.Table((&Object{}).TableName()).
-		Where("object_id in (?)", objectIDs).
-		Find(&objects).Error
-	if err != nil {
-		return nil, err
+	for i := 0; i < ObjectsNumberOfShards; i++ {
+		err = b.db.Table(GetObjectsTableNameByShardNumber(i)).
+			Where("object_id in (?)", objectIDs).
+			Find(&objects).Error
+		//stop after finding one set?
+		if err != nil {
+			return nil, err
+		}
+		totalObjects = append(totalObjects, objects...)
 	}
 
 	objectsMap = make(map[common.Hash]*Object)
-	for _, object := range objects {
+	for _, object := range totalObjects {
 		objectsMap[object.ObjectID] = object
 	}
 
@@ -115,4 +124,16 @@ func (b *BsDBImpl) filterObjects(nodes []*SlashPrefixTreeNode) ([]*ListObjectsRe
 		}
 	}
 	return res, nil
+}
+
+func GetPrefixesTableName(bucketName string) string {
+	return GetPrefixesTableNameByShardNumber(int(GetPrefixesShardNumberByBucketName(bucketName)))
+}
+
+func GetPrefixesShardNumberByBucketName(bucketName string) uint32 {
+	return murmur3.Sum32([]byte(bucketName)) % PrefixesNumberOfShards
+}
+
+func GetPrefixesTableNameByShardNumber(shard int) string {
+	return fmt.Sprintf("slash_prefix_tree_nodes_%02d", shard)
 }

--- a/store/sqldb/object_integrity.go
+++ b/store/sqldb/object_integrity.go
@@ -71,7 +71,8 @@ func (s *SpDBImpl) GetObjectIntegrity(objectID uint64) (meta *corespdb.Integrity
 	}()
 
 	queryReturn := &IntegrityMetaTable{}
-	result := s.db.Table(GetIntegrityMetasTableName(objectID)).
+	shardTableName := GetIntegrityMetasTableName(objectID)
+	result := s.db.Table(shardTableName).
 		Where("object_id = ?", objectID).
 		First(queryReturn)
 	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
@@ -136,7 +137,8 @@ func (s *SpDBImpl) SetObjectIntegrity(meta *corespdb.IntegrityMeta) (err error) 
 		IntegrityChecksum: hex.EncodeToString(meta.IntegrityChecksum),
 		Signature:         hex.EncodeToString(meta.Signature),
 	}
-	result := s.db.Table(GetIntegrityMetasTableName(meta.ObjectID)).Create(insertIntegrityMetaRecord)
+	shardTableName := GetIntegrityMetasTableName(meta.ObjectID)
+	result := s.db.Table(shardTableName).Create(insertIntegrityMetaRecord)
 	if result.Error != nil && MysqlErrCode(result.Error) == ErrDuplicateEntryCode {
 		return nil
 	}

--- a/store/sqldb/object_integrity.go
+++ b/store/sqldb/object_integrity.go
@@ -71,7 +71,7 @@ func (s *SpDBImpl) GetObjectIntegrity(objectID uint64) (meta *corespdb.Integrity
 	}()
 
 	queryReturn := &IntegrityMetaTable{}
-	result := s.db.Model(&IntegrityMetaTable{}).
+	result := s.db.Table(GetIntegrityMetasTableName(objectID)).
 		Where("object_id = ?", objectID).
 		First(queryReturn)
 	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
@@ -136,7 +136,7 @@ func (s *SpDBImpl) SetObjectIntegrity(meta *corespdb.IntegrityMeta) (err error) 
 		IntegrityChecksum: hex.EncodeToString(meta.IntegrityChecksum),
 		Signature:         hex.EncodeToString(meta.Signature),
 	}
-	result := s.db.Create(insertIntegrityMetaRecord)
+	result := s.db.Table(GetIntegrityMetasTableName(meta.ObjectID)).Create(insertIntegrityMetaRecord)
 	if result.Error != nil && MysqlErrCode(result.Error) == ErrDuplicateEntryCode {
 		return nil
 	}
@@ -162,7 +162,8 @@ func (s *SpDBImpl) DeleteObjectIntegrity(objectID uint64) (err error) {
 			time.Since(startTime).Seconds())
 	}()
 
-	err = s.db.Delete(&IntegrityMetaTable{
+	shardTableName := GetIntegrityMetasTableName(objectID)
+	err = s.db.Table(shardTableName).Delete(&IntegrityMetaTable{
 		ObjectID: objectID, // should be the primary key
 	}).Error
 	return err

--- a/store/sqldb/object_integrity_schema.go
+++ b/store/sqldb/object_integrity_schema.go
@@ -1,5 +1,14 @@
 package sqldb
 
+import (
+	"fmt"
+)
+
+const (
+	IntegrityMetasNumberOfShards = 64
+	ReasonableTableSize          = 5_000_000
+)
+
 // PieceHashTable table schema
 type PieceHashTable struct {
 	ObjectID       uint64 `gorm:"primary_key"`
@@ -24,4 +33,17 @@ type IntegrityMetaTable struct {
 // TableName is used to set IntegrityMetaTable schema's table name in database
 func (IntegrityMetaTable) TableName() string {
 	return IntegrityMetaTableName
+}
+
+func GetIntegrityMetasTableName(objectID uint64) string {
+	return GetIntegrityMetasTableNameByShardNumber(int(GetIntegrityMetasShardNumberByBucketName(objectID)))
+}
+
+// GetIntegrityMetasShardNumberByBucketName Allocate each shard table with 5,000,000 continuous entry before using the next shard table
+func GetIntegrityMetasShardNumberByBucketName(objectID uint64) uint64 {
+	return objectID / ReasonableTableSize % IntegrityMetasNumberOfShards
+}
+
+func GetIntegrityMetasTableNameByShardNumber(shard int) string {
+	return fmt.Sprintf("%s_%02d", IntegrityMetaTableName, shard)
 }

--- a/store/sqldb/store.go
+++ b/store/sqldb/store.go
@@ -118,9 +118,12 @@ func InitDB(config *config.SQLDBConfig) (*gorm.DB, error) {
 		log.Errorw("failed to create piece hash table", "error", err)
 		return nil, err
 	}
-	if err = db.AutoMigrate(&IntegrityMetaTable{}); err != nil {
-		log.Errorw("failed to create integrity meta table", "error", err)
-		return nil, err
+	for i := 0; i < IntegrityMetasNumberOfShards; i++ {
+		shardTableName := fmt.Sprintf(IntegrityMetaTable{}.TableName()+"_%02d", i)
+		if err = db.Table(shardTableName).AutoMigrate(&IntegrityMetaTable{}); err != nil {
+			log.Errorw("failed to create integrity meta table", "error", err)
+			return nil, err
+		}
 	}
 	if err = db.AutoMigrate(&BucketTrafficTable{}); err != nil {
 		log.Errorw("failed to create bucket traffic table", "error", err)


### PR DESCRIPTION
### Description

Sharding for SP database tables which include:
BSDB: object, slash_prefix_tree_nodes
SPDB: object_integrity

Each of the above tables will be sharded to 64 tables.

### Rationale

We want to optimize the query speed with no breaking change, before the Mainnet get launched. After the Mainnet launch, the object size will soon exceed 5,000,000 lines, which would degrade Mysql performance.

### Example

None of the API usage shall feel any difference. The changes are made in the db level.

### Changes

Notable changes: 
* bsdb
* spdb
* metadata service
