### PR TITLE
refactor : migrate bucket fix v0.2.3

### DIFF
--- a/base/gfspvgmgr/virtual_group_manager.go
+++ b/base/gfspvgmgr/virtual_group_manager.go
@@ -134,10 +134,7 @@ func (vgfm *virtualGroupFamilyManager) pickGlobalVirtualGroupForBucketMigrate(fi
 		}
 		for _, gvg := range vgf.GVGMap {
 			log.Debugw("prepare to add pickGlobalVirtualGroupForBucketMigrate", "gvg", gvg)
-			if filter.CheckGVG(&vgmgr.GlobalVirtualGroupMeta{
-				SecondarySPIDs:     gvg.SecondarySPIDs,
-				StakingStorageSize: gvg.StakingStorageSize,
-			}) {
+			if filter.CheckGVG(gvg) {
 				picker.addGlobalVirtualGroup(gvg)
 				log.Debugw("add pickGlobalVirtualGroupForBucketMigrate", "gvg", gvg)
 			}

--- a/modular/manager/bucket_migrate_scheduler.go
+++ b/modular/manager/bucket_migrate_scheduler.go
@@ -313,7 +313,7 @@ func (s *BucketMigrateScheduler) processEvents(migrateBucketEvents *types.ListMi
 			}
 		}
 		// when receive CompleteMigrationBucket/ event, we should delete memory & db's status
-		s.deleteExecutePlanByBucketID(migrateBucketEvents.CancelEvents.BucketId.Uint64())
+		s.deleteExecutePlanByBucketID(migrateBucketEvents.CompleteEvents.BucketId.Uint64())
 		executePlan.stopSPSchedule()
 		return err
 	}

