### PR TITLE
fix: resumable upload maxpayload size bugs

### DIFF
--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -202,11 +202,7 @@ func (g *GateModular) resumablePutObjectHandler(w http.ResponseWriter, r *http.R
 		err = ErrConsensus
 		return
 	}
-	if objectInfo.GetPayloadSize() == 0 || objectInfo.GetPayloadSize() > g.maxPayloadSize {
-		log.CtxErrorw(reqCtx.Context(), "failed to put object payload size is zero")
-		err = ErrInvalidPayloadSize
-		return
-	}
+
 	startGetStorageParamTime := time.Now()
 	params, err = g.baseApp.Consensus().QueryStorageParams(reqCtx.Context())
 	metrics.PerfPutObjectTime.WithLabelValues("gateway_resumable_put_object_query_params_cost").Observe(time.Since(startGetStorageParamTime).Seconds())


### PR DESCRIPTION
### Description

Fixed #795  introduced a bug when resolving conflicts. Resumable uploads should be determined based on the `MaxPayloadSize on the blockchain`, rather than the `maxPayloadSize parameter on the sp side`.

### Rationale

NA

### Example

NA

### Changes

Notable changes: 
* NA
* ...
