### PR TITLE
fix: remove sp v2 authorization

### DIFF
--- a/modular/gater/admin_handler.go
+++ b/modular/gater/admin_handler.go
@@ -91,22 +91,20 @@ func (g *GateModular) getApprovalHandler(w http.ResponseWriter, r *http.Request)
 			err = ErrValidateMsg
 			return
 		}
-		if !reqCtx.SkipVerifyAuthentication() {
-			startVerifyAuthentication := time.Now()
-			authenticated, err = g.baseApp.GfSpClient().VerifyAuthentication(
-				reqCtx.Context(), coremodule.AuthOpAskCreateBucketApproval,
-				reqCtx.Account(), createBucketApproval.GetBucketName(), "")
-			metrics.PerfApprovalTime.WithLabelValues("gateway_create_bucket_auth_cost").Observe(time.Since(startVerifyAuthentication).Seconds())
-			metrics.PerfApprovalTime.WithLabelValues("gateway_create_bucket_auth_end").Observe(time.Since(startTime).Seconds())
-			if err != nil {
-				log.CtxErrorw(reqCtx.Context(), "failed to verify authentication", "error", err)
-				return
-			}
-			if !authenticated {
-				log.CtxErrorw(reqCtx.Context(), "no permission to operate")
-				err = ErrNoPermission
-				return
-			}
+		startVerifyAuthentication := time.Now()
+		authenticated, err = g.baseApp.GfSpClient().VerifyAuthentication(
+			reqCtx.Context(), coremodule.AuthOpAskCreateBucketApproval,
+			reqCtx.Account(), createBucketApproval.GetBucketName(), "")
+		metrics.PerfApprovalTime.WithLabelValues("gateway_create_bucket_auth_cost").Observe(time.Since(startVerifyAuthentication).Seconds())
+		metrics.PerfApprovalTime.WithLabelValues("gateway_create_bucket_auth_end").Observe(time.Since(startTime).Seconds())
+		if err != nil {
+			log.CtxErrorw(reqCtx.Context(), "failed to verify authentication", "error", err)
+			return
+		}
+		if !authenticated {
+			log.CtxErrorw(reqCtx.Context(), "no permission to operate")
+			err = ErrNoPermission
+			return
 		}
 		task := &gfsptask.GfSpCreateBucketApprovalTask{}
 		task.InitApprovalCreateBucketTask(reqCtx.Account(), &createBucketApproval, g.baseApp.TaskPriority(task))
@@ -139,19 +137,17 @@ func (g *GateModular) getApprovalHandler(w http.ResponseWriter, r *http.Request)
 			err = ErrValidateMsg
 			return
 		}
-		if !reqCtx.SkipVerifyAuthentication() {
-			authenticated, err = g.baseApp.GfSpClient().VerifyAuthentication(
-				reqCtx.Context(), coremodule.AuthOpAskMigrateBucketApproval,
-				reqCtx.Account(), migrateBucketApproval.GetBucketName(), "")
-			if err != nil {
-				log.CtxErrorw(reqCtx.Context(), "failed to verify authentication", "error", err)
-				return
-			}
-			if !authenticated {
-				log.CtxErrorw(reqCtx.Context(), "no permission to operate")
-				err = ErrNoPermission
-				return
-			}
+		authenticated, err = g.baseApp.GfSpClient().VerifyAuthentication(
+			reqCtx.Context(), coremodule.AuthOpAskMigrateBucketApproval,
+			reqCtx.Account(), migrateBucketApproval.GetBucketName(), "")
+		if err != nil {
+			log.CtxErrorw(reqCtx.Context(), "failed to verify authentication", "error", err)
+			return
+		}
+		if !authenticated {
+			log.CtxErrorw(reqCtx.Context(), "no permission to operate")
+			err = ErrNoPermission
+			return
 		}
 		task := &gfsptask.GfSpMigrateBucketApprovalTask{}
 		task.InitApprovalMigrateBucketTask(&migrateBucketApproval, g.baseApp.TaskPriority(task))
@@ -181,23 +177,21 @@ func (g *GateModular) getApprovalHandler(w http.ResponseWriter, r *http.Request)
 			err = ErrValidateMsg
 			return
 		}
