### PR TITLE
test: add cmd ut

### DIFF
--- a/base/gnfd/gnfd_service.go
+++ b/base/gnfd/gnfd_service.go
@@ -88,7 +88,7 @@ const (
 	// ChainFailureVerifyGetObjectPermission defines the metrics label of unsuccessfully verify get object permission
 	ChainFailureVerifyGetObjectPermission = "verify_get_object_permission_failure"
 	// ChainSuccessVerifyPutObjectPermission defines the metrics label of successfully verify put object permission
-	ChainSuccessVerifyPutObjectPermission = "verify_putt_object_permission_success"
+	ChainSuccessVerifyPutObjectPermission = "verify_put_object_permission_success"
 	// ChainFailureVerifyPutObjectPermission defines the metrics label of unsuccessfully verify put object permission
 	ChainFailureVerifyPutObjectPermission = "verify_put_object_permission_failure"
 

--- a/cmd/command/cmd_wrapper.go
+++ b/cmd/command/cmd_wrapper.go
@@ -1,0 +1,50 @@
+package command
+
+import (
+	"github.com/bnb-chain/greenfield-storage-provider/base/gfspclient"
+	"github.com/bnb-chain/greenfield-storage-provider/base/gfspconfig"
+	"github.com/bnb-chain/greenfield-storage-provider/cmd/utils"
+	"github.com/bnb-chain/greenfield-storage-provider/core/consensus"
+	"github.com/bnb-chain/greenfield-storage-provider/core/spdb"
+	"github.com/urfave/cli/v2"
+)
+
+var CW CMDWrapper
+
+// CMDWrapper defines cmd wrapper.
+type CMDWrapper struct {
+	config   *gfspconfig.GfSpConfig
+	grpcAPI  gfspclient.GfSpClientAPI
+	spDBAPI  spdb.SPDB
+	chainAPI consensus.Consensus
+}
+
+func (w *CMDWrapper) init(ctx *cli.Context) (err error) {
+	if w.config == nil || w.grpcAPI == nil || w.spDBAPI == nil {
+		w.config, err = utils.MakeConfig(ctx)
+		if err != nil {
+			return err
+		}
+		w.grpcAPI = utils.MakeGfSpClient(w.config)
+		w.spDBAPI, _ = utils.MakeSPDB(w.config)
+	}
+	return nil
+}
+
+func (w *CMDWrapper) initChainAPI(ctx *cli.Context) (err error) {
+	if w.chainAPI == nil {
+		config, configErr := utils.MakeConfig(ctx)
+		if configErr != nil {
+			return configErr
+		}
+		w.chainAPI, err = utils.MakeGnfd(config)
+		return err
+	}
+	return nil
+}
+
+func (w *CMDWrapper) initEmptyGRPCAPI() {
+	if w.grpcAPI == nil {
+		w.grpcAPI = &gfspclient.GfSpClient{}
+	}
+}

--- a/cmd/command/config.go
+++ b/cmd/command/config.go
@@ -9,6 +9,11 @@ import (
 	"github.com/bnb-chain/greenfield-storage-provider/base/gfspconfig"
 )
 
+const (
+	DefaultConfigFile = "./config.toml"
+)
+
+// ConfigDumpCmd is used to dump default config.toml template.
 var ConfigDumpCmd = &cli.Command{
 	Action:   dumpConfigAction,
 	Name:     "config.dump",
@@ -24,7 +29,7 @@ func dumpConfigAction(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if err = os.WriteFile("./config.toml", bz, os.ModePerm); err != nil {
+	if err = os.WriteFile(DefaultConfigFile, bz, os.ModePerm); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/command/config_test.go
+++ b/cmd/command/config_test.go
@@ -1,0 +1,17 @@
+package command
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v2"
+)
+
+func TestConfigDumpCmd(t *testing.T) {
+	err := ConfigDumpCmd.Action(&cli.Context{})
+	assert.Equal(t, nil, err)
+	_, err = os.Stat(DefaultConfigFile)
+	assert.Equal(t, nil, err)
+	os.Remove(DefaultConfigFile)
+}

--- a/cmd/command/debug_test.go
+++ b/cmd/command/debug_test.go
@@ -1,0 +1,129 @@
+package command
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/bnb-chain/greenfield-storage-provider/base/gfspclient"
+	"github.com/bnb-chain/greenfield-storage-provider/base/gfspconfig"
+	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsptask"
+	"github.com/bnb-chain/greenfield-storage-provider/core/spdb"
+	"github.com/bnb-chain/greenfield-storage-provider/util"
+	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v2"
+	"go.uber.org/mock/gomock"
+)
+
+func TestCreateBucketApproval(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	CW.config = &gfspconfig.GfSpConfig{}
+	CW.spDBAPI = spdb.NewMockSPDB(ctrl)
+	mockGRPCAPI := gfspclient.NewMockGfSpClientAPI(ctrl)
+	o1 := mockGRPCAPI.EXPECT().AskCreateBucketApproval(gomock.Any(), gomock.Any()).Return(true, &gfsptask.GfSpCreateBucketApprovalTask{}, nil)
+	o2 := mockGRPCAPI.EXPECT().AskCreateBucketApproval(gomock.Any(), gomock.Any()).Return(false, &gfsptask.GfSpCreateBucketApprovalTask{}, nil)
+	o3 := mockGRPCAPI.EXPECT().AskCreateBucketApproval(gomock.Any(), gomock.Any()).Return(true, &gfsptask.GfSpCreateBucketApprovalTask{}, fmt.Errorf("failed to get create bucket approval"))
+	gomock.InOrder(o1, o2, o3)
+
+	CW.grpcAPI = mockGRPCAPI
+	// succeed
+	err := DebugCreateBucketApprovalCmd.Action(&cli.Context{})
+	assert.Nil(t, err)
+	// not allow
+	err = DebugCreateBucketApprovalCmd.Action(&cli.Context{})
+	assert.NotNil(t, err)
+	// failed
+	err = DebugCreateBucketApprovalCmd.Action(&cli.Context{})
+	assert.NotNil(t, err)
+}
+
+func TestCreateObjectApproval(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	CW.config = &gfspconfig.GfSpConfig{}
+	CW.spDBAPI = spdb.NewMockSPDB(ctrl)
+	mockGRPCAPI := gfspclient.NewMockGfSpClientAPI(ctrl)
+	o1 := mockGRPCAPI.EXPECT().AskCreateObjectApproval(gomock.Any(), gomock.Any()).Return(true, &gfsptask.GfSpCreateObjectApprovalTask{}, nil)
+	o2 := mockGRPCAPI.EXPECT().AskCreateObjectApproval(gomock.Any(), gomock.Any()).Return(false, &gfsptask.GfSpCreateObjectApprovalTask{}, nil)
+	o3 := mockGRPCAPI.EXPECT().AskCreateObjectApproval(gomock.Any(), gomock.Any()).Return(true, &gfsptask.GfSpCreateObjectApprovalTask{}, fmt.Errorf("failed to get create object approval"))
+	gomock.InOrder(o1, o2, o3)
+
+	CW.grpcAPI = mockGRPCAPI
+	// succeed
+	err := DebugCreateObjectApprovalCmd.Action(&cli.Context{})
+	assert.Nil(t, err)
+	// not allow
+	err = DebugCreateObjectApprovalCmd.Action(&cli.Context{})
+	assert.NotNil(t, err)
+	// failed
+	err = DebugCreateObjectApprovalCmd.Action(&cli.Context{})
+	assert.NotNil(t, err)
+}
+
+func TestReplicatePieceApproval(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	CW.config = &gfspconfig.GfSpConfig{}
+	mockGRPCAPI := gfspclient.NewMockGfSpClientAPI(ctrl)
+	o1 := mockGRPCAPI.EXPECT().AskSecondaryReplicatePieceApproval(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("failed to get replicate piece approval"))
+	o2 := mockGRPCAPI.EXPECT().AskSecondaryReplicatePieceApproval(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]*gfsptask.GfSpReplicatePieceApprovalTask{{}}, nil)
+	o4 := mockGRPCAPI.EXPECT().AskSecondaryReplicatePieceApproval(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]*gfsptask.GfSpReplicatePieceApprovalTask{{}}, nil)
+	mockDBAPI := spdb.NewMockSPDB(ctrl)
+	o3 := mockDBAPI.EXPECT().GetSpByAddress(gomock.Any(), gomock.Any()).Return(&sptypes.StorageProvider{}, nil)
+	o5 := mockDBAPI.EXPECT().GetSpByAddress(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("failed to query sp db"))
+	gomock.InOrder(o1, o2, o3, o4, o5)
+
+	CW.grpcAPI = mockGRPCAPI
+	CW.spDBAPI = mockDBAPI
+	// failed to get replicate approval
+	err := DebugReplicateApprovalCmd.Action(&cli.Context{})
+	assert.NotNil(t, err)
+	// succeed
+	err = DebugReplicateApprovalCmd.Action(&cli.Context{})
+	assert.Nil(t, err)
+	// failed to query sp db
+	err = DebugReplicateApprovalCmd.Action(&cli.Context{})
+	assert.NotNil(t, err)
+}
+
+func TestPutObject(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	CW.config = &gfspconfig.GfSpConfig{}
+	CW.spDBAPI = spdb.NewMockSPDB(ctrl)
+	mockGRPCAPI := gfspclient.NewMockGfSpClientAPI(ctrl)
+	CW.grpcAPI = mockGRPCAPI
+	o1 := mockGRPCAPI.EXPECT().UploadObject(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("failed to upload"))
+	o2 := mockGRPCAPI.EXPECT().UploadObject(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	gomock.InOrder(o1, o2)
+
+	app := cli.NewApp()
+	app.Commands = []*cli.Command{
+		DebugPutObjectCmd,
+	}
+	// failed, due to not exist file
+	err := app.Run([]string{"./gnfd-sp", "debug.put.object", "--file", "./not_exist_file"})
+	assert.NotNil(t, err)
+
+	// failed, due to file too large
+	fileContent := util.RandomString(DefaultMaxSegmentPieceSize + 1)
+	err = os.WriteFile("./too_large_file", []byte(fileContent), os.ModePerm)
+	assert.Nil(t, err)
+	err = app.Run([]string{"./gnfd-sp", "debug.put.object", "--file", "./too_large_file"})
+	assert.NotNil(t, err)
+	os.Remove("./too_large_file")
+
+	// failed due to uploader
+	fileContent = util.RandomString(8 * 1024 * 1024)
+	err = os.WriteFile("./normal_file", []byte(fileContent), os.ModePerm)
+	assert.Nil(t, err)
+	err = app.Run([]string{"./gnfd-sp", "debug.put.object", "--file", "./normal_file"})
+	assert.NotNil(t, err)
+
+	// succeed
+	err = app.Run([]string{"./gnfd-sp", "debug.put.object", "--file", "./normal_file"})
+	assert.Nil(t, err)
+	os.Remove("./normal_file")
+}

--- a/cmd/command/exit_migrate_test.go
+++ b/cmd/command/exit_migrate_test.go
@@ -1,0 +1,104 @@
+package command
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/bnb-chain/greenfield-storage-provider/base/gfspclient"
+	"github.com/bnb-chain/greenfield-storage-provider/base/gfspconfig"
+	"github.com/bnb-chain/greenfield-storage-provider/core/spdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v2"
+	"go.uber.org/mock/gomock"
+)
+
+func TestSPExit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	CW.config = &gfspconfig.GfSpConfig{}
+	CW.spDBAPI = spdb.NewMockSPDB(ctrl)
+	mockGRPCAPI := gfspclient.NewMockGfSpClientAPI(ctrl)
+	CW.grpcAPI = mockGRPCAPI
+	o1 := mockGRPCAPI.EXPECT().SPExit(gomock.Any(), gomock.Any()).Return("txHash", nil)
+	o2 := mockGRPCAPI.EXPECT().SPExit(gomock.Any(), gomock.Any()).Return("", fmt.Errorf("failed to send signer"))
+	gomock.InOrder(o1, o2)
+
+	app := cli.NewApp()
+	app.Commands = []*cli.Command{
+		SPExitCmd,
+	}
+	// failed due to check operator address
+	err := app.Run([]string{"./gnfd-sp", "sp.exit", "--operatorAddress", "abc"})
+	assert.NotNil(t, err)
+
+	// succeed
+	CW.config.SpAccount.SpOperatorAddress = "abc"
+	err = app.Run([]string{"./gnfd-sp", "sp.exit", "--operatorAddress", "abc"})
+	assert.Nil(t, err)
+
+	// failed due to send signer error
+	err = app.Run([]string{"./gnfd-sp", "sp.exit", "--operatorAddress", "abc"})
+	assert.NotNil(t, err)
+}
+
+func TestCompleteSPExit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	CW.config = &gfspconfig.GfSpConfig{}
+	CW.spDBAPI = spdb.NewMockSPDB(ctrl)
+	mockGRPCAPI := gfspclient.NewMockGfSpClientAPI(ctrl)
+	CW.grpcAPI = mockGRPCAPI
+	o1 := mockGRPCAPI.EXPECT().CompleteSPExit(gomock.Any(), gomock.Any()).Return("txHash", nil)
+	o2 := mockGRPCAPI.EXPECT().CompleteSPExit(gomock.Any(), gomock.Any()).Return("", fmt.Errorf("failed to send signer"))
+	gomock.InOrder(o1, o2)
+
+	app := cli.NewApp()
+	app.Commands = []*cli.Command{
+		CompleteSPExitCmd,
+	}
+	// failed due to check operator address
+	err := app.Run([]string{"./gnfd-sp", "sp.complete.exit", "--operatorAddress", "abc"})
+	assert.NotNil(t, err)
+
+	// succeed
+	CW.config.SpAccount.SpOperatorAddress = "abc"
+	err = app.Run([]string{"./gnfd-sp", "sp.complete.exit", "--operatorAddress", "abc"})
+	assert.Nil(t, err)
+
+	// failed due to send signer error
+	err = app.Run([]string{"./gnfd-sp", "sp.complete.exit", "--operatorAddress", "abc"})
+	assert.NotNil(t, err)
+}
+
+func TestCompleteSwapOut(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	CW.config = &gfspconfig.GfSpConfig{}
+	CW.spDBAPI = spdb.NewMockSPDB(ctrl)
+	mockGRPCAPI := gfspclient.NewMockGfSpClientAPI(ctrl)
+	CW.grpcAPI = mockGRPCAPI
+	o1 := mockGRPCAPI.EXPECT().CompleteSwapOut(gomock.Any(), gomock.Any()).Return("txHash", nil)
+	o2 := mockGRPCAPI.EXPECT().CompleteSwapOut(gomock.Any(), gomock.Any()).Return("", fmt.Errorf("failed to send signer"))
+	gomock.InOrder(o1, o2)
+
+	app := cli.NewApp()
+	app.Commands = []*cli.Command{
+		CompleteSwapOutCmd,
+	}
+	// failed due to check operator address
+	err := app.Run([]string{"./gnfd-sp", "sp.complete.swapout", "--operatorAddress", "abc", "-gvgIDList", ""})
+	assert.NotNil(t, err)
+
+	// failed due to invalid gvg list
+	err = app.Run([]string{"./gnfd-sp", "sp.complete.swapout", "--operatorAddress", "abc", "-gvgIDList", "abc"})
+	assert.NotNil(t, err)
+
+	// succeed
+	CW.config.SpAccount.SpOperatorAddress = "abc"
+	err = app.Run([]string{"./gnfd-sp", "sp.complete.swapout", "--operatorAddress", "abc", "--gvgIDList", "1,2,3", "--familyID", "1"})
+	assert.Nil(t, err)
+
+	// failed due to send signer error
+	err = app.Run([]string{"./gnfd-sp", "sp.complete.swapout", "--operatorAddress", "abc", "--gvgIDList", "1,2,3"})
+	assert.NotNil(t, err)
+}

