### PR TITLE
fix: signer module does not need spdb

### DIFF
--- a/base/gfspapp/app_options.go
+++ b/base/gfspapp/app_options.go
@@ -231,7 +231,7 @@ func DefaultGfSpDBOption(app *GfSpBaseApp, cfg *gfspconfig.GfSpConfig) error {
 		return nil
 	}
 	for _, v := range cfg.Server {
-		if v == coremodule.BlockSyncerModularName {
+		if v == coremodule.BlockSyncerModularName || v == coremodule.SignModularName {
 			log.Infof("[%s] module doesn't need sp db", v)
 			continue
 		}


### PR DESCRIPTION
### Description

Signer module does not need spdb.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
