### PR TITLE
fix: when object not exist, don't return error for queryResumeOffsetHandler

### DIFF
--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -340,12 +340,10 @@ func (g *GateModular) queryResumeOffsetHandler(w http.ResponseWriter, r *http.Re
 	}
 
 	segmentCount, err = g.baseApp.GfSpClient().GetUploadObjectSegment(reqCtx.Context(), objectInfo.Id.Uint64())
-	if err != nil {
+	if err != nil && err.Error() != metadata.ErrNoRecord.String() {
 		// ignore metadata.ErrNoRecord error
-		if err.Error() != metadata.ErrNoRecord.String() {
-			log.CtxErrorw(reqCtx.Context(), "failed to get uploading job state", "error", err)
-			return
-		}
+		log.CtxErrorw(reqCtx.Context(), "failed to get uploading job state", "error", err)
+		return
 	}
 
 	offset = uint64(segmentCount) * params.GetMaxSegmentSize()


### PR DESCRIPTION
### Description

remove this warning:
`"message":"do API error, url: http://127.0.0.1:9033/gsc/svm?upload-context=, err: statusCode 404 : code : 90003  (Message: no uploading record)"}`

### Rationale

tell us why we need these changes...

### Example

NA

### Changes

Notable changes: 
* NA
* ...
