### PR TITLE
fix: add missing path for pprof server

### DIFF
--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -82,4 +82,13 @@ func (p *PProf) registerProfiler(r *mux.Router) {
 	r.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	r.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	r.Handle("/debug/fgprof", fgprof.Handler())
+
+	// Manually add support for paths linked to by index page at /debug/pprof/
+	r.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+	r.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+	r.Handle("/debug/pprof/allocs", pprof.Handler("allocs"))
+	r.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+	r.Handle("/debug/pprof/block", pprof.Handler("block"))
+	r.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
+
 }


### PR DESCRIPTION
### Description

- allocs      : "A sampling of all past memory allocations"
- block       : "Stack traces that led to blocking on synchronization primitives"
- goroutine   : "Stack traces of all current goroutines. Use debug=2 as a query parameter to export in the same format as an unrecovered panic."
- heap        : "A sampling of memory allocations of live objects. You can specify the gc GET parameter to run GC before taking the heap sample."
- mutex       : "Stack traces of holders of contended mutexes"
- threadcreate: "Stack traces that led to the creation of new OS threads"

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
