### PR TITLE
feat: pick sp gvg not exiting

### DIFF
--- a/modular/manager/bucket_migrate_scheduler.go
+++ b/modular/manager/bucket_migrate_scheduler.go
@@ -438,6 +438,32 @@ func (s *BucketMigrateScheduler) createGlobalVirtualGroupForBucketMigrate(vgfID 
 	})
 }
 
+// replace SecondarySp which is in STATUS_GRACEFUL_EXITING
+func (s *BucketMigrateScheduler) replaceExitingSP(secondarySPIDs []uint32) ([]uint32, error) {
+	replacedSPIDs := secondarySPIDs
+	excludedSPIDs := secondarySPIDs
+
+	for idx, spID := range secondarySPIDs {
+		sp, err := s.manager.virtualGroupManager.QuerySPByID(spID)
+		if err != nil {
+			log.Errorw("failed to query sp", "error", err)
+			return nil, err
+		}
+		if sp.Status == sptypes.STATUS_GRACEFUL_EXITING {
+			replacedSP, pickErr := s.manager.virtualGroupManager.PickSPByFilter(NewPickDestSPFilterWithSlice(excludedSPIDs))
+			if pickErr != nil {
+				log.Errorw("failed to pick new sp to replace exiting secondary sp", "excludedSPIDs", excludedSPIDs, "error", pickErr)
+				return nil, pickErr
+			}
+			replacedSPIDs[idx] = replacedSP.GetId()
+			excludedSPIDs = append(excludedSPIDs, replacedSP.GetId())
+		}
+	}
+
+	return replacedSPIDs, nil
+
+}
+
 func (s *BucketMigrateScheduler) produceBucketMigrateExecutePlan(event *storagetypes.EventMigrationBucket) (*BucketMigrateExecutePlan, error) {
 	var (
 		primarySPGVGList []*virtualgrouptypes.GlobalVirtualGroup
@@ -480,7 +506,14 @@ func (s *BucketMigrateScheduler) produceBucketMigrateExecutePlan(event *storaget
 	destFamilyID = 0
 	log.Debugw("produceBucketMigrateExecutePlan list", "primarySPGVGList", primarySPGVGList, "len:", len(primarySPGVGList))
 	for _, srcGVG := range primarySPGVGList {
-		secondarySPIDs := srcGVG.GetSecondarySpIds()
+		srcSecondarySPIDs := srcGVG.GetSecondarySpIds()
+		// check sp exiting
+		secondarySPIDs, err := s.replaceExitingSP(srcSecondarySPIDs)
+		if err != nil {
+			log.Errorw("pick sp to replace exiting sp error", "srcSecondarySPIDs", srcSecondarySPIDs, "secondarySPIDs", secondarySPIDs)
+			return nil, err
+		}
+
 		// check conflicts.
 		conflictedIndex, errNotInSecondarySPs := util.GetSecondarySPIndexFromGVG(srcGVG, destSP.GetId())
 		log.Debugw("produceBucketMigrateExecutePlan prepare to check conflicts", "srcGVG", srcGVG, "destSP", destSP, "conflictedIndex", conflictedIndex, "errNotInSecondarySPs", errNotInSecondarySPs)


### PR DESCRIPTION
### Description

pick sp gvg not exiting.

### Rationale

During the bucket migration process, we have a source Global Virtual Group (GVG) with a list of members [3, 1, 2, 4, 5, 6, 7]. The goal is to organize the destination GVG by replacing any member from the source GVG that is in STATUS_GRACEFUL_EXITING.
To achieve this, we compare the members of the source GVG with the destination GVG. If we find a member from the source GVG that is in STATUS_GRACEFUL_EXITING, we replace it in the destination GVG. 

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
