### PR TITLE
fix: fix src gvg is overwritten v0.2.4

### DIFF
--- a/base/gfspconfig/config.go
+++ b/base/gfspconfig/config.go
@@ -142,13 +142,14 @@ type GatewayConfig struct {
 }
 
 type ExecutorConfig struct {
-	MaxExecuteNumber             int64   `comment:"optional"`
-	AskTaskInterval              int     `comment:"optional"`
-	AskReplicateApprovalTimeout  int64   `comment:"optional"`
-	AskReplicateApprovalExFactor float64 `comment:"optional"`
-	ListenSealTimeoutHeight      int     `comment:"optional"`
-	ListenSealRetryTimeout       int     `comment:"optional"`
-	MaxListenSealRetry           int     `comment:"optional"`
+	MaxExecuteNumber                int64   `comment:"optional"`
+	AskTaskInterval                 int     `comment:"optional"`
+	AskReplicateApprovalTimeout     int64   `comment:"optional"`
+	AskReplicateApprovalExFactor    float64 `comment:"optional"`
+	ListenSealTimeoutHeight         int     `comment:"optional"`
+	ListenSealRetryTimeout          int     `comment:"optional"`
+	MaxListenSealRetry              int     `comment:"optional"`
+	EnableSkipFailedToMigrateObject bool    `comment:"optional"`
 }
 
 type P2PConfig struct {

--- a/cmd/command/exit_migrate.go
+++ b/cmd/command/exit_migrate.go
@@ -3,6 +3,7 @@ package command
 import (
 	"fmt"
 
+	"github.com/bnb-chain/greenfield-storage-provider/util"
 	"github.com/urfave/cli/v2"
 
 	"github.com/bnb-chain/greenfield-storage-provider/cmd/utils"
@@ -33,7 +34,6 @@ func spExit(ctx *cli.Context) error {
 	}
 	client := utils.MakeGfSpClient(cfg)
 	operatorAddress := ctx.String(spOperatorAddressFlag.Name)
-	// TODO: add more verification for cli args
 	if operatorAddress != cfg.SpAccount.SpOperatorAddress {
 		return fmt.Errorf("invalid operator address")
 	}
@@ -43,5 +43,91 @@ func spExit(ctx *cli.Context) error {
 		return err
 	}
 	fmt.Printf("send sp exit txn successfully, txn hash: %s", txHash)
+	return nil
+}
+
+/*
+The following commands are only used in debug scenarios.
+*/
+var swapOutFamilyID = &cli.StringFlag{
+	Name:  "familyID",
+	Usage: "The familyID who intends to swap out",
+}
+
+var swapOutGVGIDList = &cli.StringFlag{
+	Name:  "gvgIDList",
+	Usage: "The gvgIDList who intends to swap out, eg: '1,2,3'",
+}
+
+var CompleteSPExitCmd = &cli.Command{
+	Name:  "sp.complete.exit",
+	Usage: "Only used in debugging scenarios, online use not allowed. Used for sp complete exits from the Greenfield storage network.",
+	Description: `Using this command, it will send an transaction to Greenfield blockchain to tell this SP is prepared
+		to complete exit from Greenfield storage network`,
+	Category: "MIGRATE COMMANDS",
+	Action:   completeSPExit,
+	Flags: []cli.Flag{
+		spOperatorAddressFlag,
+	},
+}
+
+func completeSPExit(ctx *cli.Context) error {
+	cfg, err := utils.MakeConfig(ctx)
+	if err != nil {
+		return err
+	}
+	client := utils.MakeGfSpClient(cfg)
+	operatorAddress := ctx.String(spOperatorAddressFlag.Name)
+	if operatorAddress != cfg.SpAccount.SpOperatorAddress {
+		return fmt.Errorf("invalid operator address")
+	}
+	txHash, err := client.CompleteSPExit(ctx.Context, &virtualgrouptypes.MsgCompleteStorageProviderExit{StorageProvider: operatorAddress})
+	if err != nil {
+		fmt.Printf("failed to send complete sp exit txn, operatorAddress: %s\n", operatorAddress)
+		return err
+	}
+	fmt.Printf("send complete sp exit txn successfully, txn hash: %s", txHash)
+	return nil
+}
+
+var CompleteSwapOutCmd = &cli.Command{
+	Name:  "sp.complete.swapout",
+	Usage: "Only used in debugging scenarios, online use not allowed. Used for swap out from the Greenfield storage network.",
+	Description: `Using this command, it will send an transaction to Greenfield blockchain to tell this SP is prepared
+		to swap out from Greenfield storage network`,
+	Category: "MIGRATE COMMANDS",
+	Action:   completeSwapOut,
+	Flags: []cli.Flag{
+		spOperatorAddressFlag,
+		swapOutFamilyID,
+		swapOutGVGIDList,
+	},
+}
+
+func completeSwapOut(ctx *cli.Context) error {
+	cfg, err := utils.MakeConfig(ctx)
+	if err != nil {
+		return err
+	}
+	client := utils.MakeGfSpClient(cfg)
+	operatorAddress := ctx.String(spOperatorAddressFlag.Name)
+	if operatorAddress != cfg.SpAccount.SpOperatorAddress {
+		return fmt.Errorf("invalid operator address")
+	}
+	familyID := uint32(ctx.Uint64(swapOutFamilyID.Name))
+	gvgIDList, err := util.StringToUint32Slice(swapOutGVGIDList.Name)
+	if err != nil {
+		fmt.Printf("failed to send complete swap out tx, operatorAddress: %s, gvgIDList: %s\n", operatorAddress, swapOutGVGIDList.Name)
+		return err
+	}
+	txHash, err := client.CompleteSwapOut(ctx.Context, &virtualgrouptypes.MsgCompleteSwapOut{
+		StorageProvider:            operatorAddress,
+		GlobalVirtualGroupFamilyId: familyID,
+		GlobalVirtualGroupIds:      gvgIDList})
+	if err != nil {
+		fmt.Printf("failed to send complete swap out txn, operatorAddress: %s\n", operatorAddress)
+		return err
+	}
+	fmt.Printf("send complete swap out txn successfully, txn hash: %s", txHash)
 	return nil
 }

--- a/cmd/storage_provider/main.go
+++ b/cmd/storage_provider/main.go
@@ -120,6 +120,8 @@ func init() {
 		command.RecoverPieceCmd,
 		// sp exit
 		command.SPExitCmd,
+		command.CompleteSPExitCmd,  // only for debugging
+		command.CompleteSwapOutCmd, // only for debugging
 		// update quota
 		command.SetQuotaCmd,
 	}

--- a/modular/executor/executor.go
+++ b/modular/executor/executor.go
@@ -45,6 +45,8 @@ type ExecuteModular struct {
 	doingRecoveryPieceTaskCnt  int64
 	doingMigrationGVGTaskCnt   int64
 
+	enableSkipFailedToMigrateObject bool // only for debugging, and online config can only be false
+
 	spID uint32
 }
 

--- a/modular/executor/executor_options.go
+++ b/modular/executor/executor_options.go
@@ -108,5 +108,6 @@ func DefaultExecutorOptions(executor *ExecuteModular, cfg *gfspconfig.GfSpConfig
 	}
 	executor.maxListenSealRetry = cfg.Executor.MaxListenSealRetry
 	executor.statisticsOutputInterval = DefaultStatisticsOutputInterval
+	executor.enableSkipFailedToMigrateObject = cfg.Executor.EnableSkipFailedToMigrateObject
 	return nil
 }

