### PR TITLE
fix: nil pointer err caused by ObjectDetails

### DIFF
--- a/modular/metadata/metadata_object_service.go
+++ b/modular/metadata/metadata_object_service.go
@@ -315,7 +315,11 @@ func (r *MetadataModular) GfSpListObjectsInGVGAndBucket(ctx context.Context, req
 				log.CtxErrorw(ctx, "failed to get gvg by bucket and lvg id", "error", err)
 				return
 			}
-			res[idx] = &types.ObjectDetails{}
+			res[idx] = &types.ObjectDetails{
+				Object: &types.Object{},
+				Bucket: &types.Bucket{},
+				Gvg:    &virtual_types.GlobalVirtualGroup{},
+			}
 			if object != nil {
 				res[idx].Object = &types.Object{
 					ObjectInfo: &storage_types.ObjectInfo{
@@ -426,7 +430,11 @@ func (r *MetadataModular) GfSpListObjectsByGVGAndBucketForGC(ctx context.Context
 				log.CtxErrorw(ctx, "failed to get gvg by bucket and lvg id", "error", err)
 				return
 			}
-			res[idx] = &types.ObjectDetails{}
+			res[idx] = &types.ObjectDetails{
+				Object: &types.Object{},
+				Bucket: &types.Bucket{},
+				Gvg:    &virtual_types.GlobalVirtualGroup{},
+			}
 			if object != nil {
 				res[idx].Object = &types.Object{
 					ObjectInfo: &storage_types.ObjectInfo{
@@ -549,7 +557,11 @@ func (r *MetadataModular) GfSpListObjectsInGVG(ctx context.Context, req *types.G
 				log.CtxErrorw(ctx, "failed to get gvg by bucket and lvg id", "error", err)
 				return
 			}
-			res[idx] = &types.ObjectDetails{}
+			res[idx] = &types.ObjectDetails{
+				Object: &types.Object{},
+				Bucket: &types.Bucket{},
+				Gvg:    &virtual_types.GlobalVirtualGroup{},
+			}
 			if object != nil {
 				res[idx].Object = &types.Object{
 					ObjectInfo: &storage_types.ObjectInfo{


### PR DESCRIPTION
### Description

fix nil pointer err caused by ObjectDetails

### Rationale

```
/greenfield-storage-provider/store/bsdb/global_virtual_group.go:117
36
[392.420ms] [rows:1] SELECT * FROM `global_virtual_groups` WHERE global_virtual_group_id = 32 and removed = false LIMIT 1
35
{"t":"2023-08-23T03:18:24.339Z","l":"info","caller":"metadata/metadata_object_service.go:622","msg":"succeed to list objects by gvg id"}
34
panic: runtime error: invalid memory address or nil pointer dereference
33
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x141446c]
32
31
goroutine 186322 [running]:
30
github.com/bnb-chain/greenfield-storage-provider/modular/metadata/types.(*ObjectDetails).MarshalToSizedBuffer(0x0, {0xc00441a000, 0x16478, 0x16d7e})
29
	/greenfield-storage-provider/modular/metadata/types/metadata.pb.go:7202 +0x2c
28
```

### Example

N/A

### Changes

Notable changes: 
* fix nil pointer err caused by ObjectDetails

