### PR TITLE
fix: replace operation address to sp id sp exit

### DIFF
--- a/base/gfspclient/metadata.go
+++ b/base/gfspclient/metadata.go
@@ -669,7 +669,7 @@ func (s *GfSpClient) ListSwapOutEvents(ctx context.Context, blockID uint64, spID
 	return resp.Events, nil
 }
 
-func (s *GfSpClient) ListSpExitEvents(ctx context.Context, blockID uint64, operatorAddress string, opts ...grpc.DialOption) (*types.ListSpExitEvents, error) {
+func (s *GfSpClient) ListSpExitEvents(ctx context.Context, blockID uint64, spID uint32, opts ...grpc.DialOption) (*types.ListSpExitEvents, error) {
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
@@ -677,8 +677,8 @@ func (s *GfSpClient) ListSpExitEvents(ctx context.Context, blockID uint64, opera
 	}
 	defer conn.Close()
 	req := &types.GfSpListSpExitEventsRequest{
-		BlockId:         blockID,
-		OperatorAddress: operatorAddress,
+		BlockId: blockID,
+		SpId:    spID,
 	}
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpListSpExitEvents(ctx, req)
 	if err != nil {

--- a/modular/manager/sp_exit_scheduler.go
+++ b/modular/manager/sp_exit_scheduler.go
@@ -120,7 +120,7 @@ func (s *SPExitScheduler) Init(m *ManageModular) error {
 		return err
 	}
 	spExitEvents, subscribeError := s.manager.baseApp.GfSpClient().ListSpExitEvents(context.Background(),
-		s.lastSubscribedSPExitBlockHeight, s.manager.baseApp.OperatorAddress())
+		s.lastSubscribedSPExitBlockHeight, s.selfSP.GetId())
 	if subscribeError != nil {
 		log.Errorw("failed to init due to subscribe sp exit", "error", subscribeError)
 		return subscribeError
@@ -327,7 +327,7 @@ func (s *SPExitScheduler) subscribeEvents() {
 		subscribeSPExitEventsTicker := time.NewTicker(time.Duration(s.manager.subscribeSPExitEventInterval) * time.Millisecond)
 		defer subscribeSPExitEventsTicker.Stop()
 		for range subscribeSPExitEventsTicker.C {
-			spExitEvents, subscribeError := s.manager.baseApp.GfSpClient().ListSpExitEvents(context.Background(), s.lastSubscribedSPExitBlockHeight+1, s.manager.baseApp.OperatorAddress())
+			spExitEvents, subscribeError := s.manager.baseApp.GfSpClient().ListSpExitEvents(context.Background(), s.lastSubscribedSPExitBlockHeight+1, s.selfSP.GetId())
 			if subscribeError != nil {
 				log.Errorw("failed to subscribe sp exit event", "error", subscribeError)
 				continue

--- a/modular/metadata/metadata_sp_exit_service.go
+++ b/modular/metadata/metadata_sp_exit_service.go
@@ -406,7 +406,7 @@ func (r *MetadataModular) GfSpListSpExitEvents(ctx context.Context, req *types.G
 		return nil, ErrExceedBlockHeight
 	}
 
-	event, completeEvent, err = r.baseApp.GfBsDB().ListSpExitEvents(req.BlockId, common.HexToAddress(req.OperatorAddress))
+	event, completeEvent, err = r.baseApp.GfBsDB().ListSpExitEvents(req.BlockId, req.SpId)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to list sp exit events", "error", err)
 		return nil, err

--- a/proto/modular/metadata/types/metadata.proto
+++ b/proto/modular/metadata/types/metadata.proto
@@ -626,8 +626,8 @@ message GfSpListGlobalVirtualGroupsByBucketResponse {
 message GfSpListSpExitEventsRequest {
   // block_id is the unique identification for block
   uint64 block_id = 1;
-  // operator_address is the unique identification address for operator
-  string operator_address = 2;
+  // sp_id is the unique identification for sp
+  uint32 sp_id = 2;
 }
 
 // ListSpExitEvents is the combination of sp exit events

--- a/store/bsdb/database.go
+++ b/store/bsdb/database.go
@@ -92,7 +92,7 @@ type Metadata interface {
 	// ListSwapOutEvents list swap out events
 	ListSwapOutEvents(blockID uint64, spID uint32) ([]*EventSwapOut, []*EventCompleteSwapOut, []*EventCancelSwapOut, error)
 	// ListSpExitEvents list sp exit events
-	ListSpExitEvents(blockID uint64, operatorAddress common.Address) (*EventStorageProviderExit, *EventCompleteStorageProviderExit, error)
+	ListSpExitEvents(blockID uint64, spID uint32) (*EventStorageProviderExit, *EventCompleteStorageProviderExit, error)
 	// GetSPByAddress get sp info by operator address
 	GetSPByAddress(operatorAddress common.Address) (*StorageProvider, error)
 }

--- a/store/bsdb/event_sp_exit.go
+++ b/store/bsdb/event_sp_exit.go
@@ -3,12 +3,11 @@ package bsdb
 import (
 	"time"
 
-	"github.com/forbole/juno/v4/common"
 	"gorm.io/gorm"
 )
 
 // ListSpExitEvents list sp exit events
-func (b *BsDBImpl) ListSpExitEvents(blockID uint64, operatorAddress common.Address) (*EventStorageProviderExit, *EventCompleteStorageProviderExit, error) {
+func (b *BsDBImpl) ListSpExitEvents(blockID uint64, spID uint32) (*EventStorageProviderExit, *EventCompleteStorageProviderExit, error) {
 	var (
 		event         *EventStorageProviderExit
 		completeEvent *EventCompleteStorageProviderExit
@@ -26,7 +25,8 @@ func (b *BsDBImpl) ListSpExitEvents(blockID uint64, operatorAddress common.Addre
 
 	err = b.db.Table((&EventStorageProviderExit{}).TableName()).
 		Select("*").
-		Where("operator_address = ? and create_at <= ?", operatorAddress, blockID).
+		Where("storage_provider_id = ? and create_at <= ?", spID, blockID).
+		Order("create_at desc").
 		Take(&event).Error
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
@@ -37,7 +37,8 @@ func (b *BsDBImpl) ListSpExitEvents(blockID uint64, operatorAddress common.Addre
 
 	err = b.db.Table((&EventCompleteStorageProviderExit{}).TableName()).
 		Select("*").
-		Where("operator_address = ? and create_at <= ?", operatorAddress, blockID).
+		Where("storage_provider_id = ? and create_at <= ?", spID, blockID).
+		Order("create_at desc").
 		Take(&completeEvent).Error
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {


### PR DESCRIPTION
### Description

replace operator address to sp id for list sp exit event api

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 
* replace operator address to sp id for list sp exit event api
