### PR TITLE
fix: code security check

### DIFF
--- a/base/gfspclient/client.go
+++ b/base/gfspclient/client.go
@@ -2,6 +2,7 @@ package gfspclient
 
 import (
 	"context"
+	"crypto/tls"
 	"net/http"
 	"sync"
 	"time"
@@ -159,6 +160,7 @@ func (s *GfSpClient) HTTPClient(ctx context.Context) *http.Client {
 			Transport: &http.Transport{
 				MaxIdleConns:    HTTPMaxIdleConns,
 				IdleConnTimeout: HTTPIdleConnTimout,
+				TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS13},
 			}}
 	}
 	return s.httpClient

--- a/modular/gater/gater.go
+++ b/modular/gater/gater.go
@@ -3,6 +3,7 @@ package gater
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/gorilla/mux"
 
@@ -12,6 +13,8 @@ import (
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/metrics"
 )
+
+const ReadHeaderTimeout = 20 * time.Minute
 
 var _ module.Modular = &GateModular{}
 
@@ -50,8 +53,9 @@ func (g *GateModular) server(ctx context.Context) {
 	}
 	g.RegisterHandler(router)
 	server := &http.Server{
-		Addr:    g.httpAddress,
-		Handler: router,
+		Addr:              g.httpAddress,
+		Handler:           router,
+		ReadHeaderTimeout: ReadHeaderTimeout,
 	}
 	g.httpServer = server
 	if err := server.ListenAndServe(); err != nil {

--- a/modular/gater/router.go
+++ b/modular/gater/router.go
@@ -76,7 +76,7 @@ const (
 
 // notFoundHandler log not found request info.
 func (g *GateModular) notFoundHandler(w http.ResponseWriter, r *http.Request) {
-	log.Errorw("failed to find the corresponding handler", "header", r.Header, "host", r.Host, "url", r.URL)
+	log.Errorw("failed to find the corresponding handler", "method", r.Method, "host", r.Host, "url", r.URL)
 	if _, err := io.ReadAll(r.Body); err != nil {
 		log.Errorw("failed to read the unknown request", "error", err)
 	}

--- a/store/piecestore/storage/disk_file.go
+++ b/store/piecestore/storage/disk_file.go
@@ -77,7 +77,9 @@ func (d *diskFileStore) GetObject(ctx context.Context, key string, offset, limit
 		}
 	}
 	if limit > 0 {
-		defer f.Close()
+		defer func() {
+			_ = f.Close()
+		}()
 		buf := make([]byte, limit)
 		n, err := f.Read(buf)
 		if err != nil {

--- a/store/piecestore/storage/disk_file_test.go
+++ b/store/piecestore/storage/disk_file_test.go
@@ -25,7 +25,9 @@ func createTempFile(t *testing.T) *os.File {
 	fmt.Println(tmpdir)
 	f, _ := os.CreateTemp(tmpdir, "test_disk_file.txt")
 	f.Write([]byte("Hello"))
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 	return f
 }
 

--- a/test/e2e/piecestore/sharding_test.go
+++ b/test/e2e/piecestore/sharding_test.go
@@ -71,10 +71,10 @@ func createFiles(fileNum int) error {
 			log.Errorw("failed to create files", "error", err)
 			return err
 		}
-		defer f.Close()
 		writer := bufio.NewWriter(f)
 		writer.WriteString(fmt.Sprintf("test sharding func: %d\n", i))
 		writer.Flush()
+		_ = f.Close()
 	}
 	return nil
 }


### PR DESCRIPTION
### Description

* Accept
   - [x] Sensitive data returned by HTTP request headers flows to log
   - [x] Prefer SHA256 or stronger algorithm over MD5
   - [x] Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server
   - [x] Deferring unsafe method "Close" on type "*os.File"
   - [x] Error not handled(UpdateJobState)
   - [x] MinVersion is missing from this TLS configuration
   - [x] Non deterministic select
* Acknowledge
  - [x] Incorrect conversion of an integer
           strconv.Atoi includes upper bound check
   - [x] Prefer crypto/rand instead of math/rand
            rand is not involved in the security of user data and user content   
   - [x] Found an insecure gRPC server without 'grpc.Creds()' or options with credentials 
           GRPC is only used between internal services, no user requests


### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 

N/A
