### PR TITLE
fix: remove the private_key from the code

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -35,6 +35,22 @@ jobs:
       - name: Run MySQL
         run: |
           sudo /etc/init.d/mysql start
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+      - name: Install dependencies
+        run: npm install ethers
+      # generate test private key
+      - name: Generate private key
+        run: node ./.github/workflows/generate-private-key.js
+        id: generate-private-key
+      - name: set private key and account address as job variables
+        run: |
+          echo "Private key: ${{ steps.generate-private-key.outputs.private_key }}"
+          echo "Account address: ${{ steps.generate-private-key.outputs.account_address }}"
+          echo "PRIVATE_KEY=${{ steps.generate-private-key.outputs.private_key }}" >> "$GITHUB_ENV"
+          echo "ACCOUNT_ADDR=${{ steps.generate-private-key.outputs.account_address }}" >> "$GITHUB_ENV"
       # Build and Start Greenfield Blockchain
       - name: Build and Start Greenfield Blockchain
         run: |

--- a/.github/workflows/generate-private-key.js
+++ b/.github/workflows/generate-private-key.js
@@ -1,0 +1,15 @@
+const ethers = require('ethers');
+
+// Generate a random private key
+const privateKey = ethers.Wallet.createRandom().privateKey;
+
+// Create a wallet instance from the private key
+const wallet = new ethers.Wallet(privateKey);
+
+// Print the private key and account address
+console.log(`Random Ethereum private key: ${privateKey}`);
+console.log(`Account address: ${wallet.address}`);
+const privateKeyString = `${privateKey}`.substring(2)
+// Set environment variables for the private key and account address
+console.log(`::set-output name=private_key::${privateKeyString}`);
+console.log(`::set-output name=account_address::${wallet.address}`);

--- a/test/e2e/spworkflow/e2e_test.sh
+++ b/test/e2e/spworkflow/e2e_test.sh
@@ -8,8 +8,11 @@ GREENFIELD_CMD_BRANCH="adaptor-sp-e2e"
 MYSQL_USER="root"
 MYSQL_PASSWORD="root"
 MYSQL_ADDRESS="127.0.0.1:3306"
-TEST_ACCOUNT_ADDRESS="0x76263999b87D08228eFB098F36d17363Acf40c2c"
-TEST_ACCOUNT_PRIVATE_KEY="da942d31bc4034577f581057e4a3644404ac12828a84052f87086d508fdcf095"
+TEST_ACCOUNT_ADDRESS=${ACCOUNT_ADDR}
+TEST_ACCOUNT_PRIVATE_KEY=${PRIVATE_KEY}
+echo "TEST_ACCOUNT_ADDRESS is "$TEST_ACCOUNT_ADDRESS
+echo "TEST_ACCOUNT_PRIVATE_KEY is "$TEST_ACCOUNT_PRIVATE_KEY
+
 BUCKET_NAME="spbucket"
 
 #########################################
@@ -155,6 +158,7 @@ function check_md5() {
 #######################
 function run_e2e() {
   set -e
+  echo 'run test_create_bucket'
   test_create_bucket
   test_file_size_less_than_16_mb
   test_file_size_greater_than_16_mb


### PR DESCRIPTION
### Description

remove the private_key from the code
### Rationale

We should not keep the private key in the code , even it is for test purpose

### Changes

Notable changes: 
* generate the private key by using ether js package
* put the generated private key and account address into the e2e test action setp
