### PR TITLE
fix: refine migrate gvg task workflow

### DIFF
--- a/base/gfspapp/task_options.go
+++ b/base/gfspapp/task_options.go
@@ -52,9 +52,9 @@ const (
 	// MaxMigratePieceTime defines the max timeout to migrate piece.
 	MaxMigratePieceTime int64 = 50
 	// MinMigrateGVGTime defines the min timeout to migrate gvg.
-	MinMigrateGVGTime int64 = 10
+	MinMigrateGVGTime int64 = 1800 // 0.5 hour
 	// MaxMigrateGVGTime defines the max timeout to migrate gvg.
-	MaxMigrateGVGTime int64 = 50
+	MaxMigrateGVGTime int64 = 3600 // 1 hour
 
 	// NotUseRetry defines the default task max retry.
 	NotUseRetry int64 = 0
@@ -198,6 +198,7 @@ func (g *GfSpBaseApp) TaskTimeout(task coretask.Task, size uint64) int64 {
 		if g.migrateGVGTimeout > MaxMigrateGVGTime {
 			return MaxMigrateGVGTime
 		}
+		return g.migrateGVGTimeout
 	}
 	return NotUseTimeout
 }

--- a/base/types/gfsptask/task.pb.go
+++ b/base/types/gfsptask/task.pb.go
@@ -575,15 +575,14 @@ func (m *GfSpResumableUploadObjectTask) GetVirtualGroupFamilyId() uint32 {
 }
 
 type GfSpReplicatePieceTask struct {
-	Task                *GfSpTask         `protobuf:"bytes,1,opt,name=task,proto3" json:"task,omitempty"`
-	ObjectInfo          *types.ObjectInfo `protobuf:"bytes,2,opt,name=object_info,json=objectInfo,proto3" json:"object_info,omitempty"`
-	StorageParams       *types.Params     `protobuf:"bytes,3,opt,name=storage_params,json=storageParams,proto3" json:"storage_params,omitempty"`
-	SecondaryAddresses  []string          `protobuf:"bytes,4,rep,name=secondary_addresses,json=secondaryAddresses,proto3" json:"secondary_addresses,omitempty"`
-	SecondarySignatures [][]byte          `protobuf:"bytes,5,rep,name=secondary_signatures,json=secondarySignatures,proto3" json:"secondary_signatures,omitempty"`
-	Sealed              bool              `protobuf:"varint,6,opt,name=sealed,proto3" json:"sealed,omitempty"`
-	// TODO: refine it.
-	GlobalVirtualGroupId uint32   `protobuf:"varint,7,opt,name=global_virtual_group_id,json=globalVirtualGroupId,proto3" json:"global_virtual_group_id,omitempty"`
-	SecondaryEndpoints   []string `protobuf:"bytes,8,rep,name=secondary_endpoints,json=secondaryEndpoints,proto3" json:"secondary_endpoints,omitempty"`
+	Task                 *GfSpTask         `protobuf:"bytes,1,opt,name=task,proto3" json:"task,omitempty"`
+	ObjectInfo           *types.ObjectInfo `protobuf:"bytes,2,opt,name=object_info,json=objectInfo,proto3" json:"object_info,omitempty"`
+	StorageParams        *types.Params     `protobuf:"bytes,3,opt,name=storage_params,json=storageParams,proto3" json:"storage_params,omitempty"`
+	SecondaryAddresses   []string          `protobuf:"bytes,4,rep,name=secondary_addresses,json=secondaryAddresses,proto3" json:"secondary_addresses,omitempty"`
+	SecondarySignatures  [][]byte          `protobuf:"bytes,5,rep,name=secondary_signatures,json=secondarySignatures,proto3" json:"secondary_signatures,omitempty"`
+	Sealed               bool              `protobuf:"varint,6,opt,name=sealed,proto3" json:"sealed,omitempty"`
+	GlobalVirtualGroupId uint32            `protobuf:"varint,7,opt,name=global_virtual_group_id,json=globalVirtualGroupId,proto3" json:"global_virtual_group_id,omitempty"`
+	SecondaryEndpoints   []string          `protobuf:"bytes,8,rep,name=secondary_endpoints,json=secondaryEndpoints,proto3" json:"secondary_endpoints,omitempty"`
 }
 
 func (m *GfSpReplicatePieceTask) Reset()         { *m = GfSpReplicatePieceTask{} }