-		if !reqCtx.SkipVerifyAuthentication() {
-			startVerifyAuthentication := time.Now()
-			authenticated, err = g.baseApp.GfSpClient().VerifyAuthentication(
-				reqCtx.Context(), coremodule.AuthOpAskCreateObjectApproval,
-				reqCtx.Account(), createObjectApproval.GetBucketName(),
-				createObjectApproval.GetObjectName())
-			metrics.PerfApprovalTime.WithLabelValues("gateway_create_object_auth_cost").Observe(time.Since(startVerifyAuthentication).Seconds())
-			metrics.PerfApprovalTime.WithLabelValues("gateway_create_object_auth_end").Observe(time.Since(startTime).Seconds())
-			if err != nil {
-				log.CtxErrorw(reqCtx.Context(), "failed to verify authentication", "error", err)
-				return
-			}
-			if !authenticated {
-				log.CtxErrorw(reqCtx.Context(), "no permission to operate")
-				err = ErrNoPermission
-				return
-			}
+		startVerifyAuthentication := time.Now()
+		authenticated, err = g.baseApp.GfSpClient().VerifyAuthentication(
+			reqCtx.Context(), coremodule.AuthOpAskCreateObjectApproval,
+			reqCtx.Account(), createObjectApproval.GetBucketName(),
+			createObjectApproval.GetObjectName())
+		metrics.PerfApprovalTime.WithLabelValues("gateway_create_object_auth_cost").Observe(time.Since(startVerifyAuthentication).Seconds())
+		metrics.PerfApprovalTime.WithLabelValues("gateway_create_object_auth_end").Observe(time.Since(startTime).Seconds())
+		if err != nil {
+			log.CtxErrorw(reqCtx.Context(), "failed to verify authentication", "error", err)
+			return
+		}
+		if !authenticated {
+			log.CtxErrorw(reqCtx.Context(), "no permission to operate")
+			err = ErrNoPermission
+			return
 		}
 		task := &gfsptask.GfSpCreateObjectApprovalTask{}
 		task.InitApprovalCreateObjectTask(reqCtx.Account(), &createObjectApproval, g.baseApp.TaskPriority(task))
@@ -284,21 +278,19 @@ func (g *GateModular) getChallengeInfoHandler(w http.ResponseWriter, r *http.Req
 		}
 		return
 	}