--- a/cmd/command/p2p.go
+++ b/cmd/command/p2p.go
@@ -9,9 +9,10 @@ import (
 )
 
 var numberFlag = &cli.IntFlag{
-	Name:  "n",
-	Usage: "The number of key pairs",
-	Value: 1,
+	Name:     "n",
+	Usage:    "The number of key pairs",
+	Value:    1,
+	Required: true,
 }
 
 var P2PCreateKeysCmd = &cli.Command{

--- a/cmd/command/p2p_test.go
+++ b/cmd/command/p2p_test.go
@@ -1,0 +1,17 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v2"
+)
+
+func TestCreateKeys(t *testing.T) {
+	app := cli.NewApp()
+	app.Commands = []*cli.Command{
+		P2PCreateKeysCmd,
+	}
+	err := app.Run([]string{"./gnfd-sp", "p2p.create.key", "-n", "10"})
+	assert.Nil(t, err)
+}

--- a/cmd/command/query_test.go
+++ b/cmd/command/query_test.go
@@ -1,0 +1,198 @@
+package command
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/bnb-chain/greenfield-storage-provider/base/gfspclient"
+	"github.com/bnb-chain/greenfield-storage-provider/base/gfspconfig"
+	"github.com/bnb-chain/greenfield-storage-provider/core/consensus"
+	"github.com/bnb-chain/greenfield-storage-provider/core/spdb"
+	"github.com/bnb-chain/greenfield-storage-provider/modular/metadata/types"
+	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
+	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
+	virtual_types "github.com/bnb-chain/greenfield/x/virtualgroup/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v2"
+	"go.uber.org/mock/gomock"
+)
+
+func TestListModules(t *testing.T) {
+	app := cli.NewApp()
+	app.Commands = []*cli.Command{
+		ListModulesCmd,
+	}
+	err := app.Run([]string{"./gnfd-sp", "list.modules"})
+	assert.Nil(t, err)
+}
+
+func TestListErrors(t *testing.T) {
+	app := cli.NewApp()
+	app.Commands = []*cli.Command{
+		ListErrorsCmd,
+	}
+	err := app.Run([]string{"./gnfd-sp", "list.errors"})
+	assert.Nil(t, err)
+}
+
+func TestQueryTasks(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockGRPCAPI := gfspclient.NewMockGfSpClientAPI(ctrl)
+	CW.grpcAPI = mockGRPCAPI
+	o1 := mockGRPCAPI.EXPECT().QueryTasks(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("failed to query task"))
+	o2 := mockGRPCAPI.EXPECT().QueryTasks(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+	gomock.InOrder(o1, o2)
+
+	app := cli.NewApp()
+	app.Commands = []*cli.Command{
+		QueryTaskCmd,
+	}
+
+	// failed due to config file is not found
+	err := app.Run([]string{"./gnfd-sp", "query.task", "--task.key", "abc", "--config", "not_exist_config"})
+	assert.NotNil(t, err)
+
+	// failed due to query task error
+	err = ConfigDumpCmd.Action(&cli.Context{})
+	assert.Equal(t, nil, err)
+	_, err = os.Stat(DefaultConfigFile)
+	assert.Equal(t, nil, err)
+
+	err = app.Run([]string{"./gnfd-sp", "query.task", "--task.key", "abc", "--config", DefaultConfigFile})
+	assert.NotNil(t, err)
+
+	// succeed
+	err = app.Run([]string{"./gnfd-sp", "query.task", "--task.key", "abc", "--config", DefaultConfigFile})
+	assert.Nil(t, err)
+
+	// clear temp config file
+	os.Remove(DefaultConfigFile)
+}
+
+func TestGetObject(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	CW.config = &gfspconfig.GfSpConfig{}
+	CW.spDBAPI = spdb.NewMockSPDB(ctrl)
+	mockGRPCAPI := gfspclient.NewMockGfSpClientAPI(ctrl)
+	CW.grpcAPI = mockGRPCAPI
+	mockConsensusAPI := consensus.NewMockConsensus(ctrl)
+	CW.chainAPI = mockConsensusAPI
+
+	o1 := mockConsensusAPI.EXPECT().QueryObjectInfoByID(gomock.Any(), gomock.Any()).Return(&storagetypes.ObjectInfo{}, nil)
+	o2 := mockConsensusAPI.EXPECT().QueryBucketInfo(gomock.Any(), gomock.Any()).Return(&storagetypes.BucketInfo{}, nil)
+	o3 := mockConsensusAPI.EXPECT().QueryStorageParamsByTimestamp(gomock.Any(), gomock.Any()).Return(&storagetypes.Params{}, nil)
+	o4 := mockGRPCAPI.EXPECT().GetObject(gomock.Any(), gomock.Any()).Return([]byte{1}, nil)
+	gomock.InOrder(o1, o2, o3, o4)
+
+	app := cli.NewApp()
+	app.Commands = []*cli.Command{
+		GetObjectCmd,
+	}
+	err := app.Run([]string{"./gnfd-sp", "get.object", "--object.id", "100"})
+	assert.Nil(t, err)
+}
+
+func TestGetChallengePieceInfo(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	CW.config = &gfspconfig.GfSpConfig{}
+	CW.spDBAPI = spdb.NewMockSPDB(ctrl)
+	mockGRPCAPI := gfspclient.NewMockGfSpClientAPI(ctrl)
+	CW.grpcAPI = mockGRPCAPI
+	mockConsensusAPI := consensus.NewMockConsensus(ctrl)
+	CW.chainAPI = mockConsensusAPI
+
+	o1 := mockConsensusAPI.EXPECT().QueryObjectInfoByID(gomock.Any(), gomock.Any()).Return(&storagetypes.ObjectInfo{}, nil)
+	o2 := mockConsensusAPI.EXPECT().QueryBucketInfo(gomock.Any(), gomock.Any()).Return(&storagetypes.BucketInfo{}, nil)
+	o3 := mockConsensusAPI.EXPECT().QueryStorageParamsByTimestamp(gomock.Any(), gomock.Any()).Return(&storagetypes.Params{}, nil)
+	o4 := mockGRPCAPI.EXPECT().GetChallengeInfo(gomock.Any(), gomock.Any()).Return([]byte(""), [][]byte{[]byte("mock")}, []byte(""), nil)
+
+	gomock.InOrder(o1, o2, o3, o4)
+
+	app := cli.NewApp()
+	app.Commands = []*cli.Command{
+		ChallengePieceCmd,
+	}
+	err := app.Run([]string{"./gnfd-sp", "challenge.piece", "--object.id", "100", "--redundancy.index", "0", "--segment.index", "0"})
+	assert.NotNil(t, err)
+}
+
+func TestGetSegmentIntegrity(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	CW.config = &gfspconfig.GfSpConfig{}
+	mockDBAPI := spdb.NewMockSPDB(ctrl)
+	CW.spDBAPI = mockDBAPI
+	mockGRPCAPI := gfspclient.NewMockGfSpClientAPI(ctrl)
+	CW.grpcAPI = mockGRPCAPI
+	mockConsensusAPI := consensus.NewMockConsensus(ctrl)
+	CW.chainAPI = mockConsensusAPI
+
+	o1 := mockGRPCAPI.EXPECT().GetObjectByID(gomock.Any(), gomock.Any()).Return(&storagetypes.ObjectInfo{}, nil)
+	o2 := mockGRPCAPI.EXPECT().GetBucketByBucketName(gomock.Any(), gomock.Any(), gomock.Any()).Return(&types.Bucket{BucketInfo: &storagetypes.BucketInfo{Id: sdkmath.NewUint(10)}}, nil)
+	o3 := mockGRPCAPI.EXPECT().GetGlobalVirtualGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(&virtual_types.GlobalVirtualGroup{}, nil)
+	o4 := mockConsensusAPI.EXPECT().QuerySP(gomock.Any(), gomock.Any()).Return(&sptypes.StorageProvider{}, nil)
+	o5 := mockDBAPI.EXPECT().GetObjectIntegrity(gomock.Any(), gomock.Any()).Return(&spdb.IntegrityMeta{}, nil)
+	gomock.InOrder(o1, o2, o3, o4, o5)
+
+	app := cli.NewApp()
+	app.Commands = []*cli.Command{
+		GetSegmentIntegrityCmd,
+	}
+	err := app.Run([]string{"./gnfd-sp", "get.piece.integrity", "--object.id", "100"})
+	assert.Nil(t, err)
+}
+
+func TestQueryBucketMigrate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockGRPCAPI := gfspclient.NewMockGfSpClientAPI(ctrl)
+	CW.grpcAPI = mockGRPCAPI
+
+	o1 := mockGRPCAPI.EXPECT().QueryBucketMigrate(gomock.Any(), gomock.Any()).Return("bucket_migrate", nil)
+	gomock.InOrder(o1)
+
+	app := cli.NewApp()
+	app.Commands = []*cli.Command{
+		QueryBucketMigrateCmd,
+	}
+	err := ConfigDumpCmd.Action(&cli.Context{})
+	assert.Equal(t, nil, err)
+	_, err = os.Stat(DefaultConfigFile)
+	assert.Equal(t, nil, err)
+
+	err = app.Run([]string{"./gnfd-sp", "query.bucket.migrate", "--config", DefaultConfigFile, "--endpoint", "localhost:2012"})
+	assert.Nil(t, err)
+	// clear temp config file
+	os.Remove(DefaultConfigFile)
+}
+
+func TestQuerySPExit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockGRPCAPI := gfspclient.NewMockGfSpClientAPI(ctrl)
+	CW.grpcAPI = mockGRPCAPI
+
+	o1 := mockGRPCAPI.EXPECT().QuerySPExit(gomock.Any(), gomock.Any()).Return("sp_exit", nil)
+	gomock.InOrder(o1)
+
+	app := cli.NewApp()
+	app.Commands = []*cli.Command{
+		QuerySPExitCmd,
+	}
+	err := ConfigDumpCmd.Action(&cli.Context{})
+	assert.Equal(t, nil, err)
+	_, err = os.Stat(DefaultConfigFile)
+	assert.Equal(t, nil, err)
+
+	err = app.Run([]string{"./gnfd-sp", "query.sp.exit", "--config", DefaultConfigFile, "--endpoint", "localhost:2012"})
+	assert.Nil(t, err)
+	// clear temp config file
+	os.Remove(DefaultConfigFile)
+}

