### PR TITLE
feat: recover object list

### DIFF
--- a/cmd/command/recovery.go
+++ b/cmd/command/recovery.go
@@ -3,11 +3,11 @@ package command
 import (
 	"context"
 	"fmt"
-	"github.com/bnb-chain/greenfield-storage-provider/base/gfspclient"
 	"time"
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/bnb-chain/greenfield-storage-provider/base/gfspclient"
 	"github.com/bnb-chain/greenfield-storage-provider/base/gfspconfig"
 	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsptask"
 	"github.com/bnb-chain/greenfield-storage-provider/cmd/utils"

--- a/cmd/command/recovery.go
+++ b/cmd/command/recovery.go
@@ -22,20 +22,23 @@ const (
 )
 
 var bucketFlag = &cli.StringFlag{
-	Name:     "b",
+	Name:     "bucket",
 	Usage:    "The bucket name",
+	Aliases:  []string{"b"},
 	Required: true,
 }
 
 var objectFlag = &cli.StringFlag{
-	Name:     "o",
+	Name:     "object",
 	Usage:    "The object name",
-	Required: true,
+	Aliases:  []string{"o"},
+	Required: false,
 }
 
 var objectListFlag = &cli.BoolFlag{
 	Name:     "objectList",
 	Usage:    "if it is an single object or list",
+	Aliases:  []string{"l"},
 	Required: false,
 }
 
@@ -81,6 +84,10 @@ func recoverObjectAction(ctx *cli.Context) error {
 	}
 	client := utils.MakeGfSpClient(cfg)
 	bucketName := ctx.String(bucketFlag.Name)
+
+	if !ctx.IsSet(objectFlag.Name) && !ctx.IsSet(objectListFlag.Name) {
+		return fmt.Errorf("either object flag or objectList flag has to be set for object(s) recovery cmd")
+	}
 
 	if ctx.IsSet(objectListFlag.Name) {
 		if ctx.NArg() < 1 {

--- a/modular/executor/executor.go
+++ b/modular/executor/executor.go
@@ -212,7 +212,7 @@ func (e *ExecuteModular) AskTask(ctx context.Context) error {
 		e.HandleGCMetaTask(ctx, t)
 	case *gfsptask.GfSpRecoverPieceTask:
 		atomic.AddInt64(&e.doingRecoveryPieceTaskCnt, 1)
-		defer atomic.AddInt64(&e.doingRecoveryPieceTaskCnt, 1)
+		defer atomic.AddInt64(&e.doingRecoveryPieceTaskCnt, -1)
 		e.HandleRecoverPieceTask(ctx, t)
 		if t.Error() != nil {
 			metrics.ReqCounter.WithLabelValues(ExecutorFailureRecoveryTask).Inc()


### PR DESCRIPTION
### Description

1. Support recover object list 
2. fix counter bug of recover task

### Rationale

For the convenience of SP owner recover their accidentally deleted piece store.

### Example
./gnfd-sp recover.object -config config.toml -bucket gnfd-bucket -objectList testobject1 testobject2 ...

begin to recover the object of the primary SP: testobject1
succeed to gerate recovery object testobject1 task on background 
begin to recover the object of the primary SP: testobject2 
succeed to gerate recovery object testobject2 task on background 

### Changes

Notable changes: 
* recovery command
