### PR TITLE
fix: universal endpoint escape

### DIFF
--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -6,7 +6,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -637,7 +636,6 @@ func (g *GateModular) getObjectByUniversalEndpointHandler(w http.ResponseWriter,
 		rangeEnd             int64
 		redirectURL          string
 		params               *storagetypes.Params
-		escapedObjectName    string
 		isRequestFromBrowser bool
 		spEndpoint           string
 		getEndpointErr       error
@@ -683,18 +681,12 @@ func (g *GateModular) getObjectByUniversalEndpointHandler(w http.ResponseWriter,
 	// ignore the error, because the universal endpoint does not need signature
 	reqCtx, _ = NewRequestContext(r, g)
 
-	escapedObjectName, err = url.PathUnescape(reqCtx.objectName)
-	if err != nil {
-		log.Errorw("failed to unescape object name ", "object_name", reqCtx.objectName, "error", err)
-		return
-	}
-
 	if err = s3util.CheckValidBucketName(reqCtx.bucketName); err != nil {
 		log.Errorw("failed to check bucket name", "bucket_name", reqCtx.bucketName, "error", err)
 		return
 	}
-	if err = s3util.CheckValidObjectName(escapedObjectName); err != nil {
-		log.Errorw("failed to check object name", "object_name", escapedObjectName, "error", err)
+	if err = s3util.CheckValidObjectName(reqCtx.objectName); err != nil {
+		log.Errorw("failed to check object name", "object_name", reqCtx.objectName, "error", err)
 		return
 	}
 
@@ -741,9 +733,9 @@ func (g *GateModular) getObjectByUniversalEndpointHandler(w http.ResponseWriter,
 		http.Redirect(w, r, redirectURL, 302)
 		return
 	}
-	getObjectInfoRes, err := g.baseApp.GfSpClient().GetObjectMeta(reqCtx.Context(), escapedObjectName, reqCtx.bucketName, true)
+	getObjectInfoRes, err := g.baseApp.GfSpClient().GetObjectMeta(reqCtx.Context(), reqCtx.objectName, reqCtx.bucketName, true)
 	if err != nil || getObjectInfoRes == nil || getObjectInfoRes.GetObjectInfo() == nil {
-		log.Errorw("failed to check object meta", "object_name", escapedObjectName, "error", err)
+		log.Errorw("failed to check object meta", "object_name", reqCtx.objectName, "error", err)
 		err = ErrNoSuchObject
 		return
 	}
@@ -877,7 +869,7 @@ func (g *GateModular) getObjectByUniversalEndpointHandler(w http.ResponseWriter,
 	}
 
 	if isDownload {
-		w.Header().Set(ContentDispositionHeader, ContentDispositionAttachmentValue+"; filename=\""+escapedObjectName+"\"")
+		w.Header().Set(ContentDispositionHeader, ContentDispositionAttachmentValue+"; filename=\""+reqCtx.objectName+"\"")
 	} else {
 		w.Header().Set(ContentDispositionHeader, ContentDispositionInlineValue)
 	}


### PR DESCRIPTION
### Description

After refactor, the escape of object name is already done in reqContext, and doing it one more time might cause error. Thus removing the duplicate.

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 
* object handler (universal endpoint)
