### PR TITLE
fix: offchain-auth content-disposition and query param changes

### DIFF
--- a/modular/gater/const.go
+++ b/modular/gater/const.go
@@ -168,6 +168,14 @@ const (
 	// BlockIDQuery defines the block id
 	BlockIDQuery         = "block-id"
 	OperatorAddressQuery = "operator-address"
+	// OffChainAuthAuthorizationQuery defines the authorization query used by offchain-auth
+	OffChainAuthAuthorizationQuery = "authorization"
+	// OffChainAuthUserAddressQuery defines the user address query used by offchain-auth
+	OffChainAuthUserAddressQuery = "user-address"
+	// OffChainAuthAppDomainQuery defines the app domain query used by offchain-auth
+	OffChainAuthAppDomainQuery = "app-domain"
+	// OffChainAuthViewQuery defines the view query used by offchain-auth
+	OffChainAuthViewQuery = "view"
 	// GetChallengeInfoPath defines get challenge info path style suffix
 	GetChallengeInfoPath = "/greenfield/admin/v1/challenge"
 	// ReplicateObjectPiecePath defines replicate-object path style

--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"github.com/gorilla/mux"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/gorilla/mux"
 
 	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsperrors"
 	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsptask"

--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"github.com/gorilla/mux"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -397,16 +399,25 @@ func (g *GateModular) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	queryParams := r.URL.Query()
-	gnfdUserParam := queryParams.Get(GnfdUserAddressHeader)
-	gnfdOffChainAuthAppDomainParam := queryParams.Get(GnfdOffChainAuthAppDomainHeader)
-	gnfdAuthorizationParam := queryParams.Get(GnfdAuthorizationHeader)
+	offChainAuthUserAddressParam := queryParams.Get(OffChainAuthUserAddressQuery)
+	offChainAuthAppDomainParam := queryParams.Get(OffChainAuthAppDomainQuery)
+	offChainAuthAuthorizationParam := queryParams.Get(OffChainAuthAuthorizationQuery)
 
 	// if all required off-chain auth headers are passed in as query params, we fill corresponding headers
-	if gnfdUserParam != "" && gnfdOffChainAuthAppDomainParam != "" && gnfdAuthorizationParam != "" {
-		r.Header.Set(GnfdUserAddressHeader, gnfdUserParam)
-		r.Header.Set(GnfdOffChainAuthAppDomainHeader, gnfdOffChainAuthAppDomainParam)
-		r.Header.Set(GnfdAuthorizationHeader, gnfdAuthorizationParam)
-		w.Header().Set(ContentDispositionHeader, ContentDispositionAttachmentValue+"; filename=\""+reqCtx.objectName+"\"")
+	if offChainAuthUserAddressParam != "" && offChainAuthAppDomainParam != "" && offChainAuthAuthorizationParam != "" {
+		vars := mux.Vars(r)
+		objectName := vars["object"]
+		r.Header.Set(GnfdUserAddressHeader, offChainAuthUserAddressParam)
+		r.Header.Set(GnfdOffChainAuthAppDomainHeader, offChainAuthAppDomainParam)
+		r.Header.Set(GnfdAuthorizationHeader, offChainAuthAuthorizationParam)
+
+		// default set content-disposition to download, if specified in query param as view, then set to view
+		w.Header().Set(ContentDispositionHeader, ContentDispositionAttachmentValue+"; filename=\""+objectName+"\"")
+		offChainAuthViewParam := queryParams.Get(OffChainAuthViewQuery)
+		isView, _ := strconv.ParseBool(offChainAuthViewParam)
+		if isView {
+			w.Header().Set(ContentDispositionHeader, ContentDispositionInlineValue)
+		}
 	}
 
 	reqCtx, reqCtxErr = NewRequestContext(r, g)


### PR DESCRIPTION
### Description

Fix the issue for content-disposition where it used reqCtx before it has value. Also update query params' naming and add "view" as optional query param to switch content-disposition from default download to view.

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 
* object handler
