### PR TITLE
feat: support query params for getObject off-chain auth

### DIFF
--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -399,9 +399,6 @@ func (g *GateModular) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 		r.Header.Set(GnfdAuthorizationHeader, gnfdAuthorizationParam)
 	}
 
-	//todo: to be removed after testing in qa
-	log.Debugw("Check passed in params", "gnfdUserParam", gnfdUserParam, "gnfdOffChainAuthAppDomainParam", gnfdOffChainAuthAppDomainParam, "gnfdAuthorizationParam", gnfdAuthorizationParam)
-
 	reqCtx, reqCtxErr = NewRequestContext(r, g)
 	// check the object permission whether allow public read.
 	verifyObjectPermissionTime := time.Now()

--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -386,6 +386,22 @@ func (g *GateModular) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		log.CtxDebugw(reqCtx.Context(), reqCtx.String())
 	}()
+
+	queryParams := r.URL.Query()
+	gnfdUserParam := queryParams.Get(GnfdUserAddressHeader)
+	gnfdOffChainAuthAppDomainParam := queryParams.Get(GnfdOffChainAuthAppDomainHeader)
+	gnfdAuthorizationParam := queryParams.Get(GnfdAuthorizationHeader)
+
+	// if all required off-chain auth headers are passed in as query params, we fill corresponding headers
+	if gnfdUserParam != "" && gnfdOffChainAuthAppDomainParam != "" && gnfdAuthorizationParam != "" {
+		r.Header.Set(GnfdUserAddressHeader, gnfdUserParam)
+		r.Header.Set(GnfdOffChainAuthAppDomainHeader, gnfdOffChainAuthAppDomainParam)
+		r.Header.Set(GnfdAuthorizationHeader, gnfdAuthorizationParam)
+	}
+
+	//todo: to be removed after testing in qa
+	log.Debugw("Check passed in params", "gnfdUserParam", gnfdUserParam, "gnfdOffChainAuthAppDomainParam", gnfdOffChainAuthAppDomainParam, "gnfdAuthorizationParam", gnfdAuthorizationParam)
+
 	reqCtx, reqCtxErr = NewRequestContext(r, g)
 	// check the object permission whether allow public read.
 	verifyObjectPermissionTime := time.Now()


### PR DESCRIPTION
### Description

Let getObject's offchain-auth support query params along with headers.

### Rationale

For more convenient frontend/browser access when downloading objects through offchain-auth

### Example

curl --location 'https://gf-stagenet-sp-h.bk.nodereal.cc/test-sp-7/flower1.webp?Authorization=OffChainAuth%20EDDSA%2CSignedMsg%3DInvokeSPAPI_offChainSign_1689077696938%2CSignature%3De931ee622e73053aeef2ffe347ca28d9cd2f8017c2eb0c84b6afbdf04d6bcf9b047a246c965e41102235b620e918d0bc40b64e151b5ed2d498b6efe548a89d3f&X-Gnfd-User-Address=0x06B320Cd13BAe882AA446F814aA659ed0923d1e1&X-Gnfd-App-Domain=https%3A%2F%2Fdcellar-qa.fe.nodereal.cc' --output image.jpg

### Changes

Notable changes: 
* downloader
