### PR TITLE
fix: private universal endpoint special suffix handle

### DIFF
--- a/modular/gater/const.go
+++ b/modular/gater/const.go
@@ -250,6 +250,14 @@ const (
 	GnfdSecondarySPMigrationBucketApprovalHeader = "X-Gnfd-Secondary-Migration-Bucket-Approval"
 	// SwapOutApprovalPath defines get swap out approval path.
 	SwapOutApprovalPath = "/greenfield/migrate/v1/get-swap-out-approval"
+	// ObjectXmlSuffix defines the object has xml suffix
+	ObjectXmlSuffix = "xml"
+	// ObjectPdfSuffix defines the object has pdf suffix
+	ObjectPdfSuffix = "pdf"
+	// UniversalEndpointSpecialSuffixQuery defines the query of universal endpoint with special suffix
+	UniversalEndpointSpecialSuffixQuery = "objectPath"
+	// objectSpecialSuffixUrlReplacement defines the replacement part for universal endpoint object url with special suffix
+	objectSpecialSuffixUrlReplacement = "?" + UniversalEndpointSpecialSuffixQuery + "="
 )
 
 const (

--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -764,7 +764,7 @@ func (g *GateModular) getObjectByUniversalEndpointHandler(w http.ResponseWriter,
 		splitSuffix := splitPeriod[len(splitPeriod)-1]
 		if !strings.Contains(r.RequestURI, objectSpecialSuffixUrlReplacement) &&
 			(strings.EqualFold(splitSuffix, ObjectPdfSuffix) || strings.EqualFold(splitSuffix, ObjectXmlSuffix)) {
-			objectPathRequestURL := strings.Replace(r.RequestURI, "/", objectSpecialSuffixUrlReplacement, 1)
+			objectPathRequestURL := "/" + strings.Replace(r.RequestURI[1:], "/", objectSpecialSuffixUrlReplacement, 1)
 			redirectURL = spEndpoint + objectPathRequestURL
 			log.Debugw("getting redirect url for private object:", "redirectURL", redirectURL)
 			http.Redirect(w, r, redirectURL, 302)

--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -629,16 +629,18 @@ func (g *GateModular) queryUploadProgressHandler(w http.ResponseWriter, r *http.
 // getObjectByUniversalEndpointHandler handles the get object request sent by universal endpoint
 func (g *GateModular) getObjectByUniversalEndpointHandler(w http.ResponseWriter, r *http.Request, isDownload bool) {
 	var (
-		err           error
-		reqCtx        *RequestContext
-		authenticated bool
-		isRange       bool
-		rangeStart    int64
-		rangeEnd      int64
-		// redirectURL          string
+		err                  error
+		reqCtx               *RequestContext
+		authenticated        bool
+		isRange              bool
+		rangeStart           int64
+		rangeEnd             int64
+		redirectURL          string
 		params               *storagetypes.Params
 		escapedObjectName    string
 		isRequestFromBrowser bool
+		spEndpoint           string
+		getEndpointErr       error
 	)
 	startTime := time.Now()
 	defer func() {
@@ -726,14 +728,14 @@ func (g *GateModular) getObjectByUniversalEndpointHandler(w http.ResponseWriter,
 			err = ErrConsensus
 			return
 		}
-		spEndpoint, getEndpointErr := g.baseApp.GfSpClient().GetEndpointBySpAddress(reqCtx.Context(), sp.OperatorAddress)
+		spEndpoint, getEndpointErr = g.baseApp.GfSpClient().GetEndpointBySpAddress(reqCtx.Context(), sp.OperatorAddress)
 		if getEndpointErr != nil || spEndpoint == "" {
 			log.Errorw("failed to get endpoint by address ", "sp_address", reqCtx.bucketName, "error", getEndpointErr)
 			err = getEndpointErr
 			return
 		}
 
-		redirectURL := spEndpoint + r.RequestURI
+		redirectURL = spEndpoint + r.RequestURI
 		log.Debugw("getting redirect url:", "redirectURL", redirectURL)
 
 		http.Redirect(w, r, redirectURL, 302)
@@ -758,6 +760,17 @@ func (g *GateModular) getObjectByUniversalEndpointHandler(w http.ResponseWriter,
 			expiry    string
 			signature string
 		)
+		splitPeriod := strings.Split(r.RequestURI, ".")
+		splitSuffix := splitPeriod[len(splitPeriod)-1]
+		if !strings.Contains(r.RequestURI, objectSpecialSuffixUrlReplacement) &&
+			(strings.EqualFold(splitSuffix, ObjectPdfSuffix) || strings.EqualFold(splitSuffix, ObjectXmlSuffix)) {
+			objectPathRequestURL := strings.Replace(r.RequestURI, "/", objectSpecialSuffixUrlReplacement, 1)
+			redirectURL = spEndpoint + objectPathRequestURL
+			log.Debugw("getting redirect url for private object:", "redirectURL", redirectURL)
+			http.Redirect(w, r, redirectURL, 302)
+			return
+		}
+
 		queryParams := r.URL.Query()
 		if queryParams["expiry"] != nil {
 			expiry = queryParams["expiry"][0]

--- a/modular/gater/router.go
+++ b/modular/gater/router.go
@@ -116,9 +116,13 @@ func (g *GateModular) RegisterHandler(router *mux.Router) {
 	// universal endpoint download
 	router.Path("/download/{bucket:[^/]*}/{object:.+}").Name(downloadObjectByUniversalEndpointName).Methods(http.MethodGet).
 		HandlerFunc(g.downloadObjectByUniversalEndpointHandler)
+	router.Path("/download").Name(downloadObjectByUniversalEndpointName).Methods(http.MethodGet).
+		Queries(UniversalEndpointSpecialSuffixQuery, "{bucket:[^/]*}/{object:.+}").HandlerFunc(g.downloadObjectByUniversalEndpointHandler)
 	// universal endpoint view
 	router.Path("/view/{bucket:[^/]*}/{object:.+}").Name(viewObjectByUniversalEndpointName).Methods(http.MethodGet).
 		HandlerFunc(g.viewObjectByUniversalEndpointHandler)
+	router.Path("/view").Name(viewObjectByUniversalEndpointName).Methods(http.MethodGet).
+		Queries(UniversalEndpointSpecialSuffixQuery, "{bucket:[^/]*}/{object:.+}").HandlerFunc(g.viewObjectByUniversalEndpointHandler)
 
 	var routers []*mux.Router
 	routers = append(routers, router.Host("{bucket:.+}."+g.domain).Subrouter())


### PR DESCRIPTION
### Description

Fix issue where pdf and xml private universal endpoint not compatible with metamask plugin by changing to special url.

### Rationale

N/A

### Example

 https://gnfd-testnet-sp-3.bnbchain.org/download/articles/whale.pdf ->
 https://gnfd-testnet-sp-3.bnbchain.org/download?objectPath=articles/whale.pdf

### Changes

Notable changes: 
* object handler
* router