--- a/modular/manager/migrate_unit.go
+++ b/modular/manager/migrate_unit.go
@@ -16,25 +16,25 @@ var (
 	Migrated       MigrateStatus = 2
 )
 
-type basicGVGMigrateExecuteUnit struct {
-	srcGVG               *virtualgrouptypes.GlobalVirtualGroup
-	srcSP                *sptypes.StorageProvider
-	destSP               *sptypes.StorageProvider // self sp.
-	migrateStatus        MigrateStatus
-	lastMigratedObjectID uint64
+type BasicGVGMigrateExecuteUnit struct {
+	SrcGVG               *virtualgrouptypes.GlobalVirtualGroup
+	SrcSP                *sptypes.StorageProvider
+	DestSP               *sptypes.StorageProvider // self sp.
+	MigrateStatus        MigrateStatus
+	LastMigratedObjectID uint64
 }
 
 // SPExitGVGExecuteUnit is used to record sp exit gvg unit.
 type SPExitGVGExecuteUnit struct {
-	basicGVGMigrateExecuteUnit
-	redundancyIndex int32 // if < 0, represents migrate primary.
-	swapOutKey      string
+	BasicGVGMigrateExecuteUnit
+	RedundancyIndex int32 // if < 0, represents migrate primary.
+	SwapOutKey      string
 }
 
 // Key is used to as primary key.
 func (u *SPExitGVGExecuteUnit) Key() string {
 	return fmt.Sprintf("SPExit-gvg_id[%d]-vgf_id[%d]-redundancy_idx[%d]",
-		u.srcGVG.GetId(), u.srcGVG.GetFamilyId(), u.redundancyIndex)
+		u.SrcGVG.GetId(), u.SrcGVG.GetFamilyId(), u.RedundancyIndex)
 }
 
 func MakeGVGMigrateKey(gvgID uint32, vgfID uint32, redundancyIndex int32) string {
@@ -44,32 +44,32 @@ func MakeGVGMigrateKey(gvgID uint32, vgfID uint32, redundancyIndex int32) string
 
 // BucketMigrateGVGExecuteUnit is used to record bucket migrate gvg unit.
 type BucketMigrateGVGExecuteUnit struct {
-	basicGVGMigrateExecuteUnit
-	bucketID  uint64
-	destGVGID uint32
-	destGVG   *virtualgrouptypes.GlobalVirtualGroup
+	BasicGVGMigrateExecuteUnit
+	BucketID  uint64
+	DestGVGID uint32
+	DestGVG   *virtualgrouptypes.GlobalVirtualGroup
 }
 
 func newBucketMigrateGVGExecuteUnit(bucketID uint64, gvg *virtualgrouptypes.GlobalVirtualGroup, srcSP, destSP *sptypes.StorageProvider,
 	migrateStatus MigrateStatus, destGVGID uint32, lastMigrateObjectID uint64, destGVG *virtualgrouptypes.GlobalVirtualGroup) *BucketMigrateGVGExecuteUnit {
 
 	bucketUnit := &BucketMigrateGVGExecuteUnit{}
-	bucketUnit.bucketID = bucketID
-	bucketUnit.srcGVG = gvg
-	bucketUnit.destGVG = destGVG
-	bucketUnit.srcSP = srcSP
-	bucketUnit.destSP = destSP
-	bucketUnit.migrateStatus = migrateStatus
-	bucketUnit.destGVGID = destGVGID
+	bucketUnit.BucketID = bucketID
+	bucketUnit.SrcGVG = gvg
+	bucketUnit.DestGVG = destGVG
+	bucketUnit.SrcSP = srcSP
+	bucketUnit.DestSP = destSP
+	bucketUnit.MigrateStatus = migrateStatus
+	bucketUnit.DestGVGID = destGVGID
 
-	bucketUnit.lastMigratedObjectID = lastMigrateObjectID
+	bucketUnit.LastMigratedObjectID = lastMigrateObjectID
 
 	return bucketUnit
 }
 
 // Key is used to as primary key.
 func (ub *BucketMigrateGVGExecuteUnit) Key() string {
-	return fmt.Sprintf("MigrateBucket-bucket_id[%d]-gvg_id[%d]", ub.bucketID, ub.srcGVG.GetId())
+	return fmt.Sprintf("MigrateBucket-bucket_id[%d]-gvg_id[%d]", ub.BucketID, ub.SrcGVG.GetId())
 }
 
 func MakeBucketMigrateKey(bucketID uint64, gvgID uint32) string {


### PR DESCRIPTION
### Description

Fix bucket migrate workflow src gvg is overwritten.

### Rationale

Fix bucket migrate scheduler, from:
```go
srcSecondarySPIDs := srcGVG.GetSecondarySpIds()
``` 
to:
```go
srcSecondarySPIDs := make([]uint32, len(srcGVG.GetSecondarySpIds()))
copy(srcSecondarySPIDs, srcGVG.GetSecondarySpIds())
``` 
Avoid incorrectly modifying the gvg reference of proto in the context.

### Example

N/A.

### Changes

Notable changes: 
* Refine the migrate struct field for printing friendly log.
* Add some cmd and conf for debugging.

