### PR TITLE
fix: add content-disposition for off-chain download 

### DIFF
--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -406,6 +406,7 @@ func (g *GateModular) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 		r.Header.Set(GnfdUserAddressHeader, gnfdUserParam)
 		r.Header.Set(GnfdOffChainAuthAppDomainHeader, gnfdOffChainAuthAppDomainParam)
 		r.Header.Set(GnfdAuthorizationHeader, gnfdAuthorizationParam)
+		w.Header().Set(ContentDispositionHeader, ContentDispositionAttachmentValue+"; filename=\""+reqCtx.objectName+"\"")
 	}
 
 	reqCtx, reqCtxErr = NewRequestContext(r, g)

--- a/modular/gater/router_test.go
+++ b/modular/gater/router_test.go
@@ -325,6 +325,22 @@ func TestRouters(t *testing.T) {
 			wantedRouterName: viewObjectByUniversalEndpointName,
 		},
 		{
+			name:             "universal endpoint download pdf/xml special router",
+			router:           gwRouter,
+			method:           http.MethodGet,
+			url:              scheme + testDomain + "/download" + objectSpecialSuffixUrlReplacement + "test_bucket_name/test_object_name",
+			shouldMatch:      true,
+			wantedRouterName: downloadObjectByUniversalEndpointName,
+		},
+		{
+			name:             "universal endpoint view pdf/xml special router",
+			router:           gwRouter,
+			method:           http.MethodGet,
+			url:              scheme + testDomain + "/view" + objectSpecialSuffixUrlReplacement + "test_bucket_name/test_object_name",
+			shouldMatch:      true,
+			wantedRouterName: viewObjectByUniversalEndpointName,
+		},
+		{
 			name:             "offchain-auth request nonce router",
 			router:           gwRouter,
 			method:           http.MethodGet,


### PR DESCRIPTION
### Description

Add content-disposition as attachment, so that he newly added query param auth method for off-chain auth can have consistent download experience with the existing header auth method.

Also add the unit tests of new apis introduced in https://github.com/bnb-chain/greenfield-storage-provider/pull/897

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 
* object handler (getObject)
