### PR TITLE
fix: fix occasional compile error

### DIFF
--- a/test/e2e/spworkflow/e2e_test.sh
+++ b/test/e2e/spworkflow/e2e_test.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+export CGO_CFLAGS="-O -D__BLST_PORTABLE__"
+export CGO_CFLAGS_ALLOW="-O -D__BLST_PORTABLE__"
+
 workspace=${GITHUB_WORKSPACE}
 
 # some constants


### PR DESCRIPTION
### Description

Fix occasional compile error.

### Rationale

blst has problem in some old cpu, could cause SIGILL, and use environment variables for compatible configuration.

### Example

Compile error log:
```shell
Caught SIGILL in blst_cgo_init, consult <blst>/bindinds/go/README.md.
Caught SIGILL in blst_cgo_init, consult <blst>/bindinds/go/README.md.
./deployment/localup/localup.sh: line 285: echo: write error: Broken pipe
Caught SIGILL in blst_cgo_init, consult <blst>/bindinds/go/README.md.
Caught SIGILL in blst_cgo_init, consult <blst>/bindinds/go/README.md.
Caught SIGILL in blst_cgo_init, consult <blst>/bindinds/go/README.md.
Caught SIGILL in blst_cgo_init, consult <blst>/bindinds/go/README.md.
Caught SIGILL in blst_cgo_init, consult <blst>/bindinds/go/README.md.
Error: Process completed with exit code 132.
``` 
### Changes

Notable changes: 
* e2e script.
