### PR TITLE
fix: update quota 

### DIFF
--- a/modular/downloader/download_task.go
+++ b/modular/downloader/download_task.go
@@ -209,7 +209,7 @@ func (d *DownloadModular) PreDownloadPiece(ctx context.Context, downloadPieceTas
 	if downloadPieceTask.GetEnableCheck() {
 		// if it is a request from client, the task handler is the primary SP of the sp
 		if d.baseApp.OperatorAddress() == bucketPrimarySp.OperatorAddress {
-			log.CtxDebugw(ctx, "downloading from primary SP, checking quota")
+			log.CtxDebugw(ctx, "downloading from primary SP, checking quota.")
 			checkQuotaTime := time.Now()
 			if err := d.baseApp.GfSpDB().CheckQuotaAndAddReadRecord(
 				&spdb.ReadRecord{


### PR DESCRIPTION
### Description

1. change the algorithm of quota consumption
The freeQuota will no longer be reset and updated monthly. Instead, it will be fixed based on the value on the chain, and once it is fully consumed, it will not be available anymore.

3. support commands to update free quota
SP can use the command to update his free quota on greenfield

### Rationale

improve the way of quota consume

### Example

NA

### Changes

Notable changes: 
* update quota consumption method