-	if !reqCtx.SkipVerifyAuthentication() {
-		authTime := time.Now()
-		authenticated, err = g.baseApp.GfSpClient().VerifyAuthentication(reqCtx.Context(),
-			coremodule.AuthOpTypeGetChallengePieceInfo, reqCtx.Account(), objectInfo.GetBucketName(),
-			objectInfo.GetObjectName())
-		metrics.PerfChallengeTimeHistogram.WithLabelValues("challenge_auth_time").Observe(time.Since(authTime).Seconds())
-		if err != nil {
-			log.CtxErrorw(reqCtx.Context(), "failed to verify authentication", "error", err)
-			return
-		}
-		if !authenticated {
-			log.CtxErrorw(reqCtx.Context(), "failed to get challenge info due to no permission")
-			err = ErrNoPermission
-			return
-		}
+	authTime := time.Now()
+	authenticated, err = g.baseApp.GfSpClient().VerifyAuthentication(reqCtx.Context(),
+		coremodule.AuthOpTypeGetChallengePieceInfo, reqCtx.Account(), objectInfo.GetBucketName(),
+		objectInfo.GetObjectName())
+	metrics.PerfChallengeTimeHistogram.WithLabelValues("challenge_auth_time").Observe(time.Since(authTime).Seconds())
+	if err != nil {
+		log.CtxErrorw(reqCtx.Context(), "failed to verify authentication", "error", err)
+		return
+	}
+	if !authenticated {
+		log.CtxErrorw(reqCtx.Context(), "failed to get challenge info due to no permission")
+		err = ErrNoPermission
+		return
 	}
 
 	getBucketTime := time.Now()

--- a/modular/gater/bucket_handler.go
+++ b/modular/gater/bucket_handler.go
@@ -44,18 +44,16 @@ func (g *GateModular) getBucketReadQuotaHandler(w http.ResponseWriter, r *http.R
 	if err != nil {
 		return
 	}
-	if !reqCtx.SkipVerifyAuthentication() {
-		authenticated, err = g.baseApp.GfSpClient().VerifyAuthentication(reqCtx.Context(),
-			coremodule.AuthOpTypeGetBucketQuota, reqCtx.Account(), reqCtx.bucketName, "")
-		if err != nil {
-			log.CtxErrorw(reqCtx.Context(), "failed to verify authentication", "error", err)
-			return
-		}
-		if !authenticated {
-			log.CtxErrorw(reqCtx.Context(), "no permission to operate")
-			err = ErrNoPermission
-			return
-		}
+	authenticated, err = g.baseApp.GfSpClient().VerifyAuthentication(reqCtx.Context(),
+		coremodule.AuthOpTypeGetBucketQuota, reqCtx.Account(), reqCtx.bucketName, "")
+	if err != nil {
+		log.CtxErrorw(reqCtx.Context(), "failed to verify authentication", "error", err)
+		return
+	}
+	if !authenticated {
+		log.CtxErrorw(reqCtx.Context(), "no permission to operate")
+		err = ErrNoPermission
+		return
 	}
 
 	bucketInfo, err = g.baseApp.Consensus().QueryBucketInfo(reqCtx.Context(), reqCtx.bucketName)
@@ -134,18 +132,16 @@ func (g *GateModular) listBucketReadRecordHandler(w http.ResponseWriter, r *http
 	if err != nil {
 		return
 	}
-	if !reqCtx.SkipVerifyAuthentication() {
-		authenticated, err = g.baseApp.GfSpClient().VerifyAuthentication(reqCtx.Context(),
-			coremodule.AuthOpTypeListBucketReadRecord, reqCtx.Account(), reqCtx.bucketName, "")
-		if err != nil {
-			log.CtxErrorw(reqCtx.Context(), "failed to verify authentication", "error", err)
-			return
-		}
-		if !authenticated {
-			log.CtxErrorw(reqCtx.Context(), "no permission to operate")
-			err = ErrNoPermission
-			return
-		}
+	authenticated, err = g.baseApp.GfSpClient().VerifyAuthentication(reqCtx.Context(),
+		coremodule.AuthOpTypeListBucketReadRecord, reqCtx.Account(), reqCtx.bucketName, "")
+	if err != nil {
+		log.CtxErrorw(reqCtx.Context(), "failed to verify authentication", "error", err)
+		return
+	}
+	if !authenticated {
+		log.CtxErrorw(reqCtx.Context(), "no permission to operate")
+		err = ErrNoPermission
+		return
 	}
 
 	bucketInfo, err := g.baseApp.Consensus().QueryBucketInfo(reqCtx.Context(), reqCtx.bucketName)

--- a/modular/gater/const.go
+++ b/modular/gater/const.go
@@ -31,8 +31,6 @@ const (
 	Signature = "Signature"
 	// SignTypeV1 is an authentication algorithm, which is used by dapps
 	SignTypeV1 = "authTypeV1"
-	// SignTypeV2 is an authentication algorithm, which is used by metamask
-	SignTypeV2 = "authTypeV2"
 
 	SignTypeOffChain   = "OffChainAuth" // sign type - off-chain-auth
 	SignTypePersonal   = "PersonalSign" // sign type -  PersonalSign

--- a/modular/gater/metadata_handler.go
+++ b/modular/gater/metadata_handler.go
@@ -285,10 +285,7 @@ func (g *GateModular) getObjectMetaHandler(w http.ResponseWriter, r *http.Reques
 		}
 	}()
 
-	reqCtx, err = NewRequestContext(r, g)
-	if err != nil {
-		return
-	}
+	reqCtx, _ = NewRequestContext(r, g)
 
 	if err = s3util.CheckValidBucketName(reqCtx.bucketName); err != nil {
 		log.Errorw("failed to check bucket name", "bucket_name", reqCtx.bucketName, "error", err)
@@ -342,10 +339,7 @@ func (g *GateModular) getBucketMetaHandler(w http.ResponseWriter, r *http.Reques
 		}
 	}()
 
-	reqCtx, err = NewRequestContext(r, g)
-	if err != nil {
-		return
-	}
+	reqCtx, _ = NewRequestContext(r, g)
 
 	if err = s3util.CheckValidBucketName(reqCtx.bucketName); err != nil {
 		log.Errorw("failed to check bucket name", "bucket_name", reqCtx.bucketName, "error", err)
@@ -401,7 +395,7 @@ func (g *GateModular) verifyPermissionHandler(w http.ResponseWriter, r *http.Req
 		}
 	}()
 
-	reqCtx, err = NewRequestContext(r, g)
+	reqCtx, _ = NewRequestContext(r, g)
 	if err != nil {
 		return
 	}
@@ -489,7 +483,7 @@ func (g *GateModular) getGroupListHandler(w http.ResponseWriter, r *http.Request
 		}
 	}()
 
-	reqCtx, err = NewRequestContext(r, g)
+	reqCtx, _ = NewRequestContext(r, g)
 	if err != nil {
 		return
 	}

--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -63,20 +63,18 @@ func (g *GateModular) putObjectHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
-	if !reqCtx.SkipVerifyAuthentication() {
-		startAuthenticationTime := time.Now()
-		authenticated, err = g.baseApp.GfSpClient().VerifyAuthentication(reqCtx.Context(),
-			coremodule.AuthOpTypePutObject, reqCtx.Account(), reqCtx.bucketName, reqCtx.objectName)
-		metrics.PerfPutObjectTime.WithLabelValues("gateway_put_object_authorizer").Observe(time.Since(startAuthenticationTime).Seconds())
-		if err != nil {
-			log.CtxErrorw(reqCtx.Context(), "failed to verify authentication", "error", err)
-			return
-		}
-		if !authenticated {
-			log.CtxErrorw(reqCtx.Context(), "no permission to operate")
-			err = ErrNoPermission
-			return
-		}
+	startAuthenticationTime := time.Now()
+	authenticated, err = g.baseApp.GfSpClient().VerifyAuthentication(reqCtx.Context(),
+		coremodule.AuthOpTypePutObject, reqCtx.Account(), reqCtx.bucketName, reqCtx.objectName)
+	metrics.PerfPutObjectTime.WithLabelValues("gateway_put_object_authorizer").Observe(time.Since(startAuthenticationTime).Seconds())
+	if err != nil {
+		log.CtxErrorw(reqCtx.Context(), "failed to verify authentication", "error", err)
+		return
+	}
+	if !authenticated {
+		log.CtxErrorw(reqCtx.Context(), "no permission to operate")
+		err = ErrNoPermission
+		return
 	}
 
 	startGetObjectInfoTime := time.Now()
@@ -184,18 +182,16 @@ func (g *GateModular) resumablePutObjectHandler(w http.ResponseWriter, r *http.R
 	if err != nil {
 		return
 	}
-	if !reqCtx.SkipVerifyAuthentication() {
-		authenticated, err = g.baseApp.GfSpClient().VerifyAuthentication(reqCtx.Context(),
-			coremodule.AuthOpTypePutObject, reqCtx.Account(), reqCtx.bucketName, reqCtx.objectName)
-		if err != nil {
-			log.CtxErrorw(reqCtx.Context(), "failed to verify authorize", "error", err)
-			return
-		}
-		if !authenticated {
-			log.CtxErrorw(reqCtx.Context(), "no permission to operate")
-			err = ErrNoPermission
-			return
-		}
+	authenticated, err = g.baseApp.GfSpClient().VerifyAuthentication(reqCtx.Context(),
+		coremodule.AuthOpTypePutObject, reqCtx.Account(), reqCtx.bucketName, reqCtx.objectName)
+	if err != nil {
+		log.CtxErrorw(reqCtx.Context(), "failed to verify authorize", "error", err)
+		return
+	}
+	if !authenticated {
+		log.CtxErrorw(reqCtx.Context(), "no permission to operate")
+		err = ErrNoPermission
+		return
 	}
 
 	startGetObjectInfoTime := time.Now()
@@ -311,18 +307,16 @@ func (g *GateModular) queryResumeOffsetHandler(w http.ResponseWriter, r *http.Re
 	if err != nil {
 		return
 	}
-	if !reqCtx.SkipVerifyAuthentication() {
-		authenticated, err = g.baseApp.GfSpClient().VerifyAuthentication(reqCtx.Context(),
-			coremodule.AuthOpTypeGetUploadingState, reqCtx.Account(), reqCtx.bucketName, reqCtx.objectName)
-		if err != nil {
-			log.CtxErrorw(reqCtx.Context(), "failed to verify authorize", "error", err)
-			return
-		}
-		if !authenticated {
-			log.CtxErrorw(reqCtx.Context(), "no permission to operate")
-			err = ErrNoPermission
-			return
-		}
+	authenticated, err = g.baseApp.GfSpClient().VerifyAuthentication(reqCtx.Context(),
+		coremodule.AuthOpTypeGetUploadingState, reqCtx.Account(), reqCtx.bucketName, reqCtx.objectName)
+	if err != nil {
+		log.CtxErrorw(reqCtx.Context(), "failed to verify authorize", "error", err)
+		return
+	}
+	if !authenticated {
+		log.CtxErrorw(reqCtx.Context(), "no permission to operate")
+		err = ErrNoPermission
+		return
 	}
 
 	objectInfo, err = g.baseApp.Consensus().QueryObjectInfo(reqCtx.Context(), reqCtx.bucketName, reqCtx.objectName)
@@ -444,21 +438,20 @@ func (g *GateModular) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 			log.CtxErrorw(reqCtx.Context(), "no permission to operate, object is not public", "error", err)
 			return
 		}
-		if !reqCtx.SkipVerifyAuthentication() {
-			authTime := time.Now()
-			if authenticated, err = g.baseApp.GfSpClient().VerifyAuthentication(reqCtx.Context(),
-				coremodule.AuthOpTypeGetObject, reqCtx.Account(), reqCtx.bucketName, reqCtx.objectName); err != nil {
-				metrics.PerfGetObjectTimeHistogram.WithLabelValues("get_object_auth_time").Observe(time.Since(authTime).Seconds())
-				log.CtxErrorw(reqCtx.Context(), "failed to verify authentication", "error", err)
-				return
-			}
+		authTime := time.Now()
+		if authenticated, err = g.baseApp.GfSpClient().VerifyAuthentication(reqCtx.Context(),
+			coremodule.AuthOpTypeGetObject, reqCtx.Account(), reqCtx.bucketName, reqCtx.objectName); err != nil {
 			metrics.PerfGetObjectTimeHistogram.WithLabelValues("get_object_auth_time").Observe(time.Since(authTime).Seconds())
-			if !authenticated {
-				log.CtxErrorw(reqCtx.Context(), "no permission to operate")
-				err = ErrNoPermission
-				return
-			}
+			log.CtxErrorw(reqCtx.Context(), "failed to verify authentication", "error", err)
+			return
 		}
+		metrics.PerfGetObjectTimeHistogram.WithLabelValues("get_object_auth_time").Observe(time.Since(authTime).Seconds())
+		if !authenticated {
+			log.CtxErrorw(reqCtx.Context(), "no permission to operate")
+			err = ErrNoPermission
+			return
+		}
+
 	} // else anonymous users can get public object.
 
 	getObjectTime := time.Now()
@@ -578,18 +571,16 @@ func (g *GateModular) queryUploadProgressHandler(w http.ResponseWriter, r *http.
 	if err != nil {
 		return
 	}
-	if !reqCtx.SkipVerifyAuthentication() {
-		authenticated, err = g.baseApp.GfSpClient().VerifyAuthentication(reqCtx.Context(),
-			coremodule.AuthOpTypeGetUploadingState, reqCtx.Account(), reqCtx.bucketName, reqCtx.objectName)
-		if err != nil {
-			log.CtxErrorw(reqCtx.Context(), "failed to verify authentication", "error", err)
-			return
-		}
-		if !authenticated {
-			log.CtxErrorw(reqCtx.Context(), "no permission to operate")
-			err = ErrNoPermission
-			return
-		}
+	authenticated, err = g.baseApp.GfSpClient().VerifyAuthentication(reqCtx.Context(),
+		coremodule.AuthOpTypeGetUploadingState, reqCtx.Account(), reqCtx.bucketName, reqCtx.objectName)
+	if err != nil {
+		log.CtxErrorw(reqCtx.Context(), "failed to verify authentication", "error", err)
+		return
+	}
+	if !authenticated {
+		log.CtxErrorw(reqCtx.Context(), "no permission to operate")
+		err = ErrNoPermission
+		return
 	}
 
 	objectInfo, err = g.baseApp.Consensus().QueryObjectInfo(reqCtx.Context(), reqCtx.bucketName, reqCtx.objectName)

--- a/modular/gater/request_context.go
+++ b/modular/gater/request_context.go
@@ -128,12 +128,6 @@ func (r *RequestContext) String() string {
 		getRequestIP(r.request), time.Since(r.startTime), r.err)
 }
 
-// SkipVerifyAuthentication is temporary to Compatible SignatureV2
-func (r *RequestContext) SkipVerifyAuthentication() bool {
-	v2SignaturePrefix := signaturePrefix(SignTypeV2, SignAlgorithm)
-	return strings.HasPrefix(r.request.Header.Get(GnfdAuthorizationHeader), v2SignaturePrefix)
-}
-
 // signaturePrefix return supported Authentication prefix
 func signaturePrefix(version, algorithm string) string {
 	return version + " " + algorithm + ","
@@ -148,10 +142,6 @@ func (r *RequestContext) VerifySignature() (string, error) {
 			return "", err
 		}
 		return accAddress.String(), nil
-	}
-	v2SignaturePrefix := signaturePrefix(SignTypeV2, SignAlgorithm)
-	if strings.HasPrefix(requestSignature, v2SignaturePrefix) {
-		return "signV2", nil
 	}
 
 	OffChainSignaturePrefix := signaturePrefix(SignTypeOffChain, SignAlgorithmEddsa)


### PR DESCRIPTION
### Description

 remove v2 Authorization
1. metadata apis will not require authorization
2. object/admin/bucket handler will remove SkipVerifyAuthentication

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 
* remove v2 Authorization

