### PR TITLE
feat: rename personal sign auth name for updateKey API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aliyun/credentials-go v1.3.0
 	github.com/aws/aws-sdk-go v1.44.159
 	github.com/bnb-chain/greenfield v0.2.3-alpha.7
-	github.com/bnb-chain/greenfield-common/go v0.0.0-20230807072950-7d065b289ab9
+	github.com/bnb-chain/greenfield-common/go v0.0.0-20230809025353-fd0519705054
 	github.com/bytedance/gopkg v0.0.0-20221122125632-68358b8ecec6
 	github.com/cometbft/cometbft v0.37.1
 	github.com/consensys/gnark-crypto v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -180,6 +180,8 @@ github.com/bnb-chain/greenfield-common/go v0.0.0-20230807023829-a6f5d8d75f1f h1:
 github.com/bnb-chain/greenfield-common/go v0.0.0-20230807023829-a6f5d8d75f1f/go.mod h1:GEjCahULmz99qx5k8WGWa7cTXIUjoNMNW+J92I+kTWg=
 github.com/bnb-chain/greenfield-common/go v0.0.0-20230807072950-7d065b289ab9 h1:WcnWlEIgua/k3Ho78JVPKQXR/bFrpgs8k+f9m/YwYLU=
 github.com/bnb-chain/greenfield-common/go v0.0.0-20230807072950-7d065b289ab9/go.mod h1:GEjCahULmz99qx5k8WGWa7cTXIUjoNMNW+J92I+kTWg=
+github.com/bnb-chain/greenfield-common/go v0.0.0-20230809025353-fd0519705054 h1:74pdUdHjo9QNgjSifIgzbDcloqFJ2I+qo715tOXy/oM=
+github.com/bnb-chain/greenfield-common/go v0.0.0-20230809025353-fd0519705054/go.mod h1:GEjCahULmz99qx5k8WGWa7cTXIUjoNMNW+J92I+kTWg=
 github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.5 h1:VZKjhnM/GvdG6iTXj63SrBgDQLtXG4piDDG2fTMTiV4=
 github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.5/go.mod h1:EghjYxFg4NRNMfTJ6g9rVhjImhXQm+tuboknHqeGmJA=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9 h1:6fLpmmI0EZvDTfPvI0zy5dBaaTUboHnEkoC5/p/w8TQ=

--- a/modular/gater/auth_handler.go
+++ b/modular/gater/auth_handler.go
@@ -106,7 +106,7 @@ func (g *GateModular) updateUserPublicKeyHandler(w http.ResponseWriter, r *http.
 
 	reqCtx, _ = NewRequestContext(r, g)
 	// verify personal sign signature
-	personalSignSignaturePrefix := signaturePrefix(SignTypePersonal, SignAlgorithm)
+	personalSignSignaturePrefix := commonhttp.Gnfd1EthPersonalSign + ","
 	requestSignature := reqCtx.request.Header.Get(GnfdAuthorizationHeader)
 
 	if !strings.HasPrefix(requestSignature, personalSignSignaturePrefix) {

--- a/modular/gater/const.go
+++ b/modular/gater/const.go
@@ -27,18 +27,10 @@ const (
 	// ContentDispositionInlineValue is used to indicate inline
 	ContentDispositionInlineValue = "inline"
 
-	// SignAlgorithm uses secp256k1 with the ECDSA algorithm
-	SignAlgorithm = "ECDSA-secp256k1"
 	// SignedMsg is the request hash
 	SignedMsg = "SignedMsg"
 	// Signature is the request signature
 	Signature = "Signature"
-	// SignTypeV1 is an authentication algorithm, which is used by dapps
-	SignTypeV1 = "authTypeV1"
-
-	SignTypeOffChain   = "OffChainAuth" // sign type - off-chain-auth
-	SignTypePersonal   = "PersonalSign" // sign type -  PersonalSign
-	SignAlgorithmEddsa = "EDDSA"
 
 	// GetApprovalPath defines get-approval path style suffix
 	GetApprovalPath = "/greenfield/admin/v1/get-approval"

--- a/modular/gater/request_context.go
+++ b/modular/gater/request_context.go
@@ -152,11 +152,6 @@ func (r *RequestContext) String() string {
 		getRequestIP(r.request), time.Since(r.startTime), r.err)
 }
 
-// signaturePrefix return supported Authentication prefix
-func signaturePrefix(version, algorithm string) string {
-	return version + " " + algorithm + ","
-}
-
 func (r *RequestContext) VerifySignature() (string, error) {
 	// check sig
 	requestSignature := r.request.Header.Get(GnfdAuthorizationHeader)


### PR DESCRIPTION
### Description
feat: rename personal sign

It was "PersonalSign ECDSA-secp256k1" and it is now renamed to "GNFD1-ETH-PERSONAL_SIGN"