### PR TITLE
fix: remove funding key in singer module

### DIFF
--- a/modular/signer/signer_client.go
+++ b/modular/signer/signer_client.go
@@ -34,9 +34,6 @@ const (
 	// SignOperator is the type of signature signed by the operator account
 	SignOperator SignType = "operator"
 
-	// SignFunding is the type of signature signed by the funding account
-	SignFunding SignType = "funding"
-
 	// SignSeal is the type of signature signed by the seal account
 	SignSeal SignType = "seal"
 
@@ -103,16 +100,6 @@ func NewGreenfieldChainSignClient(rpcAddr, chainID string, gasInfo map[GasInfoTy
 		log.Errorw("failed to get operator nonce", "error", err)
 		return nil, err
 	}
-	fundingKM, err := keys.NewPrivateKeyManager(fundingPrivateKey)
-	if err != nil {
-		log.Errorw("failed to new funding private key manager", "error", err)
-		return nil, err
-	}
-	fundingClient, err := client.NewGreenfieldClient(rpcAddr, chainID, client.WithKeyManager(fundingKM))
-	if err != nil {
-		log.Errorw("failed to new funding greenfield client", "error", err)
-		return nil, err
-	}
 
 	blsKM, err := keys.NewBlsPrivateKeyManager(blsPrivKey)
 	if err != nil {
@@ -165,7 +152,6 @@ func NewGreenfieldChainSignClient(rpcAddr, chainID string, gasInfo map[GasInfoTy
 
 	greenfieldClients := map[SignType]*client.GreenfieldClient{
 		SignOperator: operatorClient,
-		SignFunding:  fundingClient,
 		SignSeal:     sealClient,
 		SignApproval: approvalClient,
 		SignGc:       gcClient,

--- a/modular/signer/signer_options.go
+++ b/modular/signer/signer_options.go
@@ -26,8 +26,6 @@ const (
 
 	// SpOperatorPrivKey defines env variable name for sp operator private key
 	SpOperatorPrivKey = "SIGNER_OPERATOR_PRIV_KEY"
-	// SpFundingPrivKey defines env variable name for sp funding private key
-	SpFundingPrivKey = "SIGNER_FUNDING_PRIV_KEY"
 	// SpApprovalPrivKey defines env variable name for sp approval private key
 	SpApprovalPrivKey = "SIGNER_APPROVAL_PRIV_KEY"
 	// SpSealPrivKey defines env variable name for sp seal private key
@@ -82,9 +80,6 @@ func DefaultSignerOptions(signer *SignModular, cfg *gfspconfig.GfSpConfig) error
 	}
 	if val, ok := os.LookupEnv(SpOperatorPrivKey); ok {
 		cfg.SpAccount.OperatorPrivateKey = val
-	}
-	if val, ok := os.LookupEnv(SpFundingPrivKey); ok {
-		cfg.SpAccount.FundingPrivateKey = val
 	}
 	if val, ok := os.LookupEnv(SpSealPrivKey); ok {
 		cfg.SpAccount.SealPrivateKey = val


### PR DESCRIPTION
### Description

1. remove funding key in signer module

### Rationale

funding key is the more private key that should not be held by the app or dev.

### Example

N/A

### Changes

Notable changes: 
* signer
