### PR TITLE
fix: verify group permission

### DIFF
--- a/base/gfspclient/metadata.go
+++ b/base/gfspclient/metadata.go
@@ -3,6 +3,7 @@ package gfspclient
 import (
 	"context"
 
+	"github.com/bnb-chain/greenfield/types/resource"
 	payment_types "github.com/bnb-chain/greenfield/x/payment/types"
 	permission_types "github.com/bnb-chain/greenfield/x/permission/types"
 	storage_types "github.com/bnb-chain/greenfield/x/storage/types"
@@ -774,4 +775,29 @@ func (s *GfSpClient) GetObjectByID(ctx context.Context, objectID uint64, opts ..
 		return nil, ErrNoSuchObject
 	}
 	return resp.GetObjects()[objectID].GetObjectInfo(), nil
+}
+
+// VerifyPermissionByID Verify the input account’s permission to input source type and resource id
+func (s *GfSpClient) VerifyPermissionByID(ctx context.Context, Operator string, resourceType resource.ResourceType, resourceID uint64,
+	actionType permission_types.ActionType, opts ...grpc.DialOption) (*permission_types.Effect, error) {
+	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	req := &types.GfSpVerifyPermissionByIDRequest{
+		Operator:     Operator,
+		ResourceType: resourceType,
+		ResourceId:   resourceID,
+		ActionType:   actionType,
+	}
+
+	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpVerifyPermissionByID(ctx, req)
+	ctx = log.Context(ctx, resp)
+	if err != nil {
+		log.CtxErrorw(ctx, "failed to send verify permission by id rpc", "error", err)
+		return nil, err
+	}
+	return &resp.Effect, nil
 }

