### PR TITLE
fix: set correct Content-Disposition when downloading an object

### DIFF
--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -538,7 +538,6 @@ func (g *GateModular) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set(ContentTypeHeader, objectInfo.GetContentType())
-	w.Header().Set(ContentDispositionHeader, ContentDispositionAttachmentValue+"; filename=\""+reqCtx.objectName+"\"")
 	if isRange {
 		w.Header().Set(ContentRangeHeader, "bytes "+util.Uint64ToString(uint64(lowOffset))+
 			"-"+util.Uint64ToString(uint64(highOffset)))


### PR DESCRIPTION
### Description

fix: set correct Content-Disposition when downloading an object

### Changes

- remove incorrect Content-Disposition header setting.
