### PR TITLE
feat: change json response body to xml

### DIFF
--- a/modular/gater/metadata_handler.go
+++ b/modular/gater/metadata_handler.go
@@ -568,6 +568,30 @@ func (g *GateModular) getGroupListHandler(w http.ResponseWriter, r *http.Request
 	w.Write(respBytes)
 }
 
+type GfSpListObjectsByIDsResponse types.GfSpListObjectsByIDsResponse
+
+type ObjectEntry struct {
+	Id    uint64
+	Value *types.Object
+}
+
+func (m GfSpListObjectsByIDsResponse) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if len(m.Objects) == 0 {
+		return nil
+	}
+
+	err := e.EncodeToken(start)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range m.Objects {
+		e.Encode(ObjectEntry{Id: k, Value: v})
+	}
+
+	return e.EncodeToken(start.End())
+}
+
 // listObjectsByIDsHandler list objects by object ids
 func (g *GateModular) listObjectsByIDsHandler(w http.ResponseWriter, r *http.Request) {
 	var (
@@ -638,7 +662,7 @@ func (g *GateModular) listObjectsByIDsHandler(w http.ResponseWriter, r *http.Req
 	}
 	grpcResponse := &types.GfSpListObjectsByIDsResponse{Objects: objects}
 
-	respBytes, err = xml.Marshal(grpcResponse)
+	respBytes, err = xml.Marshal((*GfSpListObjectsByIDsResponse)(grpcResponse))
 	if err != nil {
 		log.Errorf("failed to list objects by ids", "error", err)
 		return
@@ -718,7 +742,7 @@ func (g *GateModular) listBucketsByIDsHandler(w http.ResponseWriter, r *http.Req
 	}
 	grpcResponse := &types.GfSpListBucketsByIDsResponse{Buckets: buckets}
 
-	respBytes, err = xml.Marshal(grpcResponse)
+	respBytes, err = xml.Marshal((*GfSpListBucketsByIDsResponse)(grpcResponse))
 	if err != nil {
 		log.Errorf("failed to list buckets by ids", "error", err)
 		return
@@ -726,6 +750,30 @@ func (g *GateModular) listBucketsByIDsHandler(w http.ResponseWriter, r *http.Req
 
 	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
 	w.Write(respBytes)
+}
+
+type GfSpListBucketsByIDsResponse types.GfSpListBucketsByIDsResponse
+
+type BucketEntry struct {
+	Id    uint64
+	Value *types.Bucket
+}
+
+func (m GfSpListBucketsByIDsResponse) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if len(m.Buckets) == 0 {
+		return nil
+	}
+
+	err := e.EncodeToken(start)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range m.Buckets {
+		e.Encode(BucketEntry{Id: k, Value: v})
+	}
+
+	return e.EncodeToken(start.End())
 }
 
 // getPaymentByBucketIDHandler get payment by bucket id

--- a/modular/gater/metadata_handler.go
+++ b/modular/gater/metadata_handler.go
@@ -389,8 +389,8 @@ func (g *GateModular) getBucketMetaHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	var buckets = []*types.Bucket{grpcResponse.Bucket}
-	respBytes = processBucketsXmlResponse(respBytes, buckets)
+	var bucketsWithPayment = []*types.GfSpGetBucketMetaResponse{grpcResponse}
+	respBytes = processBucketsWithPaymentsponse(respBytes, bucketsWithPayment)
 
 	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
 	w.Write(respBytes)
@@ -2328,6 +2328,22 @@ func processBucketsXmlResponse(respBytes []byte, buckets []*types.Bucket) (respB
 	for _, bucket := range buckets {
 		if bucket != nil {
 			respString = strings.Replace(respString, "<Id></Id>", "<Id>"+bucket.BucketInfo.Id.String()+"</Id>", 1)
+		}
+	}
+	respBytesProcessed = []byte(respString)
+	return
+}
+
+func processBucketsWithPaymentsponse(respBytes []byte, buckets []*types.GfSpGetBucketMetaResponse) (respBytesProcessed []byte) {
+	respString := string(respBytes)
+	for _, bucket := range buckets {
+		if bucket != nil {
+			respString = strings.Replace(respString, "<Id></Id>", "<Id>"+bucket.Bucket.BucketInfo.Id.String()+"</Id>", 1)
+			respString = strings.Replace(respString, "<NetflowRate></NetflowRate>", "<NetflowRate>"+bucket.StreamRecord.NetflowRate.String()+"</NetflowRate>", 1)
+			respString = strings.Replace(respString, "<StaticBalance></StaticBalance>", "<StaticBalance>"+bucket.StreamRecord.StaticBalance.String()+"</StaticBalance>", 1)
+			respString = strings.Replace(respString, "<BufferBalance></BufferBalance>", "<BufferBalance>"+bucket.StreamRecord.BufferBalance.String()+"</BufferBalance>", 1)
+			respString = strings.Replace(respString, "<LockBalance></LockBalance>", "<LockBalance>"+bucket.StreamRecord.LockBalance.String()+"</LockBalance>", 1)
+			respString = strings.Replace(respString, "<FrozenNetflowRate></FrozenNetflowRate>", "<FrozenNetflowRate>"+bucket.StreamRecord.FrozenNetflowRate.String()+"</FrozenNetflowRate>", 1)
 		}
 	}
 	respBytesProcessed = []byte(respString)

--- a/modular/gater/metadata_handler.go
+++ b/modular/gater/metadata_handler.go
@@ -390,7 +390,7 @@ func (g *GateModular) getBucketMetaHandler(w http.ResponseWriter, r *http.Reques
 	}
 
 	var bucketsWithPayment = []*types.GfSpGetBucketMetaResponse{grpcResponse}
-	respBytes = processBucketsWithPaymentsponse(respBytes, bucketsWithPayment)
+	respBytes = processBucketsWithPaymentResponse(respBytes, bucketsWithPayment)
 
 	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
 	w.Write(respBytes)
@@ -2281,17 +2281,23 @@ func (g *GateModular) getUserOwnedGroupsHandler(w http.ResponseWriter, r *http.R
 	w.Write(respBytes)
 }
 
+// processObjectsXmlResponse process the unhandled Uint id and checksum of object xml unmarshal
 func processObjectsXmlResponse(respBytes []byte, objects []*types.Object) (respBytesProcessed []byte) {
 	respString := string(respBytes)
+	// startIdx is to trace the index for next checkSum to be processed
 	var startIdx = 0
 	for _, object := range objects {
 		if object != nil {
+			// iterate through each object and assign id value
 			respString = strings.Replace(respString, "<Id></Id>", "<Id>"+object.ObjectInfo.Id.String()+"</Id>", 1)
+			// inside each object, there is an array of checksum that need to be unmarshalled correctly
 			for _, checkSum := range object.ObjectInfo.Checksums {
 				re := regexp.MustCompile("<Checksums>(.*?)</Checksums>")
+				// first find the matching string of regex
 				found := re.FindString(respString[startIdx:])
 				respCheckSum := "<Checksums>" + fmt.Sprintf("%x", checkSum) + "</Checksums>"
 				if found != "" {
+					// replace the matching string of regex and move the startIdx after that to search next regex
 					respString = strings.Replace(respString, found, respCheckSum, 1)
 					startIdx = strings.LastIndex(respString, respCheckSum) + len(respCheckSum)
 				}
@@ -2302,17 +2308,23 @@ func processObjectsXmlResponse(respBytes []byte, objects []*types.Object) (respB
 	return
 }
 
+// processObjectsMapXmlResponse process the unhandled Uint id and checksum of object map xml unmarshal
 func processObjectsMapXmlResponse(respBytes []byte, objects map[uint64]*types.Object) (respBytesProcessed []byte) {
 	respString := string(respBytes)
+	// startIdx is to trace the index for next checkSum to be processed
 	var startIdx = 0
 	for _, object := range objects {
 		if object != nil {
+			// iterate through each object and assign id value
 			respString = strings.Replace(respString, "<Id></Id>", "<Id>"+object.ObjectInfo.Id.String()+"</Id>", 1)
+			// inside each object, there is an array of checksum that need to be unmarshalled correctly
 			for _, checkSum := range object.ObjectInfo.Checksums {
 				re := regexp.MustCompile("<Checksums>(.*?)</Checksums>")
+				// first find the matching string of regex
 				found := re.FindString(respString[startIdx:])
 				respCheckSum := "<Checksums>" + fmt.Sprintf("%x", checkSum) + "</Checksums>"
 				if found != "" {
+					// replace the matching string of regex and move the startIdx after that to search next regex
 					respString = strings.Replace(respString, found, respCheckSum, 1)
 					startIdx = strings.LastIndex(respString, respCheckSum) + len(respCheckSum)
 				}
@@ -2323,10 +2335,12 @@ func processObjectsMapXmlResponse(respBytes []byte, objects map[uint64]*types.Ob
 	return
 }
 
+// processBucketsXmlResponse process the unhandled Uint id of bucket xml unmarshal
 func processBucketsXmlResponse(respBytes []byte, buckets []*types.Bucket) (respBytesProcessed []byte) {
 	respString := string(respBytes)
 	for _, bucket := range buckets {
 		if bucket != nil {
+			// iterate through each bucket and assign id value
 			respString = strings.Replace(respString, "<Id></Id>", "<Id>"+bucket.BucketInfo.Id.String()+"</Id>", 1)
 		}
 	}
@@ -2334,10 +2348,12 @@ func processBucketsXmlResponse(respBytes []byte, buckets []*types.Bucket) (respB
 	return
 }
 
-func processBucketsWithPaymentsponse(respBytes []byte, buckets []*types.GfSpGetBucketMetaResponse) (respBytesProcessed []byte) {
+// processBucketsWithPaymentResponse process the unhandled Uint id and several balance of bucket with payment xml unmarshal
+func processBucketsWithPaymentResponse(respBytes []byte, buckets []*types.GfSpGetBucketMetaResponse) (respBytesProcessed []byte) {
 	respString := string(respBytes)
 	for _, bucket := range buckets {
 		if bucket != nil {
+			// iterate through each bucket and assign id and payment Uint value
 			respString = strings.Replace(respString, "<Id></Id>", "<Id>"+bucket.Bucket.BucketInfo.Id.String()+"</Id>", 1)
 			respString = strings.Replace(respString, "<NetflowRate></NetflowRate>", "<NetflowRate>"+bucket.StreamRecord.NetflowRate.String()+"</NetflowRate>", 1)
 			respString = strings.Replace(respString, "<StaticBalance></StaticBalance>", "<StaticBalance>"+bucket.StreamRecord.StaticBalance.String()+"</StaticBalance>", 1)
@@ -2350,10 +2366,12 @@ func processBucketsWithPaymentsponse(respBytes []byte, buckets []*types.GfSpGetB
 	return
 }
 
+// processBucketsMapXmlResponse process the unhandled Uint id of bucket map xml unmarshal
 func processBucketsMapXmlResponse(respBytes []byte, buckets map[uint64]*types.Bucket) (respBytesProcessed []byte) {
 	respString := string(respBytes)
 	for _, bucket := range buckets {
 		if bucket != nil {
+			// iterate through each bucket and assign id value
 			respString = strings.Replace(respString, "<Id></Id>", "<Id>"+bucket.BucketInfo.Id.String()+"</Id>", 1)
 		}
 	}
@@ -2361,10 +2379,12 @@ func processBucketsMapXmlResponse(respBytes []byte, buckets map[uint64]*types.Bu
 	return
 }
 
+// processGroupsXmlResponse process the unhandled Uint id of group xml unmarshal
 func processGroupsXmlResponse(respBytes []byte, groups []*types.Group) (respBytesProcessed []byte) {
 	respString := string(respBytes)
 	for _, group := range groups {
 		if group != nil {
+			// iterate through each group and assign id value
 			respString = strings.Replace(respString, "<Id></Id>", "<Id>"+group.Group.Id.String()+"</Id>", 1)
 		}
 	}
@@ -2372,10 +2392,12 @@ func processGroupsXmlResponse(respBytes []byte, groups []*types.Group) (respByte
 	return
 }
 
+// processGroupMembersXmlResponse process the unhandled Uint id of group member xml unmarshal
 func processGroupMembersXmlResponse(respBytes []byte, groupMembers []*types.GroupMember) (respBytesProcessed []byte) {
 	respString := string(respBytes)
 	for _, group := range groupMembers {
 		if group != nil {
+			// iterate through each group and assign id value
 			respString = strings.Replace(respString, "<Id></Id>", "<Id>"+group.Group.Id.String()+"</Id>", 1)
 		}
 	}

--- a/modular/gater/metadata_handler.go
+++ b/modular/gater/metadata_handler.go
@@ -3,6 +3,7 @@ package gater
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/xml"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -61,7 +62,7 @@ func (g *GateModular) getUserBucketsHandler(w http.ResponseWriter, r *http.Reque
 		includedRemoved       bool
 		queryParams           url.Values
 		err                   error
-		b                     bytes.Buffer
+		respBytes             []byte
 		reqCtx                *RequestContext
 	)
 	startTime := time.Now()
@@ -108,21 +109,21 @@ func (g *GateModular) getUserBucketsHandler(w http.ResponseWriter, r *http.Reque
 		Buckets: resp,
 	}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get user buckets", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // listObjectsByBucketNameHandler handle list objects by bucket name request
 func (g *GateModular) listObjectsByBucketNameHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err                      error
-		b                        bytes.Buffer
+		respBytes                []byte
 		maxKeys                  uint64
 		reqCtx                   *RequestContext
 		ok                       bool
@@ -270,22 +271,22 @@ func (g *GateModular) listObjectsByBucketNameHandler(w http.ResponseWriter, r *h
 		ContinuationToken:     continuationToken,
 	}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
-		log.Errorf("failed to list objects by bucket name", "error", err)
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
+		log.CtxErrorw(reqCtx.Context(), "failed to get user buckets", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // getObjectMetaHandler handle get object metadata request
 func (g *GateModular) getObjectMetaHandler(w http.ResponseWriter, r *http.Request) {
 	var (
-		err    error
-		b      bytes.Buffer
-		reqCtx *RequestContext
+		err       error
+		respBytes []byte
+		reqCtx    *RequestContext
 	)
 
 	startTime := time.Now()
@@ -324,22 +325,22 @@ func (g *GateModular) getObjectMetaHandler(w http.ResponseWriter, r *http.Reques
 		Object: resp,
 	}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.Errorf("failed to get object meta", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // getBucketMetaHandler handle get bucket metadata request
 func (g *GateModular) getBucketMetaHandler(w http.ResponseWriter, r *http.Request) {
 	var (
-		err    error
-		b      bytes.Buffer
-		reqCtx *RequestContext
+		err       error
+		respBytes []byte
+		reqCtx    *RequestContext
 	)
 	startTime := time.Now()
 	defer func() {
@@ -373,14 +374,14 @@ func (g *GateModular) getBucketMetaHandler(w http.ResponseWriter, r *http.Reques
 		StreamRecord: streamRecord,
 	}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.Errorf("failed to get bucket metadata", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // verifyPermissionHandler handle verify permission request
@@ -391,7 +392,7 @@ func (g *GateModular) verifyPermissionHandler(w http.ResponseWriter, r *http.Req
 		objectName  string
 		actionType  string
 		action      int
-		b           bytes.Buffer
+		respBytes   []byte
 		queryParams url.Values
 		effect      *permission_types.Effect
 		reqCtx      *RequestContext
@@ -453,21 +454,21 @@ func (g *GateModular) verifyPermissionHandler(w http.ResponseWriter, r *http.Req
 
 	grpcResponse := &storage_types.QueryVerifyPermissionResponse{Effect: *effect}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.Errorf("failed to verify permission", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // getGroupListHandler handle get group list request
 func (g *GateModular) getGroupListHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err         error
-		b           bytes.Buffer
+		respBytes   []byte
 		queryParams url.Values
 		limitStr    string
 		offsetStr   string
@@ -557,21 +558,21 @@ func (g *GateModular) getGroupListHandler(w http.ResponseWriter, r *http.Request
 		Count:  count,
 	}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.Errorf("failed to get group list", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // listObjectsByIDsHandler list objects by object ids
 func (g *GateModular) listObjectsByIDsHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err              error
-		buf              bytes.Buffer
+		respBytes        []byte
 		objects          map[uint64]*types.Object
 		objectIDMap      map[uint64]bool
 		ok               bool
@@ -637,21 +638,21 @@ func (g *GateModular) listObjectsByIDsHandler(w http.ResponseWriter, r *http.Req
 	}
 	grpcResponse := &types.GfSpListObjectsByIDsResponse{Objects: objects}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&buf, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.Errorf("failed to list objects by ids", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(buf.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // listBucketsByIDsHandler list buckets by bucket ids
 func (g *GateModular) listBucketsByIDsHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err              error
-		buf              bytes.Buffer
+		respBytes        []byte
 		buckets          map[uint64]*types.Bucket
 		bucketIDMap      map[uint64]bool
 		ok               bool
@@ -717,21 +718,21 @@ func (g *GateModular) listBucketsByIDsHandler(w http.ResponseWriter, r *http.Req
 	}
 	grpcResponse := &types.GfSpListBucketsByIDsResponse{Buckets: buckets}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&buf, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.Errorf("failed to list buckets by ids", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(buf.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // getPaymentByBucketIDHandler get payment by bucket id
 func (g *GateModular) getPaymentByBucketIDHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err         error
-		buf         bytes.Buffer
+		respBytes   []byte
 		payment     *payment_types.StreamRecord
 		bucketIDStr string
 		bucketID    int64
@@ -767,21 +768,21 @@ func (g *GateModular) getPaymentByBucketIDHandler(w http.ResponseWriter, r *http
 
 	grpcResponse := &types.GfSpGetPaymentByBucketIDResponse{StreamRecord: payment}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&buf, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.Errorf("failed to get payment by bucket id", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(buf.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // getPaymentByBucketNameHandler handle get payment by bucket name request
 func (g *GateModular) getPaymentByBucketNameHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err        error
-		b          bytes.Buffer
+		respBytes  []byte
 		reqCtx     *RequestContext
 		bucketName string
 		payment    *payment_types.StreamRecord
@@ -813,21 +814,21 @@ func (g *GateModular) getPaymentByBucketNameHandler(w http.ResponseWriter, r *ht
 
 	grpcResponse := &types.GfSpGetPaymentByBucketNameResponse{StreamRecord: payment}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.Errorf("failed to get payment by bucket name", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // getBucketByBucketNameHandler handle get bucket by bucket name request
 func (g *GateModular) getBucketByBucketNameHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err        error
-		b          bytes.Buffer
+		respBytes  []byte
 		reqCtx     *RequestContext
 		bucketName string
 		bucket     *types.Bucket
@@ -859,21 +860,21 @@ func (g *GateModular) getBucketByBucketNameHandler(w http.ResponseWriter, r *htt
 
 	grpcResponse := &types.GfSpGetBucketByBucketNameResponse{Bucket: bucket}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.Errorf("failed to get bucket by bucket name", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // getBucketByBucketIDHandler handle get bucket by bucket id
 func (g *GateModular) getBucketByBucketIDHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err         error
-		buf         bytes.Buffer
+		respBytes   []byte
 		bucket      *types.Bucket
 		bucketIDStr string
 		bucketID    int64
@@ -909,21 +910,21 @@ func (g *GateModular) getBucketByBucketIDHandler(w http.ResponseWriter, r *http.
 
 	grpcResponse := &types.GfSpGetBucketByBucketIDResponse{Bucket: bucket}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&buf, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.Errorf("failed to get bucket by bucket id", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(buf.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // listDeletedObjectsByBlockNumberRangeHandler handle list deleted objects info by a block number range request
 func (g *GateModular) listDeletedObjectsByBlockNumberRangeHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err                        error
-		b                          bytes.Buffer
+		respBytes                  []byte
 		reqCtx                     *RequestContext
 		requestSpOperatorAddress   string
 		requestStartBlockNumberStr string
@@ -979,23 +980,23 @@ func (g *GateModular) listDeletedObjectsByBlockNumberRangeHandler(w http.Respons
 		EndBlockNumber: int64(block),
 	}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.Errorf("failed to list deleted objects by block number range", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // getUserBucketsCountHandler handle get user bucket count request
 func (g *GateModular) getUserBucketsCountHandler(w http.ResponseWriter, r *http.Request) {
 	var (
-		err    error
-		b      bytes.Buffer
-		reqCtx *RequestContext
-		count  int64
+		err       error
+		respBytes []byte
+		reqCtx    *RequestContext
+		count     int64
 	)
 
 	defer func() {
@@ -1023,21 +1024,21 @@ func (g *GateModular) getUserBucketsCountHandler(w http.ResponseWriter, r *http.
 
 	grpcResponse := &types.GfSpGetUserBucketsCountResponse{Count: count}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get user buckets count", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // listExpiredBucketsBySpHandler handle list buckets that are expired by specific sp
 func (g *GateModular) listExpiredBucketsBySpHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err                error
-		b                  bytes.Buffer
+		respBytes          []byte
 		reqCtx             *RequestContext
 		requestLimit       string
 		requestCreateAt    string
@@ -1095,14 +1096,14 @@ func (g *GateModular) listExpiredBucketsBySpHandler(w http.ResponseWriter, r *ht
 
 	grpcResponse := &types.GfSpListExpiredBucketsBySpResponse{Buckets: buckets}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to list expired buckets by sp", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // verifyPermissionByIDHandler handle verify permission by id request
@@ -1117,7 +1118,7 @@ func (g *GateModular) verifyPermissionByIDHandler(w http.ResponseWriter, r *http
 		resourceType        uint32
 		actionType          uint32
 		ok                  bool
-		b                   bytes.Buffer
+		respBytes           []byte
 		queryParams         url.Values
 		effect              *permission_types.Effect
 		reqCtx              *RequestContext
@@ -1184,21 +1185,21 @@ func (g *GateModular) verifyPermissionByIDHandler(w http.ResponseWriter, r *http
 
 	grpcResponse := &storage_types.QueryVerifyPermissionResponse{Effect: *effect}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.Errorf("failed to verify permission by id", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // listVirtualGroupFamiliesBySpIDHandler list virtual group families by sp id
 func (g *GateModular) listVirtualGroupFamiliesBySpIDHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err         error
-		b           bytes.Buffer
+		respBytes   []byte
 		reqCtx      *RequestContext
 		requestSpID string
 		spID        uint32
@@ -1234,21 +1235,21 @@ func (g *GateModular) listVirtualGroupFamiliesBySpIDHandler(w http.ResponseWrite
 
 	grpcResponse := &types.GfSpListVirtualGroupFamiliesBySpIDResponse{GlobalVirtualGroupFamilies: families}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to list virtual group families by sp id", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // getVirtualGroupFamilyHandler get virtual group families by vgf id
 func (g *GateModular) getVirtualGroupFamilyHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err          error
-		b            bytes.Buffer
+		respBytes    []byte
 		reqCtx       *RequestContext
 		requestVgfID string
 		vgfID        uint32
@@ -1284,21 +1285,21 @@ func (g *GateModular) getVirtualGroupFamilyHandler(w http.ResponseWriter, r *htt
 
 	grpcResponse := &types.GfSpGetVirtualGroupFamilyResponse{Vgf: family}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get virtual group families by vgf id", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // getGlobalVirtualGroupByGvgIDHandler get global virtual group by gvg id
 func (g *GateModular) getGlobalVirtualGroupByGvgIDHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err          error
-		b            bytes.Buffer
+		respBytes    []byte
 		reqCtx       *RequestContext
 		requestGvgID string
 		gvgID        uint32
@@ -1334,21 +1335,21 @@ func (g *GateModular) getGlobalVirtualGroupByGvgIDHandler(w http.ResponseWriter,
 
 	grpcResponse := &types.GfSpGetGlobalVirtualGroupByGvgIDResponse{GlobalVirtualGroup: group}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get global virtual group by gvg id", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // getGlobalVirtualGroupHandler get global virtual group by lvg id and bucket id
 func (g *GateModular) getGlobalVirtualGroupHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err          error
-		b            bytes.Buffer
+		respBytes    []byte
 		reqCtx       *RequestContext
 		requestLvgID string
 		bucketIDStr  string
@@ -1393,21 +1394,21 @@ func (g *GateModular) getGlobalVirtualGroupHandler(w http.ResponseWriter, r *htt
 
 	grpcResponse := &types.GfSpGetGlobalVirtualGroupResponse{Gvg: group}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get global virtual group by lvg id and bucket id", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // listGlobalVirtualGroupsBySecondarySPHandler list global virtual group by secondary sp id
 func (g *GateModular) listGlobalVirtualGroupsBySecondarySPHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err         error
-		b           bytes.Buffer
+		respBytes   []byte
 		reqCtx      *RequestContext
 		requestSpID string
 		spID        uint32
@@ -1443,21 +1444,21 @@ func (g *GateModular) listGlobalVirtualGroupsBySecondarySPHandler(w http.Respons
 
 	grpcResponse := &types.GfSpListGlobalVirtualGroupsBySecondarySPResponse{Groups: groups}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to list global virtual group by secondary sp id", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // listGlobalVirtualGroupsByBucketHandler list global virtual group by bucket id
 func (g *GateModular) listGlobalVirtualGroupsByBucketHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err         error
-		b           bytes.Buffer
+		respBytes   []byte
 		reqCtx      *RequestContext
 		bucketIDStr string
 		bucketID    uint64
@@ -1493,21 +1494,21 @@ func (g *GateModular) listGlobalVirtualGroupsByBucketHandler(w http.ResponseWrit
 
 	grpcResponse := &types.GfSpListGlobalVirtualGroupsByBucketResponse{Groups: groups}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to list global virtual group by bucket id", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // listObjectsInGVGAndBucketHandler list objects by gvg and bucket id
 func (g *GateModular) listObjectsInGVGAndBucketHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err               error
-		b                 bytes.Buffer
+		respBytes         []byte
 		reqCtx            *RequestContext
 		requestGvgID      string
 		gvgID             uint32
@@ -1574,21 +1575,21 @@ func (g *GateModular) listObjectsInGVGAndBucketHandler(w http.ResponseWriter, r 
 
 	grpcResponse := &types.GfSpListObjectsInGVGResponse{Objects: objects}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to list objects by gvg and bucket id", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // listObjectsByGVGAndBucketForGCHandler list objects by gvg and bucket for gc
 func (g *GateModular) listObjectsByGVGAndBucketForGCHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err               error
-		b                 bytes.Buffer
+		respBytes         []byte
 		reqCtx            *RequestContext
 		requestGvgID      string
 		gvgID             uint32
@@ -1655,21 +1656,21 @@ func (g *GateModular) listObjectsByGVGAndBucketForGCHandler(w http.ResponseWrite
 
 	grpcResponse := &types.GfSpListObjectsByGVGAndBucketForGCResponse{Objects: objects}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to list objects by gvg and bucket for gc", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // listObjectsInGVGHandler list objects by gvg id
 func (g *GateModular) listObjectsInGVGHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err               error
-		b                 bytes.Buffer
+		respBytes         []byte
 		reqCtx            *RequestContext
 		requestGvgID      string
 		gvgID             uint32
@@ -1727,21 +1728,21 @@ func (g *GateModular) listObjectsInGVGHandler(w http.ResponseWriter, r *http.Req
 
 	grpcResponse := &types.GfSpListObjectsInGVGResponse{Objects: objects}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to list objects by gvg id", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // listMigrateBucketEventsHandler list migrate bucket events
 func (g *GateModular) listMigrateBucketEventsHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err            error
-		b              bytes.Buffer
+		respBytes      []byte
 		reqCtx         *RequestContext
 		requestSpID    string
 		requestBlockID string
@@ -1786,21 +1787,21 @@ func (g *GateModular) listMigrateBucketEventsHandler(w http.ResponseWriter, r *h
 
 	grpcResponse := &types.GfSpListMigrateBucketEventsResponse{Events: events}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to list migrate bucket events", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // listSwapOutEventsHandler list swap out events
 func (g *GateModular) listSwapOutEventsHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err            error
-		b              bytes.Buffer
+		respBytes      []byte
 		reqCtx         *RequestContext
 		requestSpID    string
 		requestBlockID string
@@ -1844,21 +1845,21 @@ func (g *GateModular) listSwapOutEventsHandler(w http.ResponseWriter, r *http.Re
 	}
 
 	grpcResponse := &types.GfSpListSwapOutEventsResponse{Events: events}
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to list swap out events", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // listSpExitEventsHandler list sp exit events
 func (g *GateModular) listSpExitEventsHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err            error
-		b              bytes.Buffer
+		respBytes      []byte
 		reqCtx         *RequestContext
 		requestSpID    string
 		requestBlockID string
@@ -1903,21 +1904,21 @@ func (g *GateModular) listSpExitEventsHandler(w http.ResponseWriter, r *http.Req
 
 	grpcResponse := &types.GfSpListSpExitEventsResponse{Events: events}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to list sp exit events", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // getSPInfoHandler get sp info by operator address
 func (g *GateModular) getSPInfoHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err                    error
-		b                      bytes.Buffer
+		respBytes              []byte
 		reqCtx                 *RequestContext
 		requestOperatorAddress string
 		sp                     *sp_types.StorageProvider
@@ -1951,14 +1952,14 @@ func (g *GateModular) getSPInfoHandler(w http.ResponseWriter, r *http.Request) {
 
 	grpcResponse := &types.GfSpGetSPInfoResponse{StorageProvider: sp}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get sp info by operator address", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // getStatusHandler get status info for the current SP
@@ -2003,7 +2004,7 @@ func (g *GateModular) getStatusHandler(w http.ResponseWriter, r *http.Request) {
 func (g *GateModular) getUserGroupsHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err               error
-		b                 bytes.Buffer
+		respBytes         []byte
 		reqCtx            *RequestContext
 		limit             uint32
 		limitStr          string
@@ -2058,21 +2059,21 @@ func (g *GateModular) getUserGroupsHandler(w http.ResponseWriter, r *http.Reques
 
 	grpcResponse := &types.GfSpGetUserGroupsResponse{Groups: groups}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get groups info by a user address", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // getGroupMembersHandler get group members by group id
 func (g *GateModular) getGroupMembersHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err               error
-		b                 bytes.Buffer
+		respBytes         []byte
 		groups            []*types.GroupMember
 		reqCtx            *RequestContext
 		limit             uint32
@@ -2129,21 +2130,21 @@ func (g *GateModular) getGroupMembersHandler(w http.ResponseWriter, r *http.Requ
 
 	grpcResponse := &types.GfSpGetGroupMembersResponse{Groups: groups}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get group members by group id", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }
 
 // getUserOwnedGroupsHandler retrieve groups where the user is the owner
 func (g *GateModular) getUserOwnedGroupsHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err               error
-		b                 bytes.Buffer
+		respBytes         []byte
 		reqCtx            *RequestContext
 		limit             uint32
 		limitStr          string
@@ -2198,12 +2199,12 @@ func (g *GateModular) getUserOwnedGroupsHandler(w http.ResponseWriter, r *http.R
 
 	grpcResponse := &types.GfSpGetUserOwnedGroupsResponse{Groups: groups}
 
-	m := jsonpb.Marshaler{EmitDefaults: true, OrigName: true, EnumsAsInts: true}
-	if err = m.Marshal(&b, grpcResponse); err != nil {
+	respBytes, err = xml.Marshal(grpcResponse)
+	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to retrieve groups where the user is the owner", "error", err)
 		return
 	}
 
-	w.Header().Set(ContentTypeHeader, ContentTypeJSONHeaderValue)
-	w.Write(b.Bytes())
+	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
+	w.Write(respBytes)
 }


### PR DESCRIPTION
### Description

Changing all json response body to to xml, exclude the SP status api.

### Rationale

We want to unify the success response body and failure response body to all xml.

### Example

```
localhost:9133/cwtmcrfqen?bucket-meta

<GfSpGetBucketMetaResponse>
    <Bucket>
        <BucketInfo>
            <Owner>0xB769053f37080e70EE8458B7d376cCD64C1d1eab</Owner>
            <BucketName>cwtmcrfqen</BucketName>
            <Visibility>2</Visibility>
            <Id>1</Id>
            <SourceType>0</SourceType>
            <CreateAt>1688364497</CreateAt>
            <PaymentAddress>0xB769053f37080e70EE8458B7d376cCD64C1d1eab</PaymentAddress>
            <GlobalVirtualGroupFamilyId>0</GlobalVirtualGroupFamilyId>
            <ChargedReadQuota>0</ChargedReadQuota>
            <BucketStatus>0</BucketStatus>
        </BucketInfo>
        <Removed>false</Removed>
        <DeleteAt>0</DeleteAt>
        <DeleteReason></DeleteReason>
        <Operator>0xB769053f37080e70EE8458B7d376cCD64C1d1eab</Operator>
        <CreateTxHash>0x84ec431271f80e83cf0b50c9bae347eb85efa27f9150e30fcab0e6b3e41d0bf1</CreateTxHash>
        <UpdateTxHash>0x84ec431271f80e83cf0b50c9bae347eb85efa27f9150e30fcab0e6b3e41d0bf1</UpdateTxHash>
        <UpdateAt>52</UpdateAt>
        <UpdateTime>1688364497</UpdateTime>
    </Bucket>
    <StreamRecord>
        <Account>0xB769053f37080e70EE8458B7d376cCD64C1d1eab</Account>
        <CrudTimestamp>1688364507</CrudTimestamp>
        <NetflowRate>-18536062976</NetflowRate>
        <StaticBalance>0</StaticBalance>
        <BufferBalance>1112163778560</BufferBalance>
        <LockBalance>1101152256000</LockBalance>
        <Status>0</Status>
        <SettleTimestamp>1688364537</SettleTimestamp>
        <OutFlowCount>0</OutFlowCount>
        <FrozenNetflowRate>0</FrozenNetflowRate>
    </StreamRecord>
</GfSpGetBucketMetaResponse>
```

### Changes

Notable changes: 
* metadata service
