### PR TITLE
release: draft release for v0.2.3-alpha.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.2.3-alpha.3
+
+FEATURES
+* [#824](https://github.com/bnb-chain/greenfield-storage-provider/pull/824) feat: support sp exit and bucket migrate
+* [#856](https://github.com/bnb-chain/greenfield-storage-provider/pull/856) feat: update local virtual group event
+* [#853](https://github.com/bnb-chain/greenfield-storage-provider/pull/853) feat: update greenfield-go-sdk e2e version
+* [#852](https://github.com/bnb-chain/greenfield-storage-provider/pull/852) ci: fix docker-ci.yml to push develop
+* [#865](https://github.com/bnb-chain/greenfield-storage-provider/pull/865) feat: add bucket migrate & sp exit query cli
+
+BUGFIX
+* [#834](https://github.com/bnb-chain/greenfield-storage-provider/pull/834) fix: remove v2 Authorization
+* [#832](https://github.com/bnb-chain/greenfield-storage-provider/pull/832) fix: add checking logic for sig length and public length
+* [#839](https://github.com/bnb-chain/greenfield-storage-provider/pull/839) fix: blocksyncer panic
+* [#847](https://github.com/bnb-chain/greenfield-storage-provider/pull/847) fix: block syncer copy object
+* [#850](https://github.com/bnb-chain/greenfield-storage-provider/pull/850) fix: handle concurrent spdb table creation
+* [#814](https://github.com/bnb-chain/greenfield-storage-provider/pull/814) fix: verify group permission
+* [#858](https://github.com/bnb-chain/greenfield-storage-provider/pull/858) fix: resumable upload maxpayload size bugs
+* [#863](https://github.com/bnb-chain/greenfield-storage-provider/pull/863) fix: optimize piece migration logic to avoid oom
+ 
+
 ## v0.2.3-alpha.2
 FEATURES
 * [#664](https://github.com/bnb-chain/greenfield-storage-provider/pull/664) feat: simulate discontinue transaction before broadcast

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.2.3-alpha.3
+## 0.2.3-alpha.7
 
 FEATURES
 * [#824](https://github.com/bnb-chain/greenfield-storage-provider/pull/824) feat: support sp exit and bucket migrate


### PR DESCRIPTION
### Description

draft release for v0.2.3-alpha.7.

### Rationale

FEATURES
* [#824](https://github.com/bnb-chain/greenfield-storage-provider/pull/824) feat: support sp exit and bucket migrate
* [#856](https://github.com/bnb-chain/greenfield-storage-provider/pull/856) feat: update local virtual group event
* [#853](https://github.com/bnb-chain/greenfield-storage-provider/pull/853) feat: update greenfield-go-sdk e2e version
* [#852](https://github.com/bnb-chain/greenfield-storage-provider/pull/852) ci: fix docker-ci.yml to push develop
* [#865](https://github.com/bnb-chain/greenfield-storage-provider/pull/865) feat: add bucket migrate & sp exit query cli

BUGFIX
* [#834](https://github.com/bnb-chain/greenfield-storage-provider/pull/834) fix: remove v2 Authorization
* [#832](https://github.com/bnb-chain/greenfield-storage-provider/pull/832) fix: add checking logic for sig length and public length
* [#839](https://github.com/bnb-chain/greenfield-storage-provider/pull/839) fix: blocksyncer panic
* [#847](https://github.com/bnb-chain/greenfield-storage-provider/pull/847) fix: block syncer copy object
* [#850](https://github.com/bnb-chain/greenfield-storage-provider/pull/850) fix: handle concurrent spdb table creation
* [#814](https://github.com/bnb-chain/greenfield-storage-provider/pull/814) fix: verify group permission
* [#858](https://github.com/bnb-chain/greenfield-storage-provider/pull/858) fix: resumable upload maxpayload size bugs
* [#863](https://github.com/bnb-chain/greenfield-storage-provider/pull/863) fix: optimize piece migration logic to avoid oom

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
