### PR TITLE
feat: remove ci feat on pr

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,10 +14,8 @@ on:
     branches:
       - master
       - develop
-      - ci-*
       - release*
       - fix-release*
-      - feat-*
 
 jobs:
   build-test:

--- a/.github/workflows/code-lint.yml
+++ b/.github/workflows/code-lint.yml
@@ -16,10 +16,8 @@ on:
     branches:
       - master
       - develop
-      - ci-*
       - release*
       - fix-release*
-      - feat-*
 
 jobs:
   golangci:

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -14,10 +14,8 @@ on:
     branches:
       - master
       - develop
-      - ci-*
       - release*
       - fix-release*
-      - feat-*
 
 jobs:
   # commit-message-lint:

--- a/.github/workflows/e2e-sdk.yml
+++ b/.github/workflows/e2e-sdk.yml
@@ -14,10 +14,8 @@ on:
     branches:
       - master
       - develop
-      - ci-*
       - release*
       - fix-release*
-      - feat-*
 
 jobs:
   e2e-test:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -14,10 +14,8 @@ on:
     branches:
       - master
       - develop
-      - ci-*
       - release*
       - fix-release*
-      - feat-*
 
 jobs:
   e2e-test:

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -15,9 +15,7 @@ on:
       - master
       - develop
       - release*
-      - ci-*
       - fix-release*
-      - feat-*
 
 jobs:
   gosec:

--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -16,11 +16,9 @@ on:
   pull_request:
     branches:
       - master
-      - ci-*
       - develop
       - release*
       - fix-release*
-      - feat-*
 
     paths:
       - 'proto/**'

--- a/.github/workflows/sp-exit-e2e-test.yml
+++ b/.github/workflows/sp-exit-e2e-test.yml
@@ -14,10 +14,8 @@ on:
     branches:
       - master
       - develop
-      - ci-*
       - release*
       - fix-release*
-      - feat-*
 
 jobs:
   e2e-test:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -15,9 +15,7 @@ on:
       - master
       - develop
       - release*
-      - ci-*
       - fix-release*
-      - feat-*
 
 env:
   CGO_CFLAGS: "-O -D__BLST_PORTABLE__"


### PR DESCRIPTION
### Description

Currently,  branches with ci-*, feat-* will trigger several workflow both on push and pull_request, which is unnecessary, as these branches have to first be pushed to origin before creating pull_request. As now most pull request has duplicate workflows running and taking up memory space, we remove the pull_request trigger for ci-* and feat-*.

### Rationale

N/A

### Example

Currently both pull_request and push trigger workflows for ci-* and feat-* branches:

<img width="836" alt="Screen Shot 2023-07-24 at 15 20 01" src="https://github.com/bnb-chain/greenfield-storage-provider/assets/108039750/01408d73-c650-4c2b-93db-bd73fd848122">

### Changes

Notable changes: 
* workflows
