### PR TITLE
fix: offchain-auth content-disposition and query param changes

### DIFF
--- a/modular/gater/const.go
+++ b/modular/gater/const.go
@@ -168,6 +168,14 @@ const (
 	// BlockIDQuery defines the block id
 	BlockIDQuery         = "block-id"
 	OperatorAddressQuery = "operator-address"
+	// OffChainAuthAuthorizationQuery defines the authorization query used by offchain-auth
+	OffChainAuthAuthorizationQuery = "authorization"
+	// OffChainAuthUserAddressQuery defines the user address query used by offchain-auth
+	OffChainAuthUserAddressQuery = "user-address"
+	// OffChainAuthAppDomainQuery defines the app domain query used by offchain-auth
+	OffChainAuthAppDomainQuery = "app-domain"
+	// OffChainAuthViewQuery defines the view query used by offchain-auth
+	OffChainAuthViewQuery = "view"
 	// GetChallengeInfoPath defines get challenge info path style suffix
 	GetChallengeInfoPath = "/greenfield/admin/v1/challenge"
 	// ReplicateObjectPiecePath defines replicate-object path style

--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -4,13 +4,13 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"github.com/gorilla/mux"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/gorilla/mux"
 
 	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsperrors"
 	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsptask"


### PR DESCRIPTION
### Description

Fix the issue for content-disposition where it used reqCtx before it has value. Also update query params' naming and add "view" as optional query param to switch content-disposition from default download to view.

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 
* object handler
