### PR TITLE
fix: block syncer copy object

### DIFF
--- a/modular/blocksyncer/database/object.go
+++ b/modular/blocksyncer/database/object.go
@@ -25,8 +25,13 @@ func (db *DB) UpdateObject(ctx context.Context, object *models.Object) error {
 
 func (db *DB) GetObject(ctx context.Context, objectId common.Hash) (*models.Object, error) {
 	var object models.Object
+	bucketName, err := db.GetBucketNameByObjectID(objectId)
 
-	err := db.Db.WithContext(ctx).Table(bsdb.GetObjectsTableName(object.BucketName)).Where(
+	if err != nil {
+		return nil, err
+	}
+
+	err = db.Db.WithContext(ctx).Table(bsdb.GetObjectsTableName(bucketName)).Where(
 		"object_id = ? AND removed IS NOT TRUE", objectId).Find(&object).Error
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Description

Fix block syncer copy object after introduce sharding

### Rationale

Sharding introduce a bug when try to use object bucketname that has not yet created

### Example

N/A

### Changes

Notable changes: 
* block syncer