--- a/modular/gater/const.go
+++ b/modular/gater/const.go
@@ -125,6 +125,12 @@ const (
 	ListSwapOutEventsQuery = "swap-out-events"
 	// ListSpExitEventsQuery defines list swap out events, which is used to route request
 	ListSpExitEventsQuery = "sp-exit-events"
+	// VerifyPermissionByIDQuery defines verify permission by resource id, which is used to route request
+	VerifyPermissionByIDQuery = "verify-id"
+	// ResourceIDQuery defines the bucket/object/group id of the resource that grants permission for
+	ResourceIDQuery = "resource-id"
+	// ResourceTypeQuery defines the type of resource that grants permission for
+	ResourceTypeQuery = "resource-type"
 	// GetGroupListNameQuery defines get group list name query, which is used to route request
 	GetGroupListNameQuery = "name"
 	// GetGroupListPrefixQuery defines get group list prefix query, which is used to route request

--- a/modular/gater/router.go
+++ b/modular/gater/router.go
@@ -58,6 +58,7 @@ const (
 	listMigrateBucketEventsRouterName              = "ListMigrateBucketEvents"
 	listSwapOutEventsRouterName                    = "ListSwapOutEvents"
 	listSpExitEventsRouterName                     = "ListSpExitEvents"
+	verifyPermissionByIDRouterName                 = "VerifyPermissionByID"
 )
 
 const (
@@ -190,7 +191,11 @@ func (g *GateModular) RegisterHandler(router *mux.Router) {
 		Methods(http.MethodPost).
 		Queries(ListBucketsByBucketIDQuery, "").
 		HandlerFunc(g.listBucketsByBucketIDHandler)
-
+	router.Path("/").
+		Name(verifyPermissionByIDRouterName).
+		Methods(http.MethodGet).
+		Queries(VerifyPermissionByIDQuery, "").
+		HandlerFunc(g.verifyPermissionByIDHandler)
 	if g.env != gfspapp.EnvMainnet {
 		// Get Payment By Bucket ID
 		router.Path("/").Name(getPaymentByBucketIDRouterName).Methods(http.MethodGet).Queries(GetPaymentByBucketIDQuery, "").HandlerFunc(g.getPaymentByBucketIDHandler)

--- a/modular/gater/router_test.go
+++ b/modular/gater/router_test.go
@@ -413,6 +413,14 @@ func TestRouters(t *testing.T) {
 			wantedRouterName: listExpiredBucketsBySpRouterName,
 		},
 		{
+			name:             "Verify permission by resource id router",
+			router:           gwRouter,
+			method:           http.MethodGet,
+			url:              scheme + testDomain + "/?" + VerifyPermissionByIDQuery + "&" + ResourceIDQuery + "&" + ResourceTypeQuery + "&" + VerifyPermissionOperator + "&" + VerifyPermissionActionType,
+			shouldMatch:      true,
+			wantedRouterName: verifyPermissionByIDRouterName,
+		},
+		{
 			name:             "List virtual group families by sp id router",
 			router:           gwRouter,
 			method:           http.MethodGet,

--- a/modular/metadata/metadata_permission_service.go
+++ b/modular/metadata/metadata_permission_service.go
@@ -3,12 +3,15 @@ package metadata
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/forbole/juno/v4/common"
+	"gorm.io/gorm"
 
+	"github.com/bnb-chain/greenfield-storage-provider/modular/metadata/types"
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
 	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
 	chaintypes "github.com/bnb-chain/greenfield/types"
@@ -27,6 +30,8 @@ var (
 	ErrInvalidBucketName = errors.New("invalid bucket name")
 	// ErrNoSuchBucket defines not existed bucket error
 	ErrNoSuchBucket = errors.New("the specified bucket does not exist")
+	// ErrNoSuchGroup defines not existed group error
+	ErrNoSuchGroup = errors.New("the specified group does not exist")
 	// ErrNoSuchObject defines not existed object error
 	ErrNoSuchObject = errors.New("the specified key does not exist")
 )
@@ -78,11 +83,10 @@ func (r *MetadataModular) GfSpVerifyPermission(ctx context.Context, req *storage
 		objectInfo, err = r.baseApp.GfBsDB().GetObjectByName(req.ObjectName, req.BucketName, true)
 		if err != nil {
 			log.CtxErrorw(ctx, "failed to get object info", "error", err)
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, ErrNoSuchObject
+			}
 			return nil, err
-		}
-		if objectInfo == nil || objectInfo.Removed {
-			log.CtxError(ctx, "no such object")
-			return nil, ErrNoSuchObject
 		}
 		effect, err = r.VerifyObjectPermission(ctx, bucketInfo, objectInfo, operator, req.ActionType)
 		if err != nil {
@@ -94,6 +98,138 @@ func (r *MetadataModular) GfSpVerifyPermission(ctx context.Context, req *storage
 	resp = &storagetypes.QueryVerifyPermissionResponse{Effect: effect}
 	log.CtxInfow(ctx, "succeed to verify permission")
 	return resp, nil
+}
+
+// GfSpVerifyPermissionByID Verify the input account’s permission to input source type and resource id
+func (r *MetadataModular) GfSpVerifyPermissionByID(ctx context.Context, req *types.GfSpVerifyPermissionByIDRequest) (resp *types.GfSpVerifyPermissionByIDResponse, err error) {
+	var effect permtypes.Effect
+
+	ctx = log.Context(ctx, req)
+
+	if req == nil {
+		log.CtxErrorw(ctx, "invalid request", "error", err)
+		return nil, ErrInvalidParams
+	}
+
+	switch req.ResourceType.String() {
+	case "RESOURCE_TYPE_OBJECT":
+		effect, err = r.verifyObject(ctx, req)
+	case "RESOURCE_TYPE_BUCKET":
+		effect, err = r.verifyBucket(ctx, req)
+	case "RESOURCE_TYPE_GROUP":
+		effect, err = r.verifyGroup(ctx, req)
+	default:
+		effect = permtypes.EFFECT_DENY
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	resp = &types.GfSpVerifyPermissionByIDResponse{Effect: effect}
+	log.CtxInfow(ctx, "succeed to verify permission by id")
+	return resp, nil
+}
+
+func (r *MetadataModular) verifyObject(ctx context.Context, req *types.GfSpVerifyPermissionByIDRequest) (permtypes.Effect, error) {
+	var (
+		operator   sdk.AccAddress
+		bucketInfo *bsdb.Bucket
+		objectInfo *bsdb.Object
+		effect     permtypes.Effect
+		err        error
+	)
+
+	operator, err = sdk.AccAddressFromHexUnsafe(req.Operator)
+	if err != nil {
+		log.CtxErrorw(ctx, "failed to creates an AccAddress from a HEX-encoded string", "req.Operator", operator.String(), "error", err)
+		return permtypes.EFFECT_DENY, err
+	}
+
+	objectInfo, err = r.baseApp.GfBsDB().GetObjectByID(int64(req.ResourceId), false)
+	if err != nil {
+		log.CtxErrorw(ctx, "failed to get object info", "error", err)
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return permtypes.EFFECT_DENY, ErrNoSuchObject
+		}
+		return permtypes.EFFECT_DENY, err
+	}
+	bucketInfo, err = r.baseApp.GfBsDB().GetBucketByID(objectInfo.BucketID.Big().Int64(), false)
+	if err != nil {
+		log.CtxErrorw(ctx, "failed to get bucket info", "error", err)
+		return permtypes.EFFECT_DENY, err
+	}
+	if bucketInfo == nil {
+		log.CtxError(ctx, "no such bucket")
+		return permtypes.EFFECT_DENY, ErrNoSuchBucket
+	}
+	effect, err = r.VerifyObjectPermission(ctx, bucketInfo, objectInfo, operator, req.ActionType)
+	if err != nil {
+		log.CtxErrorw(ctx, "failed to verify object permission", "error", err)
+		return effect, err
+	}
+	return effect, nil
+}
+
+func (r *MetadataModular) verifyBucket(ctx context.Context, req *types.GfSpVerifyPermissionByIDRequest) (permtypes.Effect, error) {
+	var (
+		operator   sdk.AccAddress
+		bucketInfo *bsdb.Bucket
+		effect     permtypes.Effect
+		err        error
+	)
+
+	operator, err = sdk.AccAddressFromHexUnsafe(req.Operator)
+	if err != nil {
+		log.CtxErrorw(ctx, "failed to creates an AccAddress from a HEX-encoded string", "req.Operator", operator.String(), "error", err)
+		return permtypes.EFFECT_DENY, err
+	}
+
+	bucketInfo, err = r.baseApp.GfBsDB().GetBucketByID(int64(req.ResourceId), false)
+	if err != nil {
+		log.CtxErrorw(ctx, "failed to get bucket info", "error", err)
+		return permtypes.EFFECT_DENY, err
+	}
+	if bucketInfo == nil {
+		log.CtxError(ctx, "no such bucket")
+		return permtypes.EFFECT_DENY, ErrNoSuchBucket
+	}
+	effect, err = r.VerifyBucketPermission(ctx, bucketInfo, operator, req.ActionType, nil)
+	if err != nil {
+		log.CtxErrorw(ctx, "failed to verify bucket permission", "error", err)
+		return effect, err
+	}
+	return effect, nil
+}
+
+func (r *MetadataModular) verifyGroup(ctx context.Context, req *types.GfSpVerifyPermissionByIDRequest) (permtypes.Effect, error) {
+	var (
+		operator  sdk.AccAddress
+		groupInfo *bsdb.Group
+		effect    permtypes.Effect
+		err       error
+	)
+
+	operator, err = sdk.AccAddressFromHexUnsafe(req.Operator)
+	if err != nil {
+		log.CtxErrorw(ctx, "failed to creates an AccAddress from a HEX-encoded string", "req.Operator", operator.String(), "error", err)
+		return permtypes.EFFECT_DENY, err
+	}
+
+	groupInfo, err = r.baseApp.GfBsDB().GetGroupByID(int64(req.ResourceId), false)
+	if err != nil {
+		log.CtxErrorw(ctx, "failed to get group info", "error", err)
+		return permtypes.EFFECT_DENY, err
+	}
+	if groupInfo == nil {
+		log.CtxError(ctx, "no such group")
+		return permtypes.EFFECT_DENY, ErrNoSuchGroup
+	}
+	effect, err = r.VerifyGroupPermission(ctx, groupInfo, operator, req.ActionType)
+	if err != nil {
+		log.CtxErrorw(ctx, "failed to verify group permission", "error", err)
+		return effect, err
+	}
+	return effect, nil
 }
 
 // VerifyBucketPermission verify bucket permission
@@ -185,6 +321,32 @@ func (r *MetadataModular) VerifyObjectPermission(ctx context.Context, bucketInfo
 	}
 
 	if bucketEffect == permtypes.EFFECT_ALLOW || objectEffect == permtypes.EFFECT_ALLOW {
+		return permtypes.EFFECT_ALLOW, nil
+	}
+	return permtypes.EFFECT_DENY, nil
+}
+
+// VerifyGroupPermission verify group permission
+func (r *MetadataModular) VerifyGroupPermission(ctx context.Context, groupInfo *bsdb.Group, operator sdk.AccAddress,
+	action permtypes.ActionType) (permtypes.Effect, error) {
+	var (
+		err    error
+		effect permtypes.Effect
+	)
+
+	// The owner has full permissions
+	if strings.EqualFold(groupInfo.Owner.String(), operator.String()) {
+		return permtypes.EFFECT_ALLOW, nil
+	}
+
+	// verify policy
+	effect, err = r.VerifyPolicy(ctx, math.NewUintFromBigInt(groupInfo.GroupID.Big()), gnfdresource.RESOURCE_TYPE_GROUP, operator, action, nil)
+	if err != nil {
+		log.CtxErrorw(ctx, "failed to verify bucket policy", "error", err)
+		return permtypes.EFFECT_DENY, err
+	}
+
+	if effect == permtypes.EFFECT_ALLOW {
 		return permtypes.EFFECT_ALLOW, nil
 	}
 	return permtypes.EFFECT_DENY, nil

--- a/proto/modular/metadata/types/metadata.proto
+++ b/proto/modular/metadata/types/metadata.proto
@@ -2,8 +2,11 @@ syntax = "proto3";
 package modular.metadata.types;
 
 import "base/types/gfsperrors/error.proto";
+import "cosmos_proto/cosmos.proto";
 import "gogoproto/gogo.proto";
 import "greenfield/payment/stream_record.proto";
+import "greenfield/permission/common.proto";
+import "greenfield/resource/types.proto";
 import "greenfield/storage/events.proto";
 import "greenfield/storage/query.proto";
 import "greenfield/storage/types.proto";
@@ -418,6 +421,24 @@ message GfSpListObjectsByObjectIDResponse {
   map<uint64, Object> objects = 1;
 }
 
+// GfSpVerifyPermissionByIDRequest is request type for the GfSpVerifyPermissionByID RPC method
+message GfSpVerifyPermissionByIDRequest {
+  // operator defines the account address of operator
+  string operator = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // source_type defines the source of resource creation
+  greenfield.resource.ResourceType resource_type = 2;
+  // resource_id defines the id of source
+  uint64 resource_id = 3;
+  // action_type defines the requested action type of permission
+  greenfield.permission.ActionType action_type = 4;
+}
+
+// GfSpVerifyPermissionByIDResponse is response type for the GfSpVerifyPermissionByID RPC method
+message GfSpVerifyPermissionByIDResponse {
+  // effect define the effect of the operation permission, include Allow or deny
+  greenfield.permission.Effect effect = 1;
+}
+
 // GfSpListVirtualGroupFamiliesBySpIDRequest is request type for the GfSpListVirtualGroupFamilies RPC method
 message GfSpListVirtualGroupFamiliesBySpIDRequest {
   // sp_id is the unique identification for sp
@@ -685,6 +706,7 @@ service GfSpMetadataService {
   rpc GfSpGetGroupList(GfSpGetGroupListRequest) returns (GfSpGetGroupListResponse) {}
   rpc GfSpListBucketsByBucketID(GfSpListBucketsByBucketIDRequest) returns (GfSpListBucketsByBucketIDResponse) {}
   rpc GfSpListObjectsByObjectID(GfSpListObjectsByObjectIDRequest) returns (GfSpListObjectsByObjectIDResponse) {}
+  rpc GfSpVerifyPermissionByID(GfSpVerifyPermissionByIDRequest) returns (GfSpVerifyPermissionByIDResponse) {}
   rpc GfSpListVirtualGroupFamiliesBySpID(GfSpListVirtualGroupFamiliesBySpIDRequest) returns (GfSpListVirtualGroupFamiliesBySpIDResponse) {}
   rpc GfSpGetGlobalVirtualGroupByGvgID(GfSpGetGlobalVirtualGroupByGvgIDRequest) returns (GfSpGetGlobalVirtualGroupByGvgIDResponse) {}
   rpc GfSpListBucketsBindingOnPrimarySP(GfSpListBucketsBindingOnPrimarySPRequest) returns (GfSpListBucketsBindingOnPrimarySPResponse) {}

--- a/store/bsdb/database.go
+++ b/store/bsdb/database.go
@@ -38,6 +38,8 @@ type Metadata interface {
 	ListExpiredBucketsBySp(createAt int64, primarySpID uint32, limit int64) ([]*Bucket, error)
 	// GetObjectByName get object info by an object name
 	GetObjectByName(objectName string, bucketName string, includePrivate bool) (*Object, error)
+	// GetObjectByID get object info by an object id
+	GetObjectByID(objectID int64, includeRemoved bool) (*Object, error)
 	// GetSwitchDBSignal check if there is a signal to switch the database
 	GetSwitchDBSignal() (*MasterDB, error)
 	// GetBucketMetaByName get bucket info with its related info
@@ -48,6 +50,8 @@ type Metadata interface {
 	ListObjectsByObjectID(ids []common.Hash, includeRemoved bool) ([]*Object, error)
 	// ListBucketsByBucketID list buckets by bucket ids
 	ListBucketsByBucketID(ids []common.Hash, includeRemoved bool) ([]*Bucket, error)
+	// GetGroupByID get group info by an object id
+	GetGroupByID(groupID int64, includeRemoved bool) (*Group, error)
 	// ListVirtualGroupFamiliesBySpID list virtual group families by sp id
 	ListVirtualGroupFamiliesBySpID(spID uint32) ([]*GlobalVirtualGroupFamily, error)
 	// GetVirtualGroupFamiliesByVgfID get virtual group families by vgf id

--- a/store/bsdb/group.go
+++ b/store/bsdb/group.go
@@ -1,6 +1,7 @@
 package bsdb
 
 import (
+	"cosmossdk.io/math"
 	"github.com/forbole/juno/v4/common"
 	"gorm.io/gorm"
 )
@@ -61,4 +62,26 @@ func (b *BsDBImpl) ListGroupsByNameAndSourceType(name, prefix, sourceType string
 		Scopes(filters...).
 		Take(&count).Error
 	return groups, count, err
+}
+
+// GetGroupByID get group info by object id
+func (b *BsDBImpl) GetGroupByID(groupID int64, includeRemoved bool) (*Group, error) {
+	var (
+		group       *Group
+		groupIDHash common.Hash
+		err         error
+		filters     []func(*gorm.DB) *gorm.DB
+	)
+
+	groupIDHash = common.BigToHash(math.NewInt(groupID).BigInt())
+	if !includeRemoved {
+		filters = append(filters, RemovedFilter(includeRemoved))
+	}
+
+	err = b.db.Table((&Group{}).TableName()).
+		Select("*").
+		Where("group_id  = ?", groupIDHash).
+		Scopes(filters...).
+		Find(&group).Error
+	return group, err
 }


### PR DESCRIPTION
### Description

support object/bucket/group verify permission

### Rationale

N/A

### Example

```
curl --location --request GET 'http://localhost:9133/?verify-id=&resource-id=1&resource-type=3&operator=0xB6e0Fc49DA3C0bD76aF9851Fc36589306f034583&action-type=9'
```

### Changes

Notable changes: 
*support object/bucket/group verify permission
