### PR TITLE
fix: api rate limiter path sequence

### DIFF
--- a/modular/gater/gater_options.go
+++ b/modular/gater/gater_options.go
@@ -50,14 +50,18 @@ func defaultGaterOptions(gater *GateModular, cfg *gfspconfig.GfSpConfig) error {
 
 func makeAPIRateLimitCfg(cfg mwhttp.RateLimiterConfig) *mwhttp.APILimiterConfig {
 	defaultMap := make(map[string]mwhttp.MemoryLimiterConfig)
-	for _, c := range cfg.PathPattern {
+	pathSequence := make([]string, len(cfg.PathPattern))
+	for i, c := range cfg.PathPattern {
+		pathSequence[i] = c.Key
 		defaultMap[c.Key] = mwhttp.MemoryLimiterConfig{
 			RateLimit:  c.RateLimit,
 			RatePeriod: c.RatePeriod,
 		}
 	}
 	patternMap := make(map[string]mwhttp.MemoryLimiterConfig)
-	for _, c := range cfg.HostPattern {
+	hostSequence := make([]string, len(cfg.HostPattern))
+	for i, c := range cfg.HostPattern {
+		hostSequence[i] = c.Key
 		patternMap[c.Key] = mwhttp.MemoryLimiterConfig{
 			RateLimit:  c.RateLimit,
 			RatePeriod: c.RatePeriod,
@@ -71,9 +75,11 @@ func makeAPIRateLimitCfg(cfg mwhttp.RateLimiterConfig) *mwhttp.APILimiterConfig 
 		}
 	}
 	return &mwhttp.APILimiterConfig{
-		PathPattern: defaultMap,
-		HostPattern: patternMap,
-		APILimits:   apiLimitsMap,
-		IPLimitCfg:  cfg.IPLimitCfg,
+		PathPattern:  defaultMap,
+		PathSequence: pathSequence,
+		HostPattern:  patternMap,
+		HostSequence: hostSequence,
+		APILimits:    apiLimitsMap,
+		IPLimitCfg:   cfg.IPLimitCfg,
 	}
 }


### PR DESCRIPTION
fix: api rate limiter host pattern in sequence

### Description

Currently rate limiter api patterns are store in maps, which in golang maps are unsorted and resulting in iterate sequence difference every time, that might cause mismatch of regex patterns.

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 
* api rate limiter