### PR TITLE
fix: update juno with 'spIds' type change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
-	github.com/gogo/protobuf v1.3.3 // indirect
+	github.com/gogo/protobuf v1.3.3
 	github.com/golang-jwt/jwt/v4 v4.3.0 // indirect
 	github.com/golang/glog v1.1.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
@@ -293,7 +293,7 @@ replace (
 	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v0.0.1
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-0.20230626091810-fa69f41ddfc5
-	github.com/forbole/juno/v4 => github.com/bnb-chain/juno/v4 v4.0.0-20230629134244-950c0e459a80
+	github.com/forbole/juno/v4 => github.com/bnb-chain/juno/v4 v4.0.0-20230705084105-878bb1766114
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9/go.mod h1:rbc4o84RSEvhf09o2+4Qiazsv0snRJLiEZdk17HeIDw=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230425074444-eb5869b05fe9 h1:1ZdK+iR1Up02bOa2YTZCml7PBpP//kcdamOcK6aWO/s=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230425074444-eb5869b05fe9/go.mod h1:Ygz4wBHrgc7g0N+8+MrnTfS9LLn9aaTGa9hKopuym5k=
-github.com/bnb-chain/juno/v4 v4.0.0-20230629134244-950c0e459a80 h1:T9/78KvuVVCjWk0q+rn+XDf7RMvxsTseaEfyec9gN1c=
-github.com/bnb-chain/juno/v4 v4.0.0-20230629134244-950c0e459a80/go.mod h1:ICZfZMJ49Ll8BgcoAosGsS8p/hWQI7VIpV3LvWl4KV4=
+github.com/bnb-chain/juno/v4 v4.0.0-20230705084105-878bb1766114 h1:a/64ZsoRYYYK/SHGpkhkcTiBB5Gn5gTYMz/h9JiZB5s=
+github.com/bnb-chain/juno/v4 v4.0.0-20230705084105-878bb1766114/go.mod h1:ICZfZMJ49Ll8BgcoAosGsS8p/hWQI7VIpV3LvWl4KV4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/bradfitz/gomemcache v0.0.0-20170208213004-1952afaa557d/go.mod h1:PmM6Mmwb0LSuEubjR8N7PtNe1KxZLtOUHtbeikc5h60=

--- a/modular/blocksyncer/modules/events/sp_events_handler.go
+++ b/modular/blocksyncer/modules/events/sp_events_handler.go
@@ -121,8 +121,8 @@ func (m *Module) handleSwapOut(ctx context.Context, block *tmctypes.ResultBlock,
 	eventSwapOut := &bsdb.EventSwapOut{
 		StorageProviderId:          swapOut.StorageProviderId,
 		GlobalVirtualGroupFamilyId: swapOut.GlobalVirtualGroupFamilyId,
-		//GlobalVirtualGroupIds:      swapOut.GlobalVirtualGroupIds,
-		SuccessorSpId: swapOut.SuccessorSpId,
+		GlobalVirtualGroupIds:      swapOut.GlobalVirtualGroupIds,
+		SuccessorSpId:              swapOut.SuccessorSpId,
 
 		CreateAt:     block.Block.Height,
 		CreateTxHash: txHash,

--- a/store/bsdb/event_swap_out_schema.go
+++ b/store/bsdb/event_swap_out_schema.go
@@ -2,15 +2,14 @@ package bsdb
 
 import (
 	"github.com/forbole/juno/v4/common"
-	"github.com/lib/pq"
 )
 
 type EventSwapOut struct {
-	ID                         uint64        `gorm:"column:id;primaryKey"`
-	StorageProviderId          uint32        `gorm:"column:storage_provider_id;index:idx_sp_id"`
-	GlobalVirtualGroupFamilyId uint32        `gorm:"column:global_virtual_group_family_id;index:idx_vgf_id"`
-	GlobalVirtualGroupIds      pq.Int32Array `gorm:"column:global_virtual_group_ids;type:MEDIUMTEXT"`
-	SuccessorSpId              uint32        `gorm:"column:successor_sp_id"`
+	ID                         uint64             `gorm:"column:id;primaryKey"`
+	StorageProviderId          uint32             `gorm:"column:storage_provider_id;index:idx_sp_id"`
+	GlobalVirtualGroupFamilyId uint32             `gorm:"column:global_virtual_group_family_id;index:idx_vgf_id"`
+	GlobalVirtualGroupIds      common.Uint32Array `gorm:"column:global_virtual_group_ids;type:TEXT"`
+	SuccessorSpId              uint32             `gorm:"column:successor_sp_id"`
 
 	CreateAt     int64       `gorm:"column:create_at"`
 	CreateTxHash common.Hash `gorm:"column:create_tx_hash;type:BINARY(32);not null"`


### PR DESCRIPTION
### Description

change spIds type from String[] to Unit32[]

### Rationale

It's easier for metadata to query with "FIND IN SET" 
 
### Example

N/A

### Changes

Notable changes: 
* change spIds type from String[] to Unit32[] with juno version updated
