### PR TITLE
fix: universal endpoint redirect using bucket's real endpoint

### DIFF
--- a/base/gfspclient/metadata.go
+++ b/base/gfspclient/metadata.go
@@ -288,18 +288,18 @@ func (s *GfSpClient) GetBucketMeta(ctx context.Context, bucketName string, inclu
 	return resp.GetBucket(), resp.GetStreamRecord(), nil
 }
 
-// GetEndpointBySpAddress get endpoint by sp address
-func (s *GfSpClient) GetEndpointBySpAddress(ctx context.Context, spAddress string, opts ...grpc.DialOption) (string, error) {
+// GetEndpointBySpId get endpoint by sp id
+func (s *GfSpClient) GetEndpointBySpId(ctx context.Context, spId uint32, opts ...grpc.DialOption) (string, error) {
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
 		return "", ErrRpcUnknown
 	}
 	defer conn.Close()
-	req := &types.GfSpGetEndpointBySpAddressRequest{
-		SpAddress: spAddress,
+	req := &types.GfSpGetEndpointBySpIdRequest{
+		SpId: spId,
 	}
-	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetEndpointBySpAddress(ctx, req)
+	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetEndpointBySpId(ctx, req)
 	ctx = log.Context(ctx, resp)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to send get sp by address rpc", "error", err)

--- a/core/spdb/spdb.go
+++ b/core/spdb/spdb.go
@@ -101,6 +101,8 @@ type SPInfoDB interface {
 	GetSpByAddress(address string, addressType SpAddressType) (*sptypes.StorageProvider, error)
 	// GetSpByEndpoint return sp info by endpoint.
 	GetSpByEndpoint(endpoint string) (*sptypes.StorageProvider, error)
+	// GetSpById return sp info by id.
+	GetSpById(id uint32) (*sptypes.StorageProvider, error)
 	// GetOwnSpInfo return own sp info.
 	GetOwnSpInfo() (*sptypes.StorageProvider, error)
 	// SetOwnSpInfo set(maybe overwrite) own sp info.

--- a/core/spdb/spdb_mock.go
+++ b/core/spdb/spdb_mock.go
@@ -588,6 +588,21 @@ func (mr *MockSPInfoDBMockRecorder) GetSpByEndpoint(endpoint interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSpByEndpoint", reflect.TypeOf((*MockSPInfoDB)(nil).GetSpByEndpoint), endpoint)
 }
 
+// GetSpById mocks base method.
+func (m *MockSPInfoDB) GetSpById(id uint32) (*types0.StorageProvider, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSpById", id)
+	ret0, _ := ret[0].(*types0.StorageProvider)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSpById indicates an expected call of GetSpById.
+func (mr *MockSPInfoDBMockRecorder) GetSpById(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSpById", reflect.TypeOf((*MockSPInfoDB)(nil).GetSpById), id)
+}
+
 // SetOwnSpInfo mocks base method.
 func (m *MockSPInfoDB) SetOwnSpInfo(sp *types0.StorageProvider) error {
 	m.ctrl.T.Helper()
@@ -1244,6 +1259,21 @@ func (m *MockSPDB) GetSpByEndpoint(endpoint string) (*types0.StorageProvider, er
 func (mr *MockSPDBMockRecorder) GetSpByEndpoint(endpoint interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSpByEndpoint", reflect.TypeOf((*MockSPDB)(nil).GetSpByEndpoint), endpoint)
+}
+
+// GetSpById mocks base method.
+func (m *MockSPDB) GetSpById(id uint32) (*types0.StorageProvider, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSpById", id)
+	ret0, _ := ret[0].(*types0.StorageProvider)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSpById indicates an expected call of GetSpById.
+func (mr *MockSPDBMockRecorder) GetSpById(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSpById", reflect.TypeOf((*MockSPDB)(nil).GetSpById), id)
 }
 
 // GetUploadMetasToReplicate mocks base method.

--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -1,7 +1,6 @@
 package gater
 
 import (
-	"context"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
@@ -714,15 +713,10 @@ func (g *GateModular) getObjectByUniversalEndpointHandler(w http.ResponseWriter,
 			"bucket_sp_id", bucketSPID, "self_sp_id", spID,
 		)
 
-		// TODO might need to edit GetEndpointBySpId to reduce call to chain
-		sp, queryErr := g.baseApp.Consensus().QuerySPByID(context.Background(), spID)
-		if queryErr != nil {
-			err = ErrConsensus
-			return
-		}
-		spEndpoint, getEndpointErr = g.baseApp.GfSpClient().GetEndpointBySpAddress(reqCtx.Context(), sp.OperatorAddress)
+		// get the endpoint where the bucket actually is in
+		spEndpoint, getEndpointErr = g.baseApp.GfSpClient().GetEndpointBySpId(reqCtx.Context(), bucketSPID)
 		if getEndpointErr != nil || spEndpoint == "" {
-			log.Errorw("failed to get endpoint by address ", "sp_address", reqCtx.bucketName, "error", getEndpointErr)
+			log.Errorw("failed to get endpoint by id ", "sp_id", bucketSPID, "error", getEndpointErr)
 			err = getEndpointErr
 			return
 		}

--- a/modular/metadata/metadata_sp_service.go
+++ b/modular/metadata/metadata_sp_service.go
@@ -9,27 +9,26 @@ import (
 	"github.com/forbole/juno/v4/common"
 	"gorm.io/gorm"
 
-	"github.com/bnb-chain/greenfield-storage-provider/core/spdb"
 	"github.com/bnb-chain/greenfield-storage-provider/modular/metadata/types"
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
 	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
 )
 
-// GfSpGetEndpointBySpAddress get endpoint by sp address
-func (r *MetadataModular) GfSpGetEndpointBySpAddress(
+// GfSpGetEndpointBySpId get endpoint by sp id
+func (r *MetadataModular) GfSpGetEndpointBySpId(
 	ctx context.Context,
-	req *types.GfSpGetEndpointBySpAddressRequest) (
-	resp *types.GfSpGetEndpointBySpAddressResponse, err error) {
+	req *types.GfSpGetEndpointBySpIdRequest) (
+	resp *types.GfSpGetEndpointBySpIdResponse, err error) {
 	ctx = log.Context(ctx, req)
 
-	sp, err := r.baseApp.GfSpDB().GetSpByAddress(req.SpAddress, spdb.OperatorAddressType)
+	sp, err := r.baseApp.GfSpDB().GetSpById(req.SpId)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get sp", "error", err)
 		return
 	}
 
-	resp = &types.GfSpGetEndpointBySpAddressResponse{Endpoint: sp.Endpoint}
-	log.CtxInfow(ctx, "succeed to get endpoint by a sp address")
+	resp = &types.GfSpGetEndpointBySpIdResponse{Endpoint: sp.Endpoint}
+	log.CtxInfow(ctx, "succeed to get endpoint by a sp id")
 	return resp, nil
 }
 

--- a/proto/modular/metadata/types/metadata.proto
+++ b/proto/modular/metadata/types/metadata.proto
@@ -269,14 +269,14 @@ message GfSpGetBucketMetaResponse {
   greenfield.payment.StreamRecord stream_record = 2;
 }
 
-// GfSpGetEndpointBySpAddressRequest is request type for the GfSpGetEndpointBySpAddress RPC method
-message GfSpGetEndpointBySpAddressRequest {
-  // sp_address is the address of the sp
-  string sp_address = 1;
+// GfSpGetEndpointBySpIdRequest is request type for the GfSpGetEndpointBySpId RPC method
+message GfSpGetEndpointBySpIdRequest {
+  // sp_id is the id of the sp
+  uint32 sp_id = 1;
 }
 
-// GfSpGetEndpointBySpAddressResponse is response type for the GfSpGetEndpointBySpAddress RPC method.
-message GfSpGetEndpointBySpAddressResponse {
+// GfSpGetEndpointBySpIdResponse is response type for the GfSpGetEndpointBySpId RPC method.
+message GfSpGetEndpointBySpIdResponse {
   // endpoint defines endpoint of a sp
   string endpoint = 1;
 }
@@ -669,7 +669,7 @@ service GfSpMetadataService {
   rpc GfSpGetPaymentByBucketID(GfSpGetPaymentByBucketIDRequest) returns (GfSpGetPaymentByBucketIDResponse) {}
   rpc GfSpVerifyPermission(greenfield.storage.QueryVerifyPermissionRequest) returns (greenfield.storage.QueryVerifyPermissionResponse) {}
   rpc GfSpGetBucketMeta(GfSpGetBucketMetaRequest) returns (GfSpGetBucketMetaResponse) {}
-  rpc GfSpGetEndpointBySpAddress(GfSpGetEndpointBySpAddressRequest) returns (GfSpGetEndpointBySpAddressResponse) {}
+  rpc GfSpGetEndpointBySpId(GfSpGetEndpointBySpIdRequest) returns (GfSpGetEndpointBySpIdResponse) {}
   rpc GfSpGetBucketReadQuota(GfSpGetBucketReadQuotaRequest) returns (GfSpGetBucketReadQuotaResponse) {}
   rpc GfSpListBucketReadRecord(GfSpListBucketReadRecordRequest) returns (GfSpListBucketReadRecordResponse) {}
   rpc GfSpQueryUploadProgress(GfSpQueryUploadProgressRequest) returns (GfSpQueryUploadProgressResponse) {}

--- a/store/sqldb/sp.go
+++ b/store/sqldb/sp.go
@@ -255,6 +255,36 @@ func (s *SpDBImpl) GetSpByEndpoint(endpoint string) (*sptypes.StorageProvider, e
 	}, nil
 }
 
+// GetSpById query sp info by id
+func (s *SpDBImpl) GetSpById(id uint32) (*sptypes.StorageProvider, error) {
+	queryReturn := &SpInfoTable{}
+	result := s.db.First(queryReturn, "id = ? and is_own = false", id)
+	if result.Error != nil {
+		return nil, fmt.Errorf("failed to query sp info table by id: %s", result.Error)
+	}
+	totalDeposit, ok := sdkmath.NewIntFromString(queryReturn.TotalDeposit)
+	if !ok {
+		return nil, fmt.Errorf("failed to parse int")
+	}
+	return &sptypes.StorageProvider{
+		Id:              queryReturn.ID,
+		OperatorAddress: queryReturn.OperatorAddress,
+		FundingAddress:  queryReturn.FundingAddress,
+		SealAddress:     queryReturn.SealAddress,
+		ApprovalAddress: queryReturn.ApprovalAddress,
+		TotalDeposit:    totalDeposit,
+		Status:          sptypes.Status(queryReturn.Status),
+		Endpoint:        queryReturn.Endpoint,
+		Description: sptypes.Description{
+			Moniker:         queryReturn.Moniker,
+			Identity:        queryReturn.Identity,
+			Website:         queryReturn.Website,
+			SecurityContact: queryReturn.SecurityContact,
+			Details:         queryReturn.Details,
+		},
+	}, nil
+}
+
 // GetOwnSpInfo query own sp info in db
 func (s *SpDBImpl) GetOwnSpInfo() (*sptypes.StorageProvider, error) {
 	queryReturn := &SpInfoTable{}


### PR DESCRIPTION
### Description

Fix the mistakenly changed redirect logic of Universal Endpoint, to redirect to Bucket's endpoint, not own sp's endpoint.

As the structs changed and it is easier to get SpId of a bucket comparing with SpOperatorAddress, we also change metadata's method of getting SpEndpoint to input SpId directly, and add a new query in spdb for getting sp by spId. 

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 
* object handler (universal endpoint)