### PR TITLE
fix :  refactor quota  table

### DIFF
--- a/modular/metadata/metadata_bucket_service.go
+++ b/modular/metadata/metadata_bucket_service.go
@@ -347,6 +347,7 @@ func (r *MetadataModular) GfSpGetBucketReadQuota(
 				", bucket_id: " + req.GetBucketInfo().Id.String() + ", error: " + err.Error())}, nil
 		}
 	}
+
 	// if the traffic table has been created, return the db info from meta service
 	return &types.GfSpGetBucketReadQuotaResponse{
 		ChargedQuotaSize:     req.GetBucketInfo().GetChargedReadQuota(),

--- a/modular/metadata/metadata_bucket_service.go
+++ b/modular/metadata/metadata_bucket_service.go
@@ -347,7 +347,6 @@ func (r *MetadataModular) GfSpGetBucketReadQuota(
 				", bucket_id: " + req.GetBucketInfo().Id.String() + ", error: " + err.Error())}, nil
 		}
 	}
-
 	// if the traffic table has been created, return the db info from meta service
 	return &types.GfSpGetBucketReadQuotaResponse{
 		ChargedQuotaSize:     req.GetBucketInfo().GetChargedReadQuota(),

--- a/store/sqldb/traffic.go
+++ b/store/sqldb/traffic.go
@@ -82,16 +82,15 @@ func (s *SpDBImpl) CheckQuotaAndAddReadRecord(record *corespdb.ReadRecord, quota
 // getUpdatedConsumedQuota compute the updated quota of traffic table by the incoming read cost and the newest record.
 // it returns the updated consumed free quota,consumed charged quota and remained free quota
 func getUpdatedConsumedQuota(recordQuotaCost, freeQuotaRemain, consumeFreeQuota, consumeChargedQuota, chargedQuota uint64) (uint64, uint64, uint64, bool, error) {
-	// if remain free quota more than 0 and enough, just consume free quota
+	// if remain free quota enough, just consume free quota
 	needUpdateFreeQuota := false
-	if freeQuotaRemain > 0 && recordQuotaCost < freeQuotaRemain {
+	if recordQuotaCost < freeQuotaRemain {
 		needUpdateFreeQuota = true
 		consumeFreeQuota += recordQuotaCost
 		freeQuotaRemain -= recordQuotaCost
 	} else {
 		// if free remain quota exist, consume all the free remain quota first
 		if freeQuotaRemain > 0 {
-			log.CtxDebugw(context.Background(), "remained free quota:", "quota", freeQuotaRemain)
 			if freeQuotaRemain+chargedQuota < recordQuotaCost {
 				return 0, 0, 0, false, ErrCheckQuotaEnough
 			}

--- a/store/sqldb/traffic.go
+++ b/store/sqldb/traffic.go
@@ -133,7 +133,7 @@ func (s *SpDBImpl) updateConsumedQuota(record *corespdb.ReadRecord, quota *cores
 		}
 
 		// compute the new consumed quota size to be updated
-		updatedReadConsumedSize, updatedFreeConsumedSize, err := getUpdatedConsumedQuota(record,
+		updatedFreeConsumedSize, updatedReadConsumedSize, err := getUpdatedConsumedQuota(record,
 			bucketTraffic.FreeQuotaSize, bucketTraffic.FreeQuotaConsumedSize,
 			bucketTraffic.ReadConsumedSize, bucketTraffic.ChargedQuotaSize)
 		if err != nil {

--- a/store/sqldb/traffic_schema.go
+++ b/store/sqldb/traffic_schema.go
@@ -9,10 +9,10 @@ type BucketTrafficTable struct {
 	BucketID              uint64 `gorm:"primary_key"`
 	Month                 string `gorm:"primary_key"`
 	BucketName            string
-	ReadConsumedSize      uint64
-	FreeQuotaConsumedSize uint64 // indicates the consumed free quota size
-	FreeQuotaSize         uint64 // the greenfield chain free quota
-	ChargedQuotaSize      uint64 //the greenfield chain bucket charged quota
+	ReadConsumedSize      uint64 // indicates the consumed chargedQuota of this month
+	FreeQuotaConsumedSize uint64 // indicates the consumed free quota size of this month
+	FreeQuotaSize         uint64 // indicate the remained free quota
+	ChargedQuotaSize      uint64 // indicate the greenfield chain bucket charged quota
 	ModifiedTime          time.Time
 }
 


### PR DESCRIPTION
### Description

1. fix the return value of getUpdatedConsumedQuota function,  the order is wrong now
2. refactor quota table to support better get quota computing. The original way failed to get the right value of the consumed free quota of this month , and  need to query the table of last month to compute the consumed free quota of this month which cause more db operation
<img width="1416" alt="image" src="https://github.com/bnb-chain/greenfield-storage-provider/assets/19421226/d7128305-6852-4f3e-9d53-0b9734cdb640">




### Rationale

fix quota logic

### Example

```
[root@ localtest]# ./gnfd-cmd --passwordfile password.txt bucket get-quota gnfd://testbucket4
quota info:
 charged quota:4476395008 
 free quota:1344556800    // remained free quota
 consumed quota:0 
 free consumed quota: 4429185024 
[root@ localtest]# ./gnfd-cmd --passwordfile password.txt object get gnfd://testbucket4/dss5ds download2
download object dss5ds, the file path is download2, content length:1476395008 
[root localtest]# ./gnfd-cmd --passwordfile password.txt bucket get-quota gnfd://testbucket4
quota info:
 charged quota:4476395008 
 free quota:0        // remained free quota
 consumed quota:131838208   // consumed charged quota
 free consumed quota: 5773741824 

[root@tf_nodereal_dev_storage_QA_testing2_ec2 localtest]# ./gnfd-cmd --passwordfile password.txt object get gnfd://testbucket4/dss5ds download2
download object dss5ds, the file path is download2, content length:1476395008 
[root@tf_nodereal_dev_storage_QA_testing2_ec2 localtest]# ./gnfd-cmd --passwordfile password.txt bucket get-quota gnfd://testbucket4
quota info:
 charged quota:4476395008 
 free quota:0 
 consumed quota:1608233216  // consumed charged quota
 free consumed quota: 5773741824 
```
### Changes

Notable changes: 
* add each change in a bullet point here
* ...