--- a/cmd/storage_provider/main.go
+++ b/cmd/storage_provider/main.go
@@ -95,21 +95,21 @@ func init() {
 		pprofFlags,
 	)
 	app.Commands = []*cli.Command{
+		VersionCmd,
 		// config category commands
 		command.ConfigDumpCmd,
 		// query category commands
-		command.ListModularCmd,
+		command.ListModulesCmd,
 		command.ListErrorsCmd,
 		command.QueryTaskCmd,
 		command.GetObjectCmd,
 		command.ChallengePieceCmd,
 		command.GetSegmentIntegrityCmd,
+		// query sp exit and bucket migrate status
 		command.QueryBucketMigrateCmd,
 		command.QuerySPExitCmd,
 		// p2p category commands
 		command.P2PCreateKeysCmd,
-		// miscellaneous category commands
-		VersionCmd,
 		// debug commands
 		command.DebugCreateBucketApprovalCmd,
 		command.DebugCreateObjectApprovalCmd,
@@ -137,8 +137,7 @@ func main() {
 
 // storageProvider is the main entry point into the system if no special subcommand
 // is run. It uses default config to  run storage provider services based  on the
-// command line arguments and runs it in blocking mode, waiting for it to be shut
-// down.
+// command line arguments and runs it in blocking mode, waiting for it to be shutdown.
 func storageProvider(ctx *cli.Context) error {
 	cfg, err := utils.MakeConfig(ctx)
 	if err != nil {

--- a/cmd/utils/init_env.go
+++ b/cmd/utils/init_env.go
@@ -72,7 +72,6 @@ func MakeEnv(ctx *cli.Context, cfg *gfspconfig.GfSpConfig) error {
 // initLog inits the log configuration from config file and command flags.
 func initLog(ctx *cli.Context, cfg *gfspconfig.GfSpConfig) error {
 	if cfg.Log.Level == "" {
-		// TODO:: change to info
 		cfg.Log.Level = "debug"
 	}
 	if cfg.Log.Path == "" {
@@ -171,10 +170,10 @@ func MakeSPDB(cfg *gfspconfig.GfSpConfig) (spdb.SPDB, error) {
 		cfg.SpDB.User = "root"
 	}
 	if cfg.SpDB.Passwd == "" {
-		cfg.SpDB.User = "test"
+		cfg.SpDB.Passwd = "test"
 	}
 	if cfg.SpDB.Address == "" {
-		cfg.SpDB.User = "127.0.0.1:3306"
+		cfg.SpDB.Address = "127.0.0.1:3306"
 	}
 	if cfg.SpDB.Database == "" {
 		cfg.SpDB.Database = "storage_provider_db"


### PR DESCRIPTION
### Description

Add cmd ut.

### Rationale

```shell
File coverage threshold (80%) satisfied:                FAIL
  below threshold:                                      coverage:       threshold:
  base/gfspapp/app.go                                   72%             80%
  base/gfspapp/authenticator_server.go                  0%              80%
  base/gfspapp/download_server.go                       0%              80%
  base/gfspapp/manage_server.go                         0%              80%
  base/gfspapp/p2p_server.go                            0%              80%
  base/gfspapp/query_server.go                          0%              80%
  base/gfspapp/rcmgr_server.go                          0%              80%
  base/gfspapp/receive_server.go                        0%              80%
  base/gfspapp/sign_server.go                           0%              80%
  base/gfspapp/upload_server.go                         0%              80%
  base/gfsptqueue/queue.go                              33%             80%
  base/gfsptqueue/queue_limit.go                        32%             80%
  cmd/command/cmd_wrapper.go                            31%             80%
  cmd/command/config.go                                 66%             80%
  cmd/command/query.go                                  74%             80%
  cmd/command/quota.go                                  0%              80%
  cmd/command/recovery.go                               0%              80%
  modular/approver/approve_task.go                      39%             80%
  modular/authenticator/authenticator.go                0%              80%
  modular/authenticator/authenticator_options.go        0%              80%
  modular/downloader/download_task.go                   12%             80%
  modular/downloader/downloader.go                      0%              80%
  modular/downloader/downloader_options.go              0%              80%
  modular/gater/admin_handler.go                        0%              80%
  modular/gater/auth_handler.go                         0%              80%
  modular/gater/bucket_handler.go                       0%              80%
  modular/gater/errors.go                               0%              80%
  modular/gater/gater.go                                0%              80%
  modular/gater/gater_options.go                        0%              80%
  modular/gater/metadata_handler.go                     0%              80%
  modular/gater/migrate_handler.go                      0%              80%
  modular/gater/object_handler.go                       0%              80%
  modular/gater/param_util.go                           0%              80%
  modular/gater/query_util.go                           0%              80%
  modular/gater/request_context.go                      0%              80%
  modular/p2p/p2pnode/approval.go                       0%              80%
  modular/p2p/p2pnode/node.go                           0%              80%
  modular/p2p/p2pnode/node_options.go                   63%             80%
  modular/p2p/p2pnode/peers.go                          0%              80%
  modular/p2p/p2pnode/ping.go                           0%              80%
  pkg/log/async_file_writer.go                          73%             80%
  pkg/log/async_writer_syncer.go                        62%             80%
  pkg/log/logger.go                                     53%             80%
  store/bsdb/bucket.go                                  0%              80%
  store/bsdb/epoch.go                                   0%              80%
  store/bsdb/event_migration_bucket.go                  0%              80%
  store/bsdb/event_sp_exit.go                           0%              80%
  store/bsdb/event_swap_out.go                          0%              80%
  store/bsdb/global_virtual_group.go                    0%              80%
  store/bsdb/global_virtual_group_family.go             0%              80%
  store/bsdb/group.go                                   0%              80%
  store/bsdb/local_virtual_group.go                     0%              80%
  store/bsdb/object.go                                  0%              80%
  store/bsdb/object_id_map.go                           0%              80%
  store/bsdb/payment.go                                 0%              80%
  store/bsdb/permission.go                              0%              80%
  store/bsdb/store.go                                   0%              80%
  store/piecestore/storage/disk_file.go                 77%             80%
  store/piecestore/storage/oss.go                       0%              80%
  store/sqldb/store.go                                  27%             80%

Package coverage threshold (80%) satisfied:     FAIL
  below threshold:                              coverage:       threshold:
  pkg/log                                       65%             80%
  store/piecestore/storage                      78%             80%
  modular/p2p/p2pnode                           9%              80%
  base/gfspapp                                  45%             80%
  cmd/command                                   56%             80%
  modular/approver                              56%             80%
  modular/gater                                 2%              80%
  base/gfsptqueue                               32%             80%
  modular/authenticator                         7%              80%
  modular/downloader                            10%             80%
  store/bsdb                                    21%             80%

Total coverage threshold (80%) satisfied:       FAIL
Total test coverage: 34%

``` 

### Example

N/A.

### Changes

Notable changes: 
* cmd ut.
