### PR TITLE
fix: fix challenge recovery 

### DIFF
--- a/modular/downloader/download_task.go
+++ b/modular/downloader/download_task.go
@@ -3,9 +3,7 @@ package downloader
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -370,9 +368,7 @@ func (d *DownloadModular) HandleChallengePiece(ctx context.Context, downloadPiec
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get piece data", "error", err)
 		// if read piece store error, try to recover the error data
-		if strings.Contains(err.Error(), fmt.Sprintf("inner_code:%d", ErrPieceStoreInnerCode)) {
-			d.recoverChallengePiece(ctx, downloadPieceTask, pieceKey)
-		}
+		d.recoverChallengePiece(ctx, downloadPieceTask, pieceKey)
 		return nil, nil, nil, ErrPieceStore
 	}
 
@@ -403,7 +399,7 @@ func (d *DownloadModular) recoverChallengePiece(ctx context.Context, downloadPie
 		ECIndex,
 		uint64(0),
 		d.baseApp.TaskTimeout(recoveryTask, downloadPieceTask.GetStorageParams().GetMaxSegmentSize()),
-		d.baseApp.TaskMaxRetry(recoveryTask))
+		2)
 
 	d.baseApp.GfSpClient().ReportTask(ctx, recoveryTask)
 }

--- a/modular/downloader/downloader_options.go
+++ b/modular/downloader/downloader_options.go
@@ -16,8 +16,6 @@ const (
 	DefaultChallengePieceParallelPerNode = 10240
 	// DefaultBucketFreeQuota defines the default free read quota per bucket
 	DefaultBucketFreeQuota = 10 * 1024 * 1024 * 1024
-	// ErrPieceStoreInnerCode defines the inner code of ErrPieceStore
-	ErrPieceStoreInnerCode = 35101
 )
 
 func NewDownloadModular(app *gfspapp.GfSpBaseApp, cfg *gfspconfig.GfSpConfig) (coremodule.Modular, error) {

--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -575,6 +575,7 @@ func (g *GateModular) getRecoveryPieceHandler(w http.ResponseWriter, r *http.Req
 		reqCtxErr     error
 		reqCtx        *RequestContext
 		authenticated bool
+		pieceData     []byte
 	)
 	startTime := time.Now()
 	defer func() {
@@ -656,9 +657,10 @@ func (g *GateModular) getRecoveryPieceHandler(w http.ResponseWriter, r *http.Req
 		true, reqCtx.Account(), uint64(ECPieceSize), ECPieceKey, 0, uint64(ECPieceSize),
 		g.baseApp.TaskTimeout(pieceTask, uint64(pieceTask.GetSize())), g.baseApp.TaskMaxRetry(pieceTask))
 
-	pieceData, err := g.baseApp.GfSpClient().GetPiece(reqCtx.Context(), pieceTask)
+	pieceData, err = g.baseApp.GfSpClient().GetPiece(reqCtx.Context(), pieceTask)
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to download piece", "error", err)
+		return
 	}
 	w.Write(pieceData)
 	log.CtxDebugw(reqCtx.Context(), "succeed to get secondary piece data")

--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -478,7 +478,6 @@ func (g *GateModular) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	getDataTime := time.Now()
-	var reoveredData []byte
 	for idx, pInfo := range pieceInfos {
 		enableCheck := false
 		if idx == 0 { // only check in first piece
@@ -497,22 +496,23 @@ func (g *GateModular) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 			// for now, if get piece fail, it is suspected that the piece has been lost
 			// the recovery task will recovery the total segment (ignoring the offset and length of piece info)
 			if strings.Contains(err.Error(), fmt.Sprintf("inner_code:%d", ErrPieceStoreInnerCode)) {
-				reoveredData, err = g.tryDownloadAfterRecovery(reqCtx.Context(), pieceTask, pInfo, task.GetStorageParams().GetMaxSegmentSize())
-				if err != nil {
-					log.CtxErrorw(reqCtx.Context(), "fail to get piece after recovery task submitted", "error", err)
+				recoveredPiece, recoverErr := g.tryDownloadAfterRecovery(reqCtx.Context(), pieceTask, pInfo, task.GetStorageParams().GetMaxSegmentSize())
+				if recoverErr != nil {
+					log.CtxErrorw(reqCtx.Context(), "fail to get piece after recovery task submitted", "error", recoverErr)
+					err = recoverErr
 					return
 				}
-				recoverDataLen := len(reoveredData)
+				recoverDataLen := len(recoveredPiece)
 				// the recovery segment is a total segment data, if the offset and length meta is set, it is needed to adjust the piece data with the meta
 				if pInfo.Offset > 0 {
-					reoveredData = reoveredData[pInfo.Offset:]
+					recoveredPiece = recoveredPiece[pInfo.Offset:]
 				}
 
 				if pInfo.Offset+pInfo.Length < uint64(recoverDataLen) {
-					reoveredData = reoveredData[:pInfo.Length]
-					log.CtxErrorw(reqCtx.Context(), "adjust the piece data", "len:", len(reoveredData))
+					recoveredPiece = recoveredPiece[:pInfo.Length]
+					log.CtxErrorw(reqCtx.Context(), "adjust the piece data", "len:", len(recoveredPiece))
 				}
-				w.Write(reoveredData)
+				w.Write(recoveredPiece)
 				continue
 			}
 			return


### PR DESCRIPTION
### Description
remove challenge recovery condition. If calling PieceStore().GetPiece got an error in the download task, it is the ErrPieceStore, no need to judge the inner code.

### Rationale
inner code error is not support in download task when call pieceStore.getPiece(). 

### Example

NA

### Changes

Notable changes: 
* remove challenge recovery condition