### PR TITLE
fix: filter complete migration buckets

### DIFF
--- a/modular/metadata/metadata_sp_exit_service.go
+++ b/modular/metadata/metadata_sp_exit_service.go
@@ -213,11 +213,13 @@ func (r *MetadataModular) GfSpListMigrateBucketEvents(ctx context.Context, req *
 				BucketId:   math.NewUintFromBigInt(cancel.BucketID.Big()),
 			}
 		}
-		res = append(res, &types.ListMigrateBucketEvents{
-			Events:         spEvent,
-			CompleteEvents: spCompleteEvent,
-			CancelEvents:   spCancelEvent,
-		})
+		if spCompleteEvent == nil {
+			res = append(res, &types.ListMigrateBucketEvents{
+				Events:         spEvent,
+				CompleteEvents: spCompleteEvent,
+				CancelEvents:   spCancelEvent,
+			})
+		}
 	}
 
 	resp = &types.GfSpListMigrateBucketEventsResponse{Events: res}


### PR DESCRIPTION
### Description

filter complete migration buckets from ListMigrateBucketEvents api

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 
* filter complete migration buckets from ListMigrateBucketEvents api