### PR TITLE
refactor:  update quota consumption method

### DIFF
--- a/base/gfspapp/sign_server.go
+++ b/base/gfspapp/sign_server.go
@@ -215,6 +215,11 @@ func (g *GfSpBaseApp) GfSpSign(ctx context.Context, req *gfspserver.GfSpSignRequ
 		if err != nil {
 			log.CtxErrorw(ctx, "failed to sign complete sp exit", "error", err)
 		}
+	case *gfspserver.GfSpSignRequest_SpStoragePrice:
+		txHash, err = g.signer.UpdateSPPrice(ctx, t.SpStoragePrice)
+		if err != nil {
+			log.CtxErrorw(ctx, "failed to update sp price", "error", err)
+		}
 	default:
 		log.CtxError(ctx, "unknown gfsp sign request type")
 		return &gfspserver.GfSpSignResponse{

--- a/base/gfspclient/metadata.go
+++ b/base/gfspclient/metadata.go
@@ -308,7 +308,7 @@ func (s *GfSpClient) GetEndpointBySpAddress(ctx context.Context, spAddress strin
 	return resp.GetEndpoint(), nil
 }
 
-func (s *GfSpClient) GetBucketReadQuota(ctx context.Context, bucket *storage_types.BucketInfo, yearMonth string, opts ...grpc.DialOption) (
+func (s *GfSpClient) GetBucketReadQuota(ctx context.Context, bucket *storage_types.BucketInfo, opts ...grpc.DialOption) (
 	uint64, uint64, uint64, error) {
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
@@ -318,7 +318,6 @@ func (s *GfSpClient) GetBucketReadQuota(ctx context.Context, bucket *storage_typ
 	defer conn.Close()
 	req := &types.GfSpGetBucketReadQuotaRequest{
 		BucketInfo: bucket,
-		YearMonth:  yearMonth,
 	}
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetBucketReadQuota(ctx, req)
 	if err != nil {

--- a/base/gfspclient/signer.go
+++ b/base/gfspclient/signer.go
@@ -116,7 +116,7 @@ func (s *GfSpClient) UpdateSPPrice(ctx context.Context, price *sptypes.MsgUpdate
 	}
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
-		log.CtxErrorw(ctx, "client failed to seal object approval", "error", err)
+		log.CtxErrorw(ctx, "client failed to update SP price info", "error", err)
 		return "", ErrRpcUnknown
 	}
 	if resp.GetErr() != nil {

--- a/base/gfspclient/signer.go
+++ b/base/gfspclient/signer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsptask"
 	coretask "github.com/bnb-chain/greenfield-storage-provider/core/task"
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
+	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 	virtualgrouptypes "github.com/bnb-chain/greenfield/x/virtualgroup/types"
 )
@@ -89,6 +90,28 @@ func (s *GfSpClient) SealObject(ctx context.Context, object *storagetypes.MsgSea
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_SealObjectInfo{
 			SealObjectInfo: object,
+		},
+	}
+	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
+	if err != nil {
+		log.CtxErrorw(ctx, "client failed to seal object approval", "error", err)
+		return "", ErrRpcUnknown
+	}
+	if resp.GetErr() != nil {
+		return "", resp.GetErr()
+	}
+	return resp.GetTxHash(), nil
+}
+
+func (s *GfSpClient) UpdateSPPrice(ctx context.Context, price *sptypes.MsgUpdateSpStoragePrice) (string, error) {
+	conn, connErr := s.SignerConn(ctx)
+	if connErr != nil {
+		log.CtxErrorw(ctx, "client failed to connect to signer", "error", connErr)
+		return "", ErrRpcUnknown
+	}
+	req := &gfspserver.GfSpSignRequest{
+		Request: &gfspserver.GfSpSignRequest_SpStoragePrice{
+			SpStoragePrice: price,
 		},
 	}
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)

--- a/base/gnfd/gnfd_service.go
+++ b/base/gnfd/gnfd_service.go
@@ -200,6 +200,22 @@ func (g *Gnfd) QuerySP(ctx context.Context, operatorAddress string) (*sptypes.St
 	return resp.GetStorageProvider(), nil
 }
 
+// QuerySPFreeQuota returns the sp free quota
+func (g *Gnfd) QuerySPFreeQuota(ctx context.Context, operatorAddress string) (uint64, error) {
+	startTime := time.Now()
+	defer metrics.GnfdChainTime.WithLabelValues("query_sp").Observe(time.Since(startTime).Seconds())
+	client := g.getCurrentClient().GnfdClient()
+	resp, err := client.QueryGetSpStoragePriceByTime(ctx, &sptypes.QueryGetSpStoragePriceByTimeRequest{
+		SpAddr:    operatorAddress,
+		Timestamp: 0,
+	})
+	if err != nil {
+		log.Errorw("failed to query storage provider", "error", err)
+		return 0, err
+	}
+	return resp.GetSpStoragePrice().FreeReadQuota, nil
+}
+
 // QuerySPByID returns the sp info.
 func (g *Gnfd) QuerySPByID(ctx context.Context, spID uint32) (*sptypes.StorageProvider, error) {
 	startTime := time.Now()

--- a/base/gnfd/gnfd_service.go
+++ b/base/gnfd/gnfd_service.go
@@ -8,13 +8,11 @@ import (
 	"time"
 
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/metrics"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
-	gnfdSdkTypes "github.com/bnb-chain/greenfield/sdk/types"
 	paymenttypes "github.com/bnb-chain/greenfield/x/payment/types"
 	permissiontypes "github.com/bnb-chain/greenfield/x/permission/types"
 	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
@@ -216,31 +214,6 @@ func (g *Gnfd) QuerySPFreeQuota(ctx context.Context, operatorAddress string) (ui
 		return 0, err
 	}
 	return resp.GetSpStoragePrice().FreeReadQuota, nil
-}
-
-// UpdateSPQuota update the free quota info and return the txn hash
-func (g *Gnfd) UpdateSPQuota(ctx context.Context, operatorAddress string, freeQuota uint64) (string, error) {
-	client := g.getCurrentClient().GnfdClient()
-
-	priceInfo, err := g.QuerySPPrice(ctx, operatorAddress)
-	if err != nil {
-		return "", err
-	}
-
-	msgUpdateStoragePrice := &sptypes.MsgUpdateSpStoragePrice{
-		SpAddress:     operatorAddress,
-		ReadPrice:     priceInfo.ReadPrice,
-		StorePrice:    priceInfo.StorePrice,
-		FreeReadQuota: freeQuota,
-	}
-
-	resp, err := client.BroadcastTx(ctx, []sdk.Msg{msgUpdateStoragePrice}, &gnfdSdkTypes.TxOption{})
-	if err != nil {
-		log.Errorw("failed to update storage  price ", "error", err)
-		return "", err
-	}
-
-	return resp.TxResponse.TxHash, nil
 }
 
 // QuerySPPrice returns the sp price info

--- a/base/gnfd/gnfd_service.go
+++ b/base/gnfd/gnfd_service.go
@@ -203,11 +203,10 @@ func (g *Gnfd) QuerySP(ctx context.Context, operatorAddress string) (*sptypes.St
 // QuerySPFreeQuota returns the sp free quota
 func (g *Gnfd) QuerySPFreeQuota(ctx context.Context, operatorAddress string) (uint64, error) {
 	startTime := time.Now()
-	defer metrics.GnfdChainTime.WithLabelValues("query_spQuota").Observe(time.Since(startTime).Seconds())
+	defer metrics.GnfdChainTime.WithLabelValues("query_sp_quota").Observe(time.Since(startTime).Seconds())
 	client := g.getCurrentClient().GnfdClient()
 	resp, err := client.QueryGetSpStoragePriceByTime(ctx, &sptypes.QueryGetSpStoragePriceByTimeRequest{
-		SpAddr:    operatorAddress,
-		Timestamp: 0,
+		SpAddr: operatorAddress,
 	})
 	if err != nil {
 		log.Errorw("failed to query storage provider", "error", err)
@@ -219,11 +218,10 @@ func (g *Gnfd) QuerySPFreeQuota(ctx context.Context, operatorAddress string) (ui
 // QuerySPPrice returns the sp price info
 func (g *Gnfd) QuerySPPrice(ctx context.Context, operatorAddress string) (sptypes.SpStoragePrice, error) {
 	startTime := time.Now()
-	defer metrics.GnfdChainTime.WithLabelValues("query_spPrice").Observe(time.Since(startTime).Seconds())
+	defer metrics.GnfdChainTime.WithLabelValues("query_sp_price").Observe(time.Since(startTime).Seconds())
 	client := g.getCurrentClient().GnfdClient()
 	resp, err := client.QueryGetSpStoragePriceByTime(ctx, &sptypes.QueryGetSpStoragePriceByTimeRequest{
-		SpAddr:    operatorAddress,
-		Timestamp: 0,
+		SpAddr: operatorAddress,
 	})
 	if err != nil {
 		log.Errorw("failed to query storage provider", "error", err)

--- a/cmd/command/quota.go
+++ b/cmd/command/quota.go
@@ -1,0 +1,62 @@
+package command
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bnb-chain/greenfield-storage-provider/cmd/utils"
+	"github.com/urfave/cli/v2"
+)
+
+var freeQuotaFlag = &cli.Uint64Flag{
+	Name:     "quota",
+	Usage:    "The sp free quota",
+	Required: true,
+}
+
+var SetQuotaCmd = &cli.Command{
+	Action: updateFreeQuotaAction,
+	Name:   "update.quota",
+	Usage:  "Update the free quota of the SP",
+
+	Flags: []cli.Flag{
+		utils.ConfigFileFlag,
+		freeQuotaFlag,
+	},
+
+	Category: "QUOTA COMMANDS",
+	Description: `The update.quota command is used to update the free quota of the SP on greenfield chain, 
+				it will send a txn to the chain to finish the updating ", 
+  `,
+}
+
+func updateFreeQuotaAction(ctx *cli.Context) error {
+	cfg, err := utils.MakeConfig(ctx)
+	if err != nil {
+		return err
+	}
+
+	freeQuota := ctx.Uint64(freeQuotaFlag.Name)
+	chain, err := utils.MakeGnfd(cfg)
+	if err != nil {
+		return err
+	}
+
+	localCtx := context.Background()
+	oldQuota, err := chain.QuerySPFreeQuota(localCtx, cfg.SpAccount.SpOperatorAddress)
+	if err != nil {
+		return err
+	}
+
+	if oldQuota == freeQuota {
+		return fmt.Errorf("quota value: %s is same as chain meta, no need to update \n", freeQuota)
+	}
+
+	txnHash, err := chain.UpdateSPQuota(localCtx, cfg.SpAccount.SpOperatorAddress, freeQuota)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("update sp free quota to %s successfully, txn hash is %s \n", freeQuota, txnHash)
+
+	return nil
+}

--- a/cmd/command/quota.go
+++ b/cmd/command/quota.go
@@ -55,6 +55,10 @@ func updateFreeQuotaAction(ctx *cli.Context) error {
 	}
 
 	priceInfo, err := chain.QuerySPPrice(localCtx, operatorAddr)
+	if err != nil {
+		fmt.Printf("failed to get the current quota info %s\n", err.Error())
+		return err
+	}
 	msgUpdateStoragePrice := &sptypes.MsgUpdateSpStoragePrice{
 		SpAddress:     operatorAddr,
 		ReadPrice:     priceInfo.ReadPrice,

--- a/cmd/command/quota.go
+++ b/cmd/command/quota.go
@@ -49,14 +49,14 @@ func updateFreeQuotaAction(ctx *cli.Context) error {
 	}
 
 	if oldQuota == freeQuota {
-		return fmt.Errorf("quota value: %s is same as chain meta, no need to update \n", freeQuota)
+		return fmt.Errorf("quota value: %d is same as chain meta, no need to update \n", freeQuota)
 	}
 
 	txnHash, err := chain.UpdateSPQuota(localCtx, cfg.SpAccount.SpOperatorAddress, freeQuota)
 	if err != nil {
 		return err
 	}
-	fmt.Printf("update sp free quota to %s successfully, txn hash is %s \n", freeQuota, txnHash)
+	fmt.Printf("update sp free quota from %d to %d successfully, txn hash is %s \n", oldQuota, freeQuota, txnHash)
 
 	return nil
 }

--- a/cmd/storage_provider/main.go
+++ b/cmd/storage_provider/main.go
@@ -120,6 +120,8 @@ func init() {
 		command.RecoverPieceCmd,
 		// sp exit
 		command.SPExitCmd,
+		// update quota
+		command.SetQuotaCmd,
 	}
 	registerModular()
 }

--- a/core/consensus/consensus.go
+++ b/core/consensus/consensus.go
@@ -28,8 +28,6 @@ type Consensus interface {
 	QuerySPFreeQuota(context.Context, string) (uint64, error)
 	// QuerySPPrice returns the sp price info
 	QuerySPPrice(ctx context.Context, operatorAddress string) (sptypes.SpStoragePrice, error)
-	// UpdateSPQuota returns the sp price info
-	UpdateSPQuota(ctx context.Context, operatorAddress string, freeQuota uint64) (string, error)
 	// ListBondedValidators returns all bonded validators info.
 	ListBondedValidators(ctx context.Context) ([]stakingtypes.Validator, error)
 	// ListVirtualGroupFamilies return all virtual group family which primary sp is spID.
@@ -90,10 +88,6 @@ func (*NullConsensus) QuerySPFreeQuota(context.Context, string) (uint64, error) 
 
 func (*NullConsensus) QuerySPPrice(ctx context.Context, operatorAddress string) (sptypes.SpStoragePrice, error) {
 	return sptypes.SpStoragePrice{}, nil
-}
-
-func (*NullConsensus) UpdateSPQuota(ctx context.Context, operatorAddress string, freeQuota uint64) (string, error) {
-	return "", nil
 }
 
 func (*NullConsensus) QuerySPByID(context.Context, uint32) (*sptypes.StorageProvider, error) {

--- a/core/consensus/consensus.go
+++ b/core/consensus/consensus.go
@@ -24,8 +24,12 @@ type Consensus interface {
 	QuerySP(context.Context, string) (*sptypes.StorageProvider, error)
 	// QuerySPByID returns the sp info by sp id.
 	QuerySPByID(context.Context, uint32) (*sptypes.StorageProvider, error)
-	// QuerySPFreeQuota  returns the sp free quota by operator address.
+	// QuerySPFreeQuota returns the sp free quota by operator address.
 	QuerySPFreeQuota(context.Context, string) (uint64, error)
+	// QuerySPPrice returns the sp price info
+	QuerySPPrice(ctx context.Context, operatorAddress string) (sptypes.SpStoragePrice, error)
+	// UpdateSPQuota returns the sp price info
+	UpdateSPQuota(ctx context.Context, operatorAddress string, freeQuota uint64) (string, error)
 	// ListBondedValidators returns all bonded validators info.
 	ListBondedValidators(ctx context.Context) ([]stakingtypes.Validator, error)
 	// ListVirtualGroupFamilies return all virtual group family which primary sp is spID.
@@ -82,6 +86,14 @@ func (*NullConsensus) QuerySP(context.Context, string) (*sptypes.StorageProvider
 
 func (*NullConsensus) QuerySPFreeQuota(context.Context, string) (uint64, error) {
 	return 0, nil
+}
+
+func (*NullConsensus) QuerySPPrice(ctx context.Context, operatorAddress string) (sptypes.SpStoragePrice, error) {
+	return sptypes.SpStoragePrice{}, nil
+}
+
+func (*NullConsensus) UpdateSPQuota(ctx context.Context, operatorAddress string, freeQuota uint64) (string, error) {
+	return "", nil
 }
 
 func (*NullConsensus) QuerySPByID(context.Context, uint32) (*sptypes.StorageProvider, error) {

--- a/core/consensus/consensus.go
+++ b/core/consensus/consensus.go
@@ -24,6 +24,8 @@ type Consensus interface {
 	QuerySP(context.Context, string) (*sptypes.StorageProvider, error)
 	// QuerySPByID returns the sp info by sp id.
 	QuerySPByID(context.Context, uint32) (*sptypes.StorageProvider, error)
+	// QuerySPFreeQuota  returns the sp free quota by operator address.
+	QuerySPFreeQuota(context.Context, string) (uint64, error)
 	// ListBondedValidators returns all bonded validators info.
 	ListBondedValidators(ctx context.Context) ([]stakingtypes.Validator, error)
 	// ListVirtualGroupFamilies return all virtual group family which primary sp is spID.
@@ -76,6 +78,10 @@ func (*NullConsensus) ListSPs(context.Context) ([]*sptypes.StorageProvider, erro
 
 func (*NullConsensus) QuerySP(context.Context, string) (*sptypes.StorageProvider, error) {
 	return nil, nil
+}
+
+func (*NullConsensus) QuerySPFreeQuota(context.Context, string) (uint64, error) {
+	return 0, nil
 }
 
 func (*NullConsensus) QuerySPByID(context.Context, uint32) (*sptypes.StorageProvider, error) {

--- a/core/module/modular.go
+++ b/core/module/modular.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bnb-chain/greenfield-storage-provider/core/rcmgr"
 	"github.com/bnb-chain/greenfield-storage-provider/core/spdb"
 	"github.com/bnb-chain/greenfield-storage-provider/core/task"
+	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 	virtualgrouptypes "github.com/bnb-chain/greenfield/x/virtualgroup/types"
 )
@@ -294,6 +295,8 @@ type Signer interface {
 	SPExit(ctx context.Context, spExit *virtualgrouptypes.MsgStorageProviderExit) (string, error)
 	// CompleteSPExit signs the MsgCompleteStorageProviderExit and broadcast the tx to greenfield.
 	CompleteSPExit(ctx context.Context, completeSPExit *virtualgrouptypes.MsgCompleteStorageProviderExit) (string, error)
+	// UpdateSPPrice signs the MsgUpdateSpStoragePrice and  broadcast the tx to greenfield.
+	UpdateSPPrice(ctx context.Context, price *sptypes.MsgUpdateSpStoragePrice) (string, error)
 }
 
 // Uploader is an abstract interface to handle putting object requests from users' account and store

--- a/core/module/null_modular.go
+++ b/core/module/null_modular.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bnb-chain/greenfield-storage-provider/core/rcmgr"
 	corespdb "github.com/bnb-chain/greenfield-storage-provider/core/spdb"
 	"github.com/bnb-chain/greenfield-storage-provider/core/task"
+	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 	virtualgrouptypes "github.com/bnb-chain/greenfield/x/virtualgroup/types"
 )
@@ -274,6 +275,10 @@ func (*NilModular) SPExit(ctx context.Context, spExit *virtualgrouptypes.MsgStor
 	return "", ErrNilModular
 }
 func (*NilModular) CompleteSPExit(ctx context.Context, completeSPExit *virtualgrouptypes.MsgCompleteStorageProviderExit) (string, error) {
+	return "", ErrNilModular
+}
+
+func (*NilModular) UpdateSPPrice(ctx context.Context, price *sptypes.MsgUpdateSpStoragePrice) (string, error) {
 	return "", ErrNilModular
 }
 

--- a/core/spdb/entity.go
+++ b/core/spdb/entity.go
@@ -73,7 +73,7 @@ type BucketTraffic struct {
 	ReadConsumedSize      uint64
 	FreeQuotaSize         uint64 // the total free quota size of SP price meta
 	FreeQuotaConsumedSize uint64 // the consumed free quota size
-	ReadQuotaSize         uint64 // the total charged quota of bucket
+	ChargedQuotaSize      uint64 // the total charged quota of bucket
 	ModifyTime            int64
 }
 

--- a/core/spdb/entity.go
+++ b/core/spdb/entity.go
@@ -57,17 +57,24 @@ type ReadRecord struct {
 
 // BucketQuota defines read quota of a bucket.
 type BucketQuota struct {
-	ReadQuotaSize uint64
+	ChargedQuotaSize uint64 // the charged quota of bucket on greenfield chain meta
+	FreeQuotaSize    uint64 // the free quota of SP on greenfield chain
+}
+
+// BucketFreeQuota defines free quota of a bucket.
+type BucketFreeQuota struct {
+	QuotaSize uint64
 }
 
 // BucketTraffic is record traffic by year and month.
 type BucketTraffic struct {
-	BucketID         uint64
-	YearMonth        string // YearMonth is traffic's YearMonth, format "2023-02".
-	BucketName       string
-	ReadConsumedSize uint64
-	ReadQuotaSize    uint64
-	ModifyTime       int64
+	BucketID              uint64
+	BucketName            string
+	ReadConsumedSize      uint64
+	FreeQuotaSize         uint64 // the total free quota size of SP price meta
+	FreeQuotaConsumedSize uint64 // the consumed free quota size
+	ReadQuotaSize         uint64 // the total charged quota of bucket
+	ModifyTime            int64
 }
 
 // TrafficTimeRange is used by query, return records in [StartTimestampUs, EndTimestampUs).

--- a/core/spdb/spdb.go
+++ b/core/spdb/spdb.go
@@ -69,13 +69,15 @@ type SignatureDB interface {
 
 // TrafficDB defines a series of traffic interfaces.
 type TrafficDB interface {
-	// CheckQuotaAndAddReadRecord create bucket traffic firstly if bucket is not existed,
-	// and check whether the added traffic record exceeds the quota, if it exceeds the quota,
+	// CheckQuotaAndAddReadRecord get the traffic info from db, update the quota meta and check
+	// whether the added traffic record exceeds the quota, if it exceeds the quota,
 	// it will return error, Otherwise, add a record and return nil.
 	CheckQuotaAndAddReadRecord(record *ReadRecord, quota *BucketQuota) error
+	// InitBucketTraffic init the traffic info
+	InitBucketTraffic(bucketID uint64, bucketName string, quota *BucketQuota) error
 	// GetBucketTraffic return bucket traffic info,
 	// notice maybe return (nil, nil) while there is no bucket traffic.
-	GetBucketTraffic(bucketID uint64, yearMonth string) (*BucketTraffic, error)
+	GetBucketTraffic(bucketID uint64) (*BucketTraffic, error)
 	// GetReadRecord return record list by time range.
 	GetReadRecord(timeRange *TrafficTimeRange) ([]*ReadRecord, error)
 	// GetBucketReadRecord return bucket record list by time range.

--- a/core/spdb/spdb_mock.go
+++ b/core/spdb/spdb_mock.go
@@ -328,20 +328,6 @@ func (mr *MockSignatureDBMockRecorder) SetReplicatePieceChecksum(objectID, segme
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetReplicatePieceChecksum", reflect.TypeOf((*MockSignatureDB)(nil).SetReplicatePieceChecksum), objectID, segmentIdx, redundancyIdx, checksum)
 }
 
-// UpdateIntegrityChecksum mocks base method.
-func (m *MockSignatureDB) UpdateIntegrityChecksum(integrity *IntegrityMeta) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateIntegrityChecksum", integrity)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateIntegrityChecksum indicates an expected call of UpdateIntegrityChecksum.
-func (mr *MockSignatureDBMockRecorder) UpdateIntegrityChecksum(integrity interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateIntegrityChecksum", reflect.TypeOf((*MockSignatureDB)(nil).UpdateIntegrityChecksum), integrity)
-}
-
 // UpdatePieceChecksum mocks base method.
 func (m *MockSignatureDB) UpdatePieceChecksum(objectID uint64, redundancyIndex int32, checksum []byte) error {
 	m.ctrl.T.Helper()
@@ -354,6 +340,20 @@ func (m *MockSignatureDB) UpdatePieceChecksum(objectID uint64, redundancyIndex i
 func (mr *MockSignatureDBMockRecorder) UpdatePieceChecksum(objectID, redundancyIndex, checksum interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePieceChecksum", reflect.TypeOf((*MockSignatureDB)(nil).UpdatePieceChecksum), objectID, redundancyIndex, checksum)
+}
+
+// UpdateIntegrityChecksum mocks base method.
+func (m *MockSignatureDB) UpdateIntegrityChecksum(integrity *IntegrityMeta) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateIntegrityChecksum", integrity)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateIntegrityChecksum indicates an expected call of UpdateIntegrityChecksum.
+func (mr *MockSignatureDBMockRecorder) UpdateIntegrityChecksum(integrity interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateIntegrityChecksum", reflect.TypeOf((*MockSignatureDB)(nil).UpdateIntegrityChecksum), integrity)
 }
 
 // MockTrafficDB is a mock of TrafficDB interface.

--- a/core/spdb/spdb_mock.go
+++ b/core/spdb/spdb_mock.go
@@ -409,18 +409,18 @@ func (mr *MockTrafficDBMockRecorder) GetBucketReadRecord(bucketID, timeRange int
 }
 
 // GetBucketTraffic mocks base method.
-func (m *MockTrafficDB) GetBucketTraffic(bucketID uint64, yearMonth string) (*BucketTraffic, error) {
+func (m *MockTrafficDB) GetBucketTraffic(bucketID uint64) (*BucketTraffic, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBucketTraffic", bucketID, yearMonth)
+	ret := m.ctrl.Call(m, "GetBucketTraffic", bucketID)
 	ret0, _ := ret[0].(*BucketTraffic)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetBucketTraffic indicates an expected call of GetBucketTraffic.
-func (mr *MockTrafficDBMockRecorder) GetBucketTraffic(bucketID, yearMonth interface{}) *gomock.Call {
+func (mr *MockTrafficDBMockRecorder) GetBucketTraffic(bucketID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketTraffic", reflect.TypeOf((*MockTrafficDB)(nil).GetBucketTraffic), bucketID, yearMonth)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketTraffic", reflect.TypeOf((*MockTrafficDB)(nil).GetBucketTraffic), bucketID)
 }
 
 // GetObjectReadRecord mocks base method.
@@ -466,6 +466,20 @@ func (m *MockTrafficDB) GetUserReadRecord(userAddress string, timeRange *Traffic
 func (mr *MockTrafficDBMockRecorder) GetUserReadRecord(userAddress, timeRange interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserReadRecord", reflect.TypeOf((*MockTrafficDB)(nil).GetUserReadRecord), userAddress, timeRange)
+}
+
+// InitBucketTraffic mocks base method.
+func (m *MockTrafficDB) InitBucketTraffic(bucketID uint64, bucketName string, quota *BucketQuota) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InitBucketTraffic", bucketID, bucketName, quota)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InitBucketTraffic indicates an expected call of InitBucketTraffic.
+func (mr *MockTrafficDBMockRecorder) InitBucketTraffic(bucketID, bucketName, quota interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitBucketTraffic", reflect.TypeOf((*MockTrafficDB)(nil).InitBucketTraffic), bucketID, bucketName, quota)
 }
 
 // MockSPInfoDB is a mock of SPInfoDB interface.
@@ -1113,18 +1127,18 @@ func (mr *MockSPDBMockRecorder) GetBucketReadRecord(bucketID, timeRange interfac
 }
 
 // GetBucketTraffic mocks base method.
-func (m *MockSPDB) GetBucketTraffic(bucketID uint64, yearMonth string) (*BucketTraffic, error) {
+func (m *MockSPDB) GetBucketTraffic(bucketID uint64) (*BucketTraffic, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBucketTraffic", bucketID, yearMonth)
+	ret := m.ctrl.Call(m, "GetBucketTraffic", bucketID)
 	ret0, _ := ret[0].(*BucketTraffic)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetBucketTraffic indicates an expected call of GetBucketTraffic.
-func (mr *MockSPDBMockRecorder) GetBucketTraffic(bucketID, yearMonth interface{}) *gomock.Call {
+func (mr *MockSPDBMockRecorder) GetBucketTraffic(bucketID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketTraffic", reflect.TypeOf((*MockSPDB)(nil).GetBucketTraffic), bucketID, yearMonth)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketTraffic", reflect.TypeOf((*MockSPDB)(nil).GetBucketTraffic), bucketID)
 }
 
 // GetGCMetasToGC mocks base method.
@@ -1291,6 +1305,20 @@ func (m *MockSPDB) GetUserReadRecord(userAddress string, timeRange *TrafficTimeR
 func (mr *MockSPDBMockRecorder) GetUserReadRecord(userAddress, timeRange interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserReadRecord", reflect.TypeOf((*MockSPDB)(nil).GetUserReadRecord), userAddress, timeRange)
+}
+
+// InitBucketTraffic mocks base method.
+func (m *MockSPDB) InitBucketTraffic(bucketID uint64, bucketName string, quota *BucketQuota) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InitBucketTraffic", bucketID, bucketName, quota)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InitBucketTraffic indicates an expected call of InitBucketTraffic.
+func (mr *MockSPDBMockRecorder) InitBucketTraffic(bucketID, bucketName, quota interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitBucketTraffic", reflect.TypeOf((*MockSPDB)(nil).InitBucketTraffic), bucketID, bucketName, quota)
 }
 
 // InsertAuthKey mocks base method.

--- a/modular/downloader/download_task.go
+++ b/modular/downloader/download_task.go
@@ -270,7 +270,7 @@ func (d *DownloadModular) PreDownloadPiece(ctx context.Context, downloadPieceTas
 			}
 		}
 
-		if err := d.baseApp.GfSpDB().CheckQuotaAndAddReadRecord(
+		if dbErr := d.baseApp.GfSpDB().CheckQuotaAndAddReadRecord(
 			&spdb.ReadRecord{
 				BucketID:        bucketID,
 				ObjectID:        downloadPieceTask.GetObjectInfo().Id.Uint64(),
@@ -283,10 +283,10 @@ func (d *DownloadModular) PreDownloadPiece(ctx context.Context, downloadPieceTas
 			&spdb.BucketQuota{
 				ChargedQuotaSize: downloadPieceTask.GetBucketInfo().GetChargedReadQuota(),
 			},
-		); err != nil {
+		); dbErr != nil {
 			metrics.PerfGetObjectTimeHistogram.WithLabelValues("get_object_check_quota_time").Observe(time.Since(checkQuotaTime).Seconds())
-			log.CtxErrorw(ctx, "failed to check bucket quota", "error", err)
-			if errors.Is(err, sqldb.ErrCheckQuotaEnough) {
+			log.CtxErrorw(ctx, "failed to check bucket quota", "error", dbErr)
+			if errors.Is(dbErr, sqldb.ErrCheckQuotaEnough) {
 				return ErrExceedBucketQuota
 			}
 			// ignore the access db error, it is the system's inner error, will be let the request go.

--- a/modular/downloader/download_task.go
+++ b/modular/downloader/download_task.go
@@ -18,6 +18,7 @@ import (
 	"github.com/bnb-chain/greenfield-storage-provider/store/sqldb"
 	"github.com/bnb-chain/greenfield-storage-provider/util"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
+	"gorm.io/gorm"
 )
 
 var (
@@ -35,6 +36,12 @@ var (
 )
 
 func (d *DownloadModular) PreDownloadObject(ctx context.Context, downloadObjectTask task.DownloadObjectTask) error {
+	var (
+		err           error
+		freeQuotaSize uint64
+		bucketTraffic *spdb.BucketTraffic
+	)
+
 	if downloadObjectTask == nil || downloadObjectTask.GetObjectInfo() == nil || downloadObjectTask.GetStorageParams() == nil {
 		log.CtxErrorw(ctx, "failed pre download object due to pointer dangling")
 		return ErrDanglingPointer
@@ -43,6 +50,30 @@ func (d *DownloadModular) PreDownloadObject(ctx context.Context, downloadObjectT
 		log.CtxErrorw(ctx, "failed to pre download object due to object unsealed")
 		return ErrObjectUnsealed
 	}
+
+	bucketID := downloadObjectTask.GetBucketInfo().Id.Uint64()
+	bucketName := downloadObjectTask.GetBucketInfo().GetBucketName()
+	bucketTraffic, err = d.baseApp.GfSpDB().GetBucketTraffic(downloadObjectTask.GetBucketInfo().Id.Uint64())
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return err
+	}
+	// init the bucket traffic table when checking quota for the first time
+	if bucketTraffic == nil {
+		freeQuotaSize, err = d.baseApp.Consensus().QuerySPFreeQuota(ctx, d.baseApp.OperatorAddress())
+		if err != nil {
+			return ErrConsensus
+		}
+		// only need to set the free quota when init the traffic table
+		err = d.baseApp.GfSpDB().InitBucketTraffic(bucketID, bucketName, &spdb.BucketQuota{
+			ChargedQuotaSize: downloadObjectTask.GetBucketInfo().GetChargedReadQuota(),
+			FreeQuotaSize:    freeQuotaSize,
+		})
+		if err != nil {
+			log.CtxErrorw(ctx, "init bucket traffic fail", "error", err)
+			return ErrGfSpDB
+		}
+	}
+
 	// TODO:: spilt check and add record steps, check in pre download, add record in post download
 	if err := d.baseApp.GfSpDB().CheckQuotaAndAddReadRecord(
 		&spdb.ReadRecord{
@@ -55,7 +86,8 @@ func (d *DownloadModular) PreDownloadObject(ctx context.Context, downloadObjectT
 			ReadTimestampUs: sqldb.GetCurrentTimestampUs(),
 		},
 		&spdb.BucketQuota{
-			ReadQuotaSize: downloadObjectTask.GetBucketInfo().GetChargedReadQuota() + d.bucketFreeQuota,
+			ChargedQuotaSize: downloadObjectTask.GetBucketInfo().GetChargedReadQuota(),
+			FreeQuotaSize:    freeQuotaSize,
 		},
 	); err != nil {
 		log.CtxErrorw(ctx, "failed to check bucket quota", "error", err)
@@ -182,6 +214,11 @@ func (d *DownloadModular) PreDownloadPiece(ctx context.Context, downloadPieceTas
 			_ = d.baseApp.GfSpClient().ReportTask(context.Background(), downloadPieceTask)
 		}()
 	}()
+	var (
+		err           error
+		freeQuotaSize uint64
+		bucketTraffic *spdb.BucketTraffic
+	)
 
 	if downloadPieceTask == nil || downloadPieceTask.GetObjectInfo() == nil || downloadPieceTask.GetStorageParams() == nil {
 		log.CtxErrorw(ctx, "failed pre download piece due to pointer dangling")
@@ -207,34 +244,54 @@ func (d *DownloadModular) PreDownloadPiece(ctx context.Context, downloadPieceTas
 		return nil
 	}
 	if downloadPieceTask.GetEnableCheck() {
-		// if it is a request from client, the task handler is the primary SP of the sp
-		if d.baseApp.OperatorAddress() == bucketPrimarySp.OperatorAddress {
-			log.CtxDebugw(ctx, "downloading from primary SP, checking quota")
-			checkQuotaTime := time.Now()
-			if err := d.baseApp.GfSpDB().CheckQuotaAndAddReadRecord(
-				&spdb.ReadRecord{
-					BucketID:        downloadPieceTask.GetBucketInfo().Id.Uint64(),
-					ObjectID:        downloadPieceTask.GetObjectInfo().Id.Uint64(),
-					UserAddress:     downloadPieceTask.GetUserAddress(),
-					BucketName:      downloadPieceTask.GetBucketInfo().GetBucketName(),
-					ObjectName:      downloadPieceTask.GetObjectInfo().GetObjectName(),
-					ReadSize:        downloadPieceTask.GetTotalSize(),
-					ReadTimestampUs: sqldb.GetCurrentTimestampUs(),
-				},
-				&spdb.BucketQuota{
-					ReadQuotaSize: downloadPieceTask.GetBucketInfo().GetChargedReadQuota() + d.bucketFreeQuota,
-				},
-			); err != nil {
-				metrics.PerfGetObjectTimeHistogram.WithLabelValues("get_object_check_quota_time").Observe(time.Since(checkQuotaTime).Seconds())
-				log.CtxErrorw(ctx, "failed to check bucket quota", "error", err)
-				if errors.Is(err, sqldb.ErrCheckQuotaEnough) {
-					return ErrExceedBucketQuota
-				}
-				// ignore the access db error, it is the system's inner error, will be let the request go.
-			}
-			metrics.PerfGetObjectTimeHistogram.WithLabelValues("get_object_check_quota_time").Observe(time.Since(checkQuotaTime).Seconds())
-			return nil
+		log.CtxDebugw(ctx, "downloading from primary SP, checking quota")
+		checkQuotaTime := time.Now()
+
+		bucketID := downloadPieceTask.GetBucketInfo().Id.Uint64()
+		bucketName := downloadPieceTask.GetBucketInfo().GetBucketName()
+		bucketTraffic, err = d.baseApp.GfSpDB().GetBucketTraffic(downloadPieceTask.GetBucketInfo().Id.Uint64())
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
 		}
+		// init the bucket traffic table when checking quota for the first time
+		if bucketTraffic == nil {
+			freeQuotaSize, err = d.baseApp.Consensus().QuerySPFreeQuota(ctx, d.baseApp.OperatorAddress())
+			if err != nil {
+				return ErrConsensus
+			}
+			// only need to set the free quota when init the traffic table
+			err = d.baseApp.GfSpDB().InitBucketTraffic(bucketID, bucketName, &spdb.BucketQuota{
+				ChargedQuotaSize: downloadPieceTask.GetBucketInfo().GetChargedReadQuota(),
+				FreeQuotaSize:    freeQuotaSize,
+			})
+			if err != nil {
+				log.CtxErrorw(ctx, "init bucket traffic fail", "error", err)
+				return ErrGfSpDB
+			}
+		}
+
+		if err := d.baseApp.GfSpDB().CheckQuotaAndAddReadRecord(
+			&spdb.ReadRecord{
+				BucketID:        bucketID,
+				ObjectID:        downloadPieceTask.GetObjectInfo().Id.Uint64(),
+				UserAddress:     downloadPieceTask.GetUserAddress(),
+				BucketName:      bucketName,
+				ObjectName:      downloadPieceTask.GetObjectInfo().GetObjectName(),
+				ReadSize:        downloadPieceTask.GetTotalSize(),
+				ReadTimestampUs: sqldb.GetCurrentTimestampUs(),
+			},
+			&spdb.BucketQuota{
+				ChargedQuotaSize: downloadPieceTask.GetBucketInfo().GetChargedReadQuota(),
+			},
+		); err != nil {
+			metrics.PerfGetObjectTimeHistogram.WithLabelValues("get_object_check_quota_time").Observe(time.Since(checkQuotaTime).Seconds())
+			log.CtxErrorw(ctx, "failed to check bucket quota", "error", err)
+			if errors.Is(err, sqldb.ErrCheckQuotaEnough) {
+				return ErrExceedBucketQuota
+			}
+			// ignore the access db error, it is the system's inner error, will be let the request go.
+		}
+		metrics.PerfGetObjectTimeHistogram.WithLabelValues("get_object_check_quota_time").Observe(time.Since(checkQuotaTime).Seconds())
 
 	}
 

--- a/modular/downloader/download_task.go
+++ b/modular/downloader/download_task.go
@@ -69,7 +69,7 @@ func (d *DownloadModular) PreDownloadObject(ctx context.Context, downloadObjectT
 			FreeQuotaSize:    freeQuotaSize,
 		})
 		if err != nil {
-			log.CtxErrorw(ctx, "init bucket traffic fail", "error", err)
+			log.CtxErrorw(ctx, "failed to init bucket traffic", "error", err)
 			return ErrGfSpDB
 		}
 	}
@@ -244,7 +244,6 @@ func (d *DownloadModular) PreDownloadPiece(ctx context.Context, downloadPieceTas
 		return nil
 	}
 	if downloadPieceTask.GetEnableCheck() {
-		log.CtxDebugw(ctx, "downloading from primary SP, checking quota")
 		checkQuotaTime := time.Now()
 
 		bucketID := downloadPieceTask.GetBucketInfo().Id.Uint64()
@@ -259,13 +258,16 @@ func (d *DownloadModular) PreDownloadPiece(ctx context.Context, downloadPieceTas
 			if err != nil {
 				return ErrConsensus
 			}
+			log.CtxDebugw(ctx, "finish init bucket traffic table", "charged_quota", downloadPieceTask.GetBucketInfo().GetChargedReadQuota(),
+				"freeQuota", freeQuotaSize)
+
 			// only need to set the free quota when init the traffic table
 			err = d.baseApp.GfSpDB().InitBucketTraffic(bucketID, bucketName, &spdb.BucketQuota{
 				ChargedQuotaSize: downloadPieceTask.GetBucketInfo().GetChargedReadQuota(),
 				FreeQuotaSize:    freeQuotaSize,
 			})
 			if err != nil {
-				log.CtxErrorw(ctx, "init bucket traffic fail", "error", err)
+				log.CtxErrorw(ctx, "failed to init bucket traffic", "error", err)
 				return ErrGfSpDB
 			}
 		}

--- a/modular/gater/bucket_handler.go
+++ b/modular/gater/bucket_handler.go
@@ -76,7 +76,7 @@ func (g *GateModular) getBucketReadQuotaHandler(w http.ResponseWriter, r *http.R
 			err = ErrConsensus
 		}
 		charge = bucketInfo.GetChargedReadQuota()
-		log.CtxDebugw(reqCtx.Context(), "fail to get traffic info in db, return the chain meta", "free quota", free, "charged quota", charge)
+		log.CtxDebugw(reqCtx.Context(), "fail to get traffic info in db, return the chain meta", "free_quota", free, "charged_quota", charge)
 		consume = 0
 	} else {
 		// if the traffic table has been created, return the db info from meta service
@@ -92,7 +92,7 @@ func (g *GateModular) getBucketReadQuotaHandler(w http.ResponseWriter, r *http.R
 		Version             string   `xml:"version,attr"`
 		BucketName          string   `xml:"BucketName"`
 		BucketID            string   `xml:"BucketID"`
-		ReadQuotaSize       uint64   `xml:"ChargedQuotaSize"`
+		ReadQuotaSize       uint64   `xml:"ReadQuotaSize"`
 		SPFreeReadQuotaSize uint64   `xml:"SPFreeReadQuotaSize"`
 		ReadConsumedSize    uint64   `xml:"ReadConsumedSize"`
 	}{

--- a/modular/gater/bucket_handler.go
+++ b/modular/gater/bucket_handler.go
@@ -2,16 +2,19 @@ package gater
 
 import (
 	"encoding/xml"
+	"errors"
 	"net/http"
 	"time"
 
 	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsperrors"
 	coremodule "github.com/bnb-chain/greenfield-storage-provider/core/module"
+	"github.com/bnb-chain/greenfield-storage-provider/core/spdb"
 	metadatatypes "github.com/bnb-chain/greenfield-storage-provider/modular/metadata/types"
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/metrics"
 	"github.com/bnb-chain/greenfield-storage-provider/util"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
+	"gorm.io/gorm"
 )
 
 // getBucketReadQuotaHandler handles the get bucket read quota request.
@@ -22,6 +25,7 @@ func (g *GateModular) getBucketReadQuotaHandler(w http.ResponseWriter, r *http.R
 		authenticated         bool
 		bucketInfo            *storagetypes.BucketInfo
 		charge, free, consume uint64
+		bucketTraffic         *spdb.BucketTraffic
 	)
 	startTime := time.Now()
 	defer func() {
@@ -62,18 +66,33 @@ func (g *GateModular) getBucketReadQuotaHandler(w http.ResponseWriter, r *http.R
 		err = ErrConsensus
 		return
 	}
-	charge, free, consume, err = g.baseApp.GfSpClient().GetBucketReadQuota(
-		reqCtx.Context(), bucketInfo, reqCtx.vars["year_month"])
-	if err != nil {
-		log.CtxErrorw(reqCtx.Context(), "failed to get bucket read quota", "error", err)
-		return
+
+	bucketTraffic, err = g.baseApp.GfSpDB().GetBucketTraffic(
+		bucketInfo.Id.Uint64())
+	// if the traffic table has not been created and initialized yet, return the chain info
+	if errors.Is(err, gorm.ErrRecordNotFound) || bucketTraffic == nil {
+		free, err = g.baseApp.Consensus().QuerySPFreeQuota(reqCtx.Context(), g.baseApp.OperatorAddress())
+		if err != nil {
+			err = ErrConsensus
+		}
+		charge = bucketInfo.GetChargedReadQuota()
+		log.CtxDebugw(reqCtx.Context(), "fail to get traffic info in db, return the chain meta", "free quota", free, "charged quota", charge)
+		consume = 0
+	} else {
+		// if the traffic table has been created, return the db info from meta service
+		charge, free, consume, err = g.baseApp.GfSpClient().GetBucketReadQuota(
+			reqCtx.Context(), bucketInfo)
+		if err != nil {
+			log.CtxErrorw(reqCtx.Context(), "failed to get bucket read quota", "error", err)
+			return
+		}
 	}
 	var xmlInfo = struct {
 		XMLName             xml.Name `xml:"GetReadQuotaResult"`
 		Version             string   `xml:"version,attr"`
 		BucketName          string   `xml:"BucketName"`
 		BucketID            string   `xml:"BucketID"`
-		ReadQuotaSize       uint64   `xml:"ReadQuotaSize"`
+		ReadQuotaSize       uint64   `xml:"ChargedQuotaSize"`
 		SPFreeReadQuotaSize uint64   `xml:"SPFreeReadQuotaSize"`
 		ReadConsumedSize    uint64   `xml:"ReadConsumedSize"`
 	}{

--- a/modular/metadata/metadata_bucket_service.go
+++ b/modular/metadata/metadata_bucket_service.go
@@ -290,7 +290,7 @@ func (r *MetadataModular) GfSpGetBucketReadQuota(
 		return nil, ErrExceedRequest
 	}
 	bucketTraffic, err := r.baseApp.GfSpDB().GetBucketTraffic(
-		req.GetBucketInfo().Id.Uint64(), req.GetYearMonth())
+		req.GetBucketInfo().Id.Uint64())
 	if systemerrors.Is(err, gorm.ErrRecordNotFound) {
 		return &types.GfSpGetBucketReadQuotaResponse{
 			ChargedQuotaSize: req.GetBucketInfo().GetChargedReadQuota(),
@@ -304,9 +304,10 @@ func (r *MetadataModular) GfSpGetBucketReadQuota(
 			"bucket_id", req.GetBucketInfo().Id.String(), "error", err)
 		return &types.GfSpGetBucketReadQuotaResponse{Err: ErrGfSpDB}, nil
 	}
+
 	return &types.GfSpGetBucketReadQuotaResponse{
 		ChargedQuotaSize: req.GetBucketInfo().GetChargedReadQuota(),
-		SpFreeQuotaSize:  r.freeQuotaPerBucket,
+		SpFreeQuotaSize:  bucketTraffic.FreeQuotaSize,
 		ConsumedSize:     bucketTraffic.ReadConsumedSize,
 	}, nil
 }

--- a/modular/metadata/metadata_options.go
+++ b/modular/metadata/metadata_options.go
@@ -35,6 +35,7 @@ func DefaultMetadataOptions(metadata *MetadataModular, cfg *gfspconfig.GfSpConfi
 	if cfg.Bucket.FreeQuotaPerBucket == 0 {
 		cfg.Bucket.FreeQuotaPerBucket = downloader.DefaultBucketFreeQuota
 	}
+
 	if cfg.Metadata.BsDBSwitchCheckIntervalSec == 0 {
 		cfg.Metadata.BsDBSwitchCheckIntervalSec = DefaultBsDBSwitchCheckIntervalSec
 	}

--- a/modular/signer/signer.go
+++ b/modular/signer/signer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bnb-chain/greenfield-storage-provider/core/rcmgr"
 	"github.com/bnb-chain/greenfield-storage-provider/core/task"
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
+	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 	virtualgrouptypes "github.com/bnb-chain/greenfield/x/virtualgroup/types"
 )
@@ -30,6 +31,7 @@ var (
 	ErrCompleteSwapOutOnChain       = gfsperrors.Register(module.SignModularName, http.StatusBadRequest, 120009, "send complete swap out failed")
 	ErrSPExitOnChain                = gfsperrors.Register(module.SignModularName, http.StatusBadRequest, 120010, "send sp exit failed")
 	ErrCompleteSPExitOnChain        = gfsperrors.Register(module.SignModularName, http.StatusBadRequest, 120011, "send complete sp exit failed")
+	ErrUpdateSPPriceOnChain         = gfsperrors.Register(module.SignModularName, http.StatusBadRequest, 120012, "send update sp price failed")
 )
 
 var _ module.Signer = &SignModular{}
@@ -171,6 +173,10 @@ func (s *SignModular) SignMigratePiece(ctx context.Context, mp *gfsptask.GfSpMig
 
 func (s *SignModular) CompleteMigrateBucket(ctx context.Context, migrateBucket *storagetypes.MsgCompleteMigrateBucket) (string, error) {
 	return s.client.CompleteMigrateBucket(ctx, SignOperator, migrateBucket)
+}
+
+func (s *SignModular) UpdateSPPrice(ctx context.Context, price *sptypes.MsgUpdateSpStoragePrice) (string, error) {
+	return s.client.UpdateSPPrice(ctx, SignOperator, price)
 }
 
 func (s *SignModular) SignSecondarySPMigrationBucket(ctx context.Context, signDoc *storagetypes.SecondarySpMigrationBucketSignDoc) ([]byte, error) {

--- a/modular/signer/signer_client.go
+++ b/modular/signer/signer_client.go
@@ -506,10 +506,10 @@ func (client *GreenfieldChainSignClient) UpdateSPPrice(ctx context.Context, scop
 	nonce := client.operatorAccNonce
 
 	msgUpdateStorageSPPrice := &sptypes.MsgUpdateSpStoragePrice{
-		km.GetAddr().String(),
-		priceInfo.ReadPrice,
-		priceInfo.FreeReadQuota,
-		priceInfo.StorePrice,
+		SpAddress:     km.GetAddr().String(),
+		ReadPrice:     priceInfo.ReadPrice,
+		FreeReadQuota: priceInfo.FreeReadQuota,
+		StorePrice:    priceInfo.StorePrice,
 	}
 	mode := tx.BroadcastMode_BROADCAST_MODE_SYNC
 	txOpt := &ctypes.TxOption{

--- a/proto/base/types/gfspserver/sign.proto
+++ b/proto/base/types/gfspserver/sign.proto
@@ -5,9 +5,9 @@ import "base/types/gfsperrors/error.proto";
 import "base/types/gfspp2p/p2p.proto";
 import "base/types/gfsptask/task.proto";
 import "cosmos/base/v1beta1/coin.proto";
+import "greenfield/sp/tx.proto";
 import "greenfield/storage/common.proto";
 import "greenfield/storage/tx.proto";
-import "greenfield/sp/tx.proto";
 import "greenfield/virtualgroup/tx.proto";
 
 option go_package = "github.com/bnb-chain/greenfield-storage-provider/base/types/gfspserver";

--- a/proto/base/types/gfspserver/sign.proto
+++ b/proto/base/types/gfspserver/sign.proto
@@ -7,6 +7,7 @@ import "base/types/gfsptask/task.proto";
 import "cosmos/base/v1beta1/coin.proto";
 import "greenfield/storage/common.proto";
 import "greenfield/storage/tx.proto";
+import "greenfield/sp/tx.proto";
 import "greenfield/virtualgroup/tx.proto";
 
 option go_package = "github.com/bnb-chain/greenfield-storage-provider/base/types/gfspserver";
@@ -48,6 +49,7 @@ message GfSpSignRequest {
     greenfield.virtualgroup.MsgCompleteSwapOut complete_swap_out = 19;
     greenfield.virtualgroup.MsgStorageProviderExit sp_exit = 20;
     greenfield.virtualgroup.MsgCompleteStorageProviderExit complete_sp_exit = 21;
+    greenfield.sp.MsgUpdateSpStoragePrice sp_storage_price = 22;
   }
 }
 

--- a/proto/modular/metadata/types/metadata.proto
+++ b/proto/modular/metadata/types/metadata.proto
@@ -285,8 +285,6 @@ message GfSpGetEndpointBySpAddressResponse {
 message GfSpGetBucketReadQuotaRequest {
   // bucket info from the greenfield chain
   greenfield.storage.BucketInfo bucket_info = 1;
-  // year_month is the query bucket quota's month, like "2023-03"
-  string year_month = 2;
 }
 
 // GfSpGetBucketReadQuotaResponse is response type for the GfSpGetBucketReadQuota RPC method.

--- a/store/sqldb/traffic.go
+++ b/store/sqldb/traffic.go
@@ -66,7 +66,7 @@ func (s *SpDBImpl) CheckQuotaAndAddReadRecord(record *corespdb.ReadRecord, quota
 	}
 
 	// the ChargedQuotaSize
-	if bucketTraffic.ReadQuotaSize != quota.ChargedQuotaSize {
+	if bucketTraffic.ChargedQuotaSize != quota.ChargedQuotaSize {
 		// update if chain quota has changed
 		result := s.db.Model(&BucketTrafficTable{}).
 			Where("bucket_id = ?", bucketTraffic.BucketID).
@@ -82,7 +82,7 @@ func (s *SpDBImpl) CheckQuotaAndAddReadRecord(record *corespdb.ReadRecord, quota
 		if result.RowsAffected != 1 {
 			log.Infow("update traffic", "RowsAffected", result.RowsAffected, "record", record, "quota", quota)
 		}
-		bucketTraffic.ReadQuotaSize = quota.ChargedQuotaSize
+		bucketTraffic.ChargedQuotaSize = quota.ChargedQuotaSize
 	}
 
 	recordQuotaCost := record.ReadSize
@@ -198,7 +198,7 @@ func (s *SpDBImpl) GetBucketTraffic(bucketID uint64) (traffic *corespdb.BucketTr
 		FreeQuotaConsumedSize: queryReturn.FreeQuotaConsumedSize,
 		BucketName:            queryReturn.BucketName,
 		ReadConsumedSize:      queryReturn.ReadConsumedSize,
-		ReadQuotaSize:         queryReturn.ChargedQuotaSize,
+		ChargedQuotaSize:      queryReturn.ChargedQuotaSize,
 		ModifyTime:            queryReturn.ModifiedTime.Unix(),
 	}, nil
 }

--- a/store/sqldb/traffic_schema.go
+++ b/store/sqldb/traffic_schema.go
@@ -6,12 +6,13 @@ import (
 
 // BucketTrafficTable table schema
 type BucketTrafficTable struct {
-	BucketID         uint64 `gorm:"primary_key"`
-	Month            string `gorm:"primary_key"`
-	BucketName       string
-	ReadConsumedSize uint64
-	ReadQuotaSize    uint64 // ReadQuotaSize = the greenfield chain bucket quota + the sp default free quota
-	ModifiedTime     time.Time
+	BucketID              uint64 `gorm:"primary_key"`
+	BucketName            string
+	ReadConsumedSize      uint64
+	FreeQuotaConsumedSize uint64 // indicates the consumed free quota size
+	FreeQuotaSize         uint64 // the greenfield chain free quota
+	ChargedQuotaSize      uint64 //the greenfield chain bucket charged quota
+	ModifiedTime          time.Time
 }
 
 // TableName is used to set BucketTraffic Schema's table name in database

--- a/test/e2e/spworkflow/e2e_test.sh
+++ b/test/e2e/spworkflow/e2e_test.sh
@@ -61,7 +61,15 @@ function greenfield_sp() {
   bash ./deployment/localup/localup.sh --generate ${workspace}/greenfield/sp.json ${MYSQL_USER} ${MYSQL_PASSWORD} ${MYSQL_ADDRESS}
   bash ./deployment/localup/localup.sh --reset
   bash ./deployment/localup/localup.sh --start
-  sleep 5
+  sleep 25
+  ./deployment/localup/local_env/sp0/gnfd-sp0 update.quota  --quota 5000000000 -c deployment/localup/local_env/sp0/config.toml
+  ./deployment/localup/local_env/sp1/gnfd-sp1 update.quota  --quota 5000000000 -c deployment/localup/local_env/sp1/config.toml
+  ./deployment/localup/local_env/sp2/gnfd-sp2 update.quota  --quota 5000000000 -c deployment/localup/local_env/sp2/config.toml
+  ./deployment/localup/local_env/sp3/gnfd-sp3 update.quota  --quota 5000000000 -c deployment/localup/local_env/sp3/config.toml
+  ./deployment/localup/local_env/sp4/gnfd-sp4 update.quota  --quota 5000000000 -c deployment/localup/local_env/sp4/config.toml
+  ./deployment/localup/local_env/sp5/gnfd-sp5 update.quota  --quota 5000000000 -c deployment/localup/local_env/sp5/config.toml
+  ./deployment/localup/local_env/sp6/gnfd-sp6 update.quota  --quota 5000000000 -c deployment/localup/local_env/sp6/config.toml
+  ./deployment/localup/local_env/sp7/gnfd-sp7 update.quota  --quota 5000000000 -c deployment/localup/local_env/sp7/config.toml
   tail -n 1000 deployment/localup/local_env/sp0/gnfd-sp.log
   ps -ef | grep gnfd-sp | wc -l
 }
@@ -165,6 +173,7 @@ function test_sp_exit() {
     ./gnfd-cmd -c ./config.toml --home ./ object get gnfd://spexit/random_file  ./new_random_file
     ./gnfd-cmd -c ./config.toml --home ./ object head gnfd://spexit/example.json
     ./gnfd-cmd -c ./config.toml --home ./ object get gnfd://spexit/example.json ./new.json
+
     sleep 10
     check_md5 ${workspace}/test/e2e/spworkflow/testdata/example.json ./new.json
     check_md5 ./random_file ./new_random_file


### PR DESCRIPTION
### Description

1. change the algorithm of quota consumption
The freeQuota will no longer be reset and updated monthly. Instead, it will be fixed based on the value on the chain, and once it is fully consumed, it will not be available anymore.

3. support commands to update free quota
SP can use the command to update his free quota on greenfield

### Rationale

improve the way of quota consume

### Example

NA

### Changes

Notable changes: 
* update quota consumption method
