### PR TITLE
fix: remove checking account if it is exists in greenfield

### DIFF
--- a/modular/authenticator/authenticator.go
+++ b/modular/authenticator/authenticator.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/bnb-chain/greenfield-storage-provider/base/gfspapp"
 	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsperrors"
@@ -27,7 +28,7 @@ var (
 	ErrNotCreatedState     = gfsperrors.Register(module.AuthenticationModularName, http.StatusBadRequest, 20003, "object has not been created state")
 	ErrNotSealedState      = gfsperrors.Register(module.AuthenticationModularName, http.StatusBadRequest, 20004, "object has not been sealed state")
 	ErrPaymentState        = gfsperrors.Register(module.AuthenticationModularName, http.StatusBadRequest, 20005, "payment account is not active")
-	ErrNoSuchAccount       = gfsperrors.Register(module.AuthenticationModularName, http.StatusNotFound, 20006, "no such account")
+	ErrInvalidAddress      = gfsperrors.Register(module.AuthenticationModularName, http.StatusBadRequest, 20006, "the user address format is invalid")
 	ErrNoSuchBucket        = gfsperrors.Register(module.AuthenticationModularName, http.StatusNotFound, 20007, "no such bucket")
 	ErrNoSuchObject        = gfsperrors.Register(module.AuthenticationModularName, http.StatusNotFound, 20008, "no such object")
 	ErrRepeatedBucket      = gfsperrors.Register(module.AuthenticationModularName, http.StatusBadRequest, 20009, "repeated bucket")
@@ -166,6 +167,11 @@ func (a *AuthenticationModular) VerifyAuthentication(
 	authType coremodule.AuthOpType,
 	account, bucket, object string) (
 	bool, error) {
+	// check the account if it is a valid address
+	_, err := sdk.AccAddressFromHexUnsafe(account)
+	if err != nil {
+		return false, ErrInvalidAddress
+	}
 
 	switch authType {
 	case coremodule.AuthOpAskCreateBucketApproval:


### PR DESCRIPTION
### Description

The logic of checking the existence of the account has been removed from the VerifyAuthentication function which is used to verify authorization of the request to SP.  The reasons for the removal are as follows:：
1）Data marketplace users only operate on BSC and have no transactions on Greenfield.
2）During batch upload, a temporary account is generated, and the gas and fees for this temporary account are deducted from the user's account (with authorization). This temporary account has not yet been created on the chain, but actions like createObject are performed


### Rationale

support marketplace user case

### Example

NA

### Changes

Notable changes: 
*  remove checking the existence of the account 