--- a/modular/manager/bucket_migrate_scheduler.go
+++ b/modular/manager/bucket_migrate_scheduler.go
@@ -306,7 +306,7 @@ func (s *BucketMigrateScheduler) checkBucketFromChain(bucketName string, expecte
 func (s *BucketMigrateScheduler) processEvents(migrateBucketEvents *types.ListMigrateBucketEvents) error {
 	// 1. process CancelEvents
 	if migrateBucketEvents.CancelEvents != nil {
-		err := s.checkBucketFromChain(migrateBucketEvents.CancelEvents.BucketName, storagetypes.BUCKET_STATUS_MIGRATING)
+		err := s.checkBucketFromChain(migrateBucketEvents.CancelEvents.BucketName, storagetypes.BUCKET_STATUS_CREATED)
 		if err != nil {
 			return err
 		}

--- a/modular/manager/bucket_migrate_scheduler.go
+++ b/modular/manager/bucket_migrate_scheduler.go
@@ -305,10 +305,6 @@ func (s *BucketMigrateScheduler) checkBucketFromChain(bucketName string, expecte
 }
 
 func (s *BucketMigrateScheduler) processEvents(migrateBucketEvents *types.ListMigrateBucketEvents) error {
-	// skip pair [Events, CancelEvents] or [Events, CompleteEvents]
-	if (migrateBucketEvents.CancelEvents != nil && migrateBucketEvents.Events != nil) || (migrateBucketEvents.CompleteEvents != nil && migrateBucketEvents.Events != nil) {
-		return nil
-	}
 	// 1. process CancelEvents
 	if migrateBucketEvents.CancelEvents != nil {
 		expected, err := s.checkBucketFromChain(migrateBucketEvents.CancelEvents.BucketName, storagetypes.BUCKET_STATUS_CREATED)

--- a/modular/manager/bucket_migrate_scheduler.go
+++ b/modular/manager/bucket_migrate_scheduler.go
@@ -183,7 +183,7 @@ func (plan *BucketMigrateExecutePlan) getBlsAggregateSigForBucketMigration(ctx c
 }
 
 func (plan *BucketMigrateExecutePlan) startSPSchedule() {
-	// dispatch to task-dispatcher, TODO: if CompleteEvents terminate the scheduling
+	// dispatch to task-dispatcher
 	for {
 		select {
 		case <-plan.stopSignal:
@@ -201,7 +201,6 @@ func (plan *BucketMigrateExecutePlan) startSPSchedule() {
 				migrateGVGTask.InitMigrateGVGTask(plan.manager.baseApp.TaskPriority(migrateGVGTask),
 					plan.bucketID, migrateGVGUnit.srcGVG, -1,
 					migrateGVGUnit.srcSP,
-					// TODO if add add a new tasktimeout
 					plan.manager.baseApp.TaskTimeout(migrateGVGTask, 0),
 					plan.manager.baseApp.TaskMaxRetry(migrateGVGTask))
 				migrateGVGTask.SetDestGvg(migrateGVGUnit.destGVG)
@@ -249,7 +248,6 @@ type BucketMigrateScheduler struct {
 	selfSP                    *sptypes.StorageProvider
 	lastSubscribedBlockHeight uint64                               // load from db
 	executePlanIDMap          map[uint64]*BucketMigrateExecutePlan // bucketID -> BucketMigrateExecutePlan
-	isExited                  bool
 }
 
 // NewBucketMigrateScheduler returns a bucket migrate scheduler instance.
@@ -277,7 +275,6 @@ func (s *BucketMigrateScheduler) Init(m *ManageModular) error {
 		return err
 	}
 	s.executePlanIDMap = make(map[uint64]*BucketMigrateExecutePlan)
-	s.isExited = false
 
 	// plan load from db
 	s.loadBucketMigrateExecutePlansFromDB()
@@ -290,77 +287,89 @@ func (s *BucketMigrateScheduler) Start() error {
 	return nil
 }
 
-func (s *BucketMigrateScheduler) subscribeEvents() {
-	subscribeBucketMigrateEventsTicker := time.NewTicker(time.Duration(s.manager.subscribeBucketMigrateEventInterval) * time.Millisecond)
-	for {
-		<-subscribeBucketMigrateEventsTicker.C
-		var (
-			migrationBucketEvents []*types.ListMigrateBucketEvents
-			err                   error
-			executePlan           *BucketMigrateExecutePlan
-		)
-
-		// 1. subscribe migrate bucket events
-		migrationBucketEvents, err = s.manager.baseApp.GfSpClient().ListMigrateBucketEvents(context.Background(), s.lastSubscribedBlockHeight+1, s.selfSP.GetId())
+func (s *BucketMigrateScheduler) processEvents(migrateBucketEvents *types.ListMigrateBucketEvents) error {
+	// when receive chain CompleteMigrationBucket event
+	if migrateBucketEvents.CancelEvents != nil {
+		executePlan, err := s.getExecutePlanByBucketID(migrateBucketEvents.CancelEvents.BucketId.Uint64())
 		if err != nil {
-			log.Errorw("failed to list migrate bucket events", "error", err)
-			continue
+			log.Errorw("bucket migrate schedule received EventCompleteMigrationBucket")
+			return err
+		}
+		// when receive CompleteMigrationBucket/ event, we should delete memory & db's status
+		executePlan.stopSPSchedule()
+	}
+	if migrateBucketEvents.CompleteEvents != nil {
+		executePlan, err := s.getExecutePlanByBucketID(migrateBucketEvents.CompleteEvents.BucketId.Uint64())
+		// check db should be migrated
+		if err != nil {
+			log.Errorw("bucket migrate schedule received EventCompleteMigrationBucket")
+			return err
 		}
 
-		// 2. make plan, start plan
-		for _, migrateBucketEvents := range migrationBucketEvents {
-			// when receive chain CompleteMigrationBucket event
-			if migrateBucketEvents.CompleteEvents != nil {
-				executePlan, err = s.getExecutePlanByBucketID(migrateBucketEvents.CompleteEvents.BucketId.Uint64())
-				// TODO check db should be migrated
-				if err != nil {
-					log.Errorw("bucket migrate schedule received EventCompleteMigrationBucket")
-					continue
-				}
+		for _, unit := range executePlan.gvgUnitMap {
+			if unit.migrateStatus != Migrated {
+				log.Errorw("report task may error, unit should be migrated", "unit", unit)
+			}
+		}
+		// when receive CompleteMigrationBucket/ event, we should delete memory & db's status
+		executePlan.stopSPSchedule()
+		return err
+	}
+	if migrateBucketEvents.Events != nil {
+		if s.executePlanIDMap[migrateBucketEvents.Events.BucketId.Uint64()] != nil {
+			return errors.New("execute plan not exists")
+		}
+		// debug
+		log.Debugw("Bucket Migrate Scheduler process Events", "migrationBucketEvents", migrateBucketEvents.Events, "lastSubscribedBlockHeight", s.lastSubscribedBlockHeight)
 
-				for _, unit := range executePlan.gvgUnitMap {
-					if unit.migrateStatus != Migrated {
-						log.Errorw("report task may error, unit should be migrated", "unit", unit)
-					}
-				}
-				// TODO when receive CompleteMigrationBucket event, we should delete memory & db's status
-				executePlan.stopSPSchedule()
+		executePlan, err := s.produceBucketMigrateExecutePlan(migrateBucketEvents.Events)
+		if err != nil {
+			log.Errorw("failed to produce bucket migrate execute plan", "error", err)
+			return err
+		}
+		if err = executePlan.Start(); err != nil {
+			log.Errorw("failed to start bucket migrate execute plan", "error", err)
+			return err
+		}
+		s.executePlanIDMap[executePlan.bucketID] = executePlan
+	}
+	return nil
+}
+
+func (s *BucketMigrateScheduler) subscribeEvents() {
+	go func() {
+		UpdateBucketMigrateSubscribeProgressFunc := func() {
+			updateErr := s.manager.baseApp.GfSpDB().UpdateBucketMigrateSubscribeProgress(s.lastSubscribedBlockHeight + 1)
+			if updateErr != nil {
+				log.Errorw("failed to update bucket migrate progress", "error", updateErr)
+			}
+			s.lastSubscribedBlockHeight++
+			log.Infow("bucket migrate subscribe progress", "last_subscribed_block_height", s.lastSubscribedBlockHeight)
+		}
+
+		subscribeBucketMigrateEventsTicker := time.NewTicker(time.Duration(s.manager.subscribeBucketMigrateEventInterval) * time.Millisecond)
+		defer subscribeBucketMigrateEventsTicker.Stop()
+		for range subscribeBucketMigrateEventsTicker.C {
+			// 1. subscribe migrate bucket events
+			migrationBucketEvents, subscribeError := s.manager.baseApp.GfSpClient().ListMigrateBucketEvents(context.Background(), s.lastSubscribedBlockHeight+1, s.selfSP.GetId())
+			if subscribeError != nil {
+				log.Errorw("failed to list migrate bucket events", "error", subscribeError)
 				continue
 			}
-			if migrateBucketEvents.Events != nil {
-				// TODO migrating, switch to db
-				if s.executePlanIDMap[migrateBucketEvents.Events.BucketId.Uint64()] != nil {
-					continue
-				}
-				// debug
-				log.Debugw("BucketMigrateScheduler subscribeEvents  ", "migrationBucketEvents", migrateBucketEvents.Events, "lastSubscribedBlockHeight", s.lastSubscribedBlockHeight)
+			log.Infow("loop subscribe bucket migrate event", "sp_exit_events", migrationBucketEvents, "block_id", s.lastSubscribedBlockHeight+1, "sp_address", s.manager.baseApp.OperatorAddress())
 
-				if s.isExited {
-					return
-				}
-				log.Debugf("parse migrateBucketEvents.Events, then produceBucketMigrateExecutePlan")
-				executePlan, err = s.produceBucketMigrateExecutePlan(migrateBucketEvents.Events)
+			// 2. make plan, start plan
+			for _, migrateBucketEvents := range migrationBucketEvents {
+				err := s.processEvents(migrateBucketEvents)
 				if err != nil {
-					log.Errorw("failed to produce bucket migrate execute plan", "error", err)
-					continue
+					log.Errorw("bucket migrate process error", "migrateBucketEvents", migrateBucketEvents, "error", err)
 				}
-				if err = executePlan.Start(); err != nil {
-					log.Errorw("failed to start bucket migrate execute plan", "error", err)
-					continue
-				}
-				s.executePlanIDMap[executePlan.bucketID] = executePlan
 			}
-		}
 
-		// 3.update subscribe progress to db
-		updateErr := s.manager.baseApp.GfSpDB().UpdateBucketMigrateSubscribeProgress(s.lastSubscribedBlockHeight + 1)
-		if updateErr != nil {
-			log.Errorw("failed to update sp exit progress", "error", updateErr)
-			continue
+			// 3.update subscribe progress to db
+			UpdateBucketMigrateSubscribeProgressFunc()
 		}
-
-		s.lastSubscribedBlockHeight++
-	}
+	}()
 }
 
 // pickGlobalVirtualGroupForBucketMigrate is used to pick a suitable gvg for replicating object.
@@ -550,7 +559,6 @@ func (s *BucketMigrateScheduler) getExecutePlanByBucketID(bucketID uint64) (*Buc
 	if ok {
 		return executePlan, nil
 	} else {
-		// TODO
 		return nil, errors.New("no such execute plan")
 	}
 }
@@ -612,15 +620,14 @@ func (s *BucketMigrateScheduler) UpdateMigrateProgress(task task.MigrateGVGTask)
 // loadBucketMigrateExecutePlansFromDB 1) subscribe progress 2) plan progress 3) task progress
 func (s *BucketMigrateScheduler) loadBucketMigrateExecutePlansFromDB() error {
 	var (
-		bucketIDs             []uint64
 		migrationBucketEvents []*types.ListMigrateBucketEvents
 		migrateGVGUnitMeta    []*spdb.MigrateGVGUnitMeta
 		err                   error
 		primarySPGVGList      []*virtualgrouptypes.GlobalVirtualGroup
+		bucketIDs             = make(map[uint64]bool)
 	)
 
-	log.Debug("loadBucketMigrateExecutePlansFromDB start")
-	// get bucket id from metadata, TODO: if you have any good idea
+	// get bucket id from metadata (migrate bucket events)
 	migrationBucketEvents, err = s.manager.baseApp.GfSpClient().ListMigrateBucketEvents(context.Background(), s.lastSubscribedBlockHeight+1, s.selfSP.GetId())
 	if err != nil {
 		log.Errorw("failed to list migrate bucket events", "error", err)
@@ -628,19 +635,17 @@ func (s *BucketMigrateScheduler) loadBucketMigrateExecutePlansFromDB() error {
 	}
 
 	for _, migrateBucketEvents := range migrationBucketEvents {
-		// if has CompleteEvents, skip it
-		if migrateBucketEvents.CompleteEvents != nil {
-			bucketIDs = append(bucketIDs, migrateBucketEvents.Events.BucketId.Uint64())
-			// TODO if completed event construct memory map
-			//continue
+		// if has CompleteEvents & CancelEvents, skip it
+		if migrateBucketEvents.CompleteEvents != nil || migrateBucketEvents.CancelEvents != nil {
+			bucketIDs[migrateBucketEvents.Events.BucketId.Uint64()] = true
 		}
 		if migrateBucketEvents.Events != nil {
-			bucketIDs = append(bucketIDs, migrateBucketEvents.Events.BucketId.Uint64())
+			bucketIDs[migrateBucketEvents.Events.BucketId.Uint64()] = true
 		}
 	}
 	log.Debugw("loadBucketMigrateExecutePlansFromDB", "bucketIDs", bucketIDs)
 	// load from db by BucketID & construct plan
-	for _, bucketID := range bucketIDs {
+	for bucketID := range bucketIDs {
 		migrateGVGUnitMeta, err = s.manager.baseApp.GfSpDB().ListMigrateGVGUnitsByBucketID(bucketID)
 		if err != nil {
 			return err
@@ -649,7 +654,6 @@ func (s *BucketMigrateScheduler) loadBucketMigrateExecutePlansFromDB() error {
 		executePlan := newBucketMigrateExecutePlan(s.manager, bucketID)
 		// Using migrateGVGUnitMeta to construct PrimaryGVGIDMapMigrateUnits and execute them one by one.
 		for _, migrateGVG := range migrateGVGUnitMeta {
-			// TODO may reuse
 			srcSP, queryErr := s.manager.virtualGroupManager.QuerySPByID(migrateGVG.SrcSPID)
 			if queryErr != nil {
 				log.Errorw("failed to query sp", "error", queryErr)
@@ -666,13 +670,15 @@ func (s *BucketMigrateScheduler) loadBucketMigrateExecutePlansFromDB() error {
 				return errors.New("failed to list gvg")
 			}
 			for _, gvg := range primarySPGVGList {
-				bucketUnit := newBucketMigrateGVGExecuteUnit(bucketID, gvg, srcSP, destSP, WaitForMigrate, migrateGVG.DestSPID, migrateGVG.LastMigratedObjectID, nil)
+				bucketUnit := newBucketMigrateGVGExecuteUnit(bucketID, gvg, srcSP, destSP, MigrateStatus(migrateGVG.MigrateStatus), migrateGVG.DestSPID, migrateGVG.LastMigratedObjectID, nil)
 				executePlan.gvgUnitMap[gvg.Id] = bucketUnit
 			}
 		}
 
-		log.Debugw("loadBucketMigrateExecutePlansFromDB", "executePlan", executePlan)
+		log.Debugw("bucket migrate scheduler load from db", "executePlan", executePlan)
 		s.executePlanIDMap[executePlan.bucketID] = executePlan
 	}
+	log.Debugw("Bucket Migrate Scheduler load from db success", "bucketIDs", bucketIDs)
+
 	return err
 }

--- a/modular/manager/bucket_migrate_scheduler.go
+++ b/modular/manager/bucket_migrate_scheduler.go
@@ -359,7 +359,7 @@ func (s *BucketMigrateScheduler) subscribeEvents() {
 				log.Errorw("failed to list migrate bucket events", "block_id", s.lastSubscribedBlockHeight+1, "error", subscribeError)
 				continue
 			}
-			log.Infow("loop subscribe bucket migrate event", "sp_exit_events", migrationBucketEvents, "block_id", s.lastSubscribedBlockHeight+1, "sp_address", s.manager.baseApp.OperatorAddress())
+			log.Infow("loop subscribe bucket migrate event", "migrationBucketEvents", migrationBucketEvents, "block_id", s.lastSubscribedBlockHeight+1, "sp_address", s.manager.baseApp.OperatorAddress())
 
 			// 2. make plan, start plan
 			for _, migrateBucketEvents := range migrationBucketEvents {
@@ -650,7 +650,7 @@ func (s *BucketMigrateScheduler) loadBucketMigrateExecutePlansFromDB() error {
 	for _, migrateBucketEvents := range migrationBucketEvents {
 		// if has CompleteEvents & CancelEvents, skip it
 		if migrateBucketEvents.CompleteEvents != nil || migrateBucketEvents.CancelEvents != nil {
-			bucketIDs[migrateBucketEvents.Events.BucketId.Uint64()] = true
+			bucketIDs[migrateBucketEvents.Events.BucketId.Uint64()] = false
 		}
 		if migrateBucketEvents.Events != nil {
 			bucketIDs[migrateBucketEvents.Events.BucketId.Uint64()] = true
@@ -658,7 +658,10 @@ func (s *BucketMigrateScheduler) loadBucketMigrateExecutePlansFromDB() error {
 	}
 	log.Debugw("loadBucketMigrateExecutePlansFromDB", "bucketIDs", bucketIDs)
 	// load from db by BucketID & construct plan
-	for bucketID := range bucketIDs {
+	for bucketID, exist := range bucketIDs {
+		if !exist {
+			continue
+		}
 		migrateGVGUnitMeta, err = s.manager.baseApp.GfSpDB().ListMigrateGVGUnitsByBucketID(bucketID)
 		if err != nil {
 			return err

--- a/modular/manager/sp_exit_scheduler.go
+++ b/modular/manager/sp_exit_scheduler.go
@@ -1007,7 +1007,6 @@ func (runner *DestSPTaskRunner) startDestSPSchedule() {
 				migrateGVGTask.InitMigrateGVGTask(runner.manager.baseApp.TaskPriority(migrateGVGTask),
 					0, unit.srcGVG, unit.redundancyIndex,
 					unit.srcSP,
-					// TODO if add add a new tasktimeout
 					runner.manager.baseApp.TaskTimeout(migrateGVGTask, 0),
 					runner.manager.baseApp.TaskMaxRetry(migrateGVGTask))
 				if err = runner.manager.migrateGVGQueue.Push(migrateGVGTask); err != nil {


### PR DESCRIPTION
### Description

refactor bucket migration and fix some bugs

### Rationale

* Reorganized the process of subscribeEvents. Upon receiving `CancelEvents` and `CompleteEvents`, they are removed from the `executePlanIDMap` in memory.
* If multiple MigrationBucketEvents are received consecutively, it is considered that the bucket is migrating, and the second event is rejected.
* The background process will repeatedly attempt to process any ongoing MigrationBucketEvents until they are either completed or canceled.

* When loading BucketMigrateExecutePlans, construction is skipped if there are CancelEvents or CompleteEvents.

### Example

NA

### Changes

Notable changes: 
* NA
* ...
