### PR TITLE
fix: ignore duplicate entry when create bucket traffic

### DIFF
--- a/modular/downloader/download_task.go
+++ b/modular/downloader/download_task.go
@@ -53,7 +53,7 @@ func (d *DownloadModular) PreDownloadObject(ctx context.Context, downloadObjectT
 
 	bucketID := downloadObjectTask.GetBucketInfo().Id.Uint64()
 	bucketName := downloadObjectTask.GetBucketInfo().GetBucketName()
-	bucketTraffic, err = d.baseApp.GfSpDB().GetBucketTraffic(downloadObjectTask.GetBucketInfo().Id.Uint64())
+	bucketTraffic, err = d.baseApp.GfSpDB().GetBucketTraffic(bucketID)
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return err
 	}

--- a/store/sqldb/traffic.go
+++ b/store/sqldb/traffic.go
@@ -152,12 +152,9 @@ func (s *SpDBImpl) InitBucketTraffic(bucketID uint64, bucketName string, quota *
 		ModifiedTime:          time.Now(),
 	}
 	result := s.db.Create(insertBucketTraffic)
-	if result.Error != nil {
+	if result.Error != nil && MysqlErrCode(result.Error) != ErrDuplicateEntryCode {
 		err := fmt.Errorf("failed to create bucket traffic table: %s", result.Error)
 		return err
-	}
-	if result.RowsAffected != 1 {
-		log.Infow("insert traffic", "RowsAffected", result.RowsAffected, "quota", quota)
 	}
 
 	return nil


### PR DESCRIPTION
### Description

Ignore duplicate entry when create bucket traffic.

### Rationale

Ignore failures caused by concurrent updates.

### Example

N/A

### Changes

Notable changes: 
* downloader.
