### PR TITLE
fix: db update bucket traffic by transaction

### DIFF
--- a/test/e2e/spworkflow/e2e_test.sh
+++ b/test/e2e/spworkflow/e2e_test.sh
@@ -8,7 +8,7 @@ workspace=${GITHUB_WORKSPACE}
 # some constants
 GREENFIELD_REPO_TAG="v0.2.4-alpha.1"
 # greenfield cmd branch name: auth-refactoring
-GREENFIELD_CMD_TAG="db9fb7793837c2aa04d0ab31081ff368dfca2414"
+GREENFIELD_CMD_TAG="v0.1.0-alpha.1"
 # greenfield go sdk branch name: feat/auth-refactor
 GREENFIELD_GO_SDK_TAG="v0.2.4-alpha.1"
 MYSQL_USER="root"


### PR DESCRIPTION
### Description

update db update bucket traffic DB table by transaction

### Rationale

avoid db error when download objects using multiple threads

### Example

NA

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