--- a/modular/gater/admin_handler.go
+++ b/modular/gater/admin_handler.go
@@ -400,12 +400,12 @@ func (g *GateModular) replicateHandler(w http.ResponseWriter, r *http.Request) {
 			metrics.ReqTime.WithLabelValues(GatewayFailureReplicatePiece).Observe(time.Since(receivePieceStartTime).Seconds())
 		} else {
 			reqCtx.SetHttpCode(http.StatusOK)
-			log.CtxDebugw(reqCtx.Context(), reqCtx.String())
 			metrics.ReqCounter.WithLabelValues(GatewayTotalSuccess).Inc()
 			metrics.ReqTime.WithLabelValues(GatewayTotalSuccess).Observe(time.Since(receivePieceStartTime).Seconds())
 			metrics.ReqCounter.WithLabelValues(GatewaySuccessReplicatePiece).Inc()
 			metrics.ReqTime.WithLabelValues(GatewaySuccessReplicatePiece).Observe(time.Since(receivePieceStartTime).Seconds())
 		}
+		log.CtxDebugw(reqCtx.Context(), reqCtx.String())
 	}()
 	// ignore the error, because the replicate request only between SPs, the request
 	// verification is by signature of the ReceivePieceTask

--- a/modular/manager/manage_task.go
+++ b/modular/manager/manage_task.go
@@ -609,6 +609,7 @@ func (m *ManageModular) HandleMigrateGVGTask(ctx context.Context, task task.Migr
 		return ErrDanglingTask
 	}
 	var err error
+	task.SetUpdateTime(time.Now().Unix())
 	if task.GetBucketID() != 0 {
 		err = m.bucketMigrateScheduler.UpdateMigrateProgress(task)
 	} else {

--- a/modular/manager/sp_exit_scheduler.go
+++ b/modular/manager/sp_exit_scheduler.go
@@ -177,10 +177,11 @@ func (s *SPExitScheduler) UpdateMigrateProgress(task task.MigrateGVGTask) error 
 	log.Infow("update migrate progress", "gvg_id", task.GetSrcGvg().GetId(), "family_id", task.GetSrcGvg().GetFamilyId(),
 		"finished", task.GetFinished(), "redundancy_idx", task.GetRedundancyIdx(), "last_migrated_object_id", task.GetLastMigratedObjectID())
 	migrateKey = MakeGVGMigrateKey(task.GetSrcGvg().GetId(), task.GetSrcGvg().GetFamilyId(), task.GetRedundancyIdx())
+	if err = s.taskRunner.UpdateMigrateGVGLastMigratedObjectID(migrateKey, task.GetLastMigratedObjectID()); err != nil {
+		return err
+	}
 	if task.GetFinished() {
 		err = s.taskRunner.UpdateMigrateGVGStatus(migrateKey, Migrated)
-	} else {
-		err = s.taskRunner.UpdateMigrateGVGLastMigratedObjectID(migrateKey, task.GetLastMigratedObjectID())
 	}
 	return err
 }

--- a/pkg/metrics/metric_items.go
+++ b/pkg/metrics/metric_items.go
@@ -76,7 +76,9 @@ var MetricsItems = []prometheus.Collector{
 
 	// sp exit and bucket migration category
 	MigrateGVGTimeHistogram,
-	MigrateGVGCouter,
+	MigrateGVGCounter,
+	MigrateObjectTimeHistogram,
+	MigrateObjectCounter,
 }
 
 // basic metrics items
@@ -303,8 +305,17 @@ var (
 		Help:    "Track migrate gvg workflow costs",
 		Buckets: prometheus.DefBuckets,
 	}, []string{"migrate_gvg_time"})
-	MigrateGVGCouter = prometheus.NewCounterVec(prometheus.CounterOpts{
+	MigrateGVGCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "migrate_gvg_counter",
 		Help: "Track migrate gvg number",
 	}, []string{"migrate_gvg_counter"})
+	MigrateObjectTimeHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "migrate_object_time",
+		Help:    "Track migrate object workflow costs",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"migrate_object_time"})
+	MigrateObjectCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "migrate_object_counter",
+		Help: "Track migrate object number",
+	}, []string{"migrate_object_counter"})
 )


### PR DESCRIPTION
### Description

Refine migrate gvg task workflow.

### Rationale

1. Infinitely retry migration tasks in case of failure, only be gc when it is finished.
2. When the task is not updated within a certain period of time, it will be executed by other executors.

### Example

N/A.

### Changes

Notable changes: 
* Refine migrate gvg task retry policy and gc policy.
* Refine some log and add metrics.
