### PR TITLE
fix: stop all replicate jobs and done replicate job by canceling context

### DIFF
--- a/base/types/gfsptask/upload.go
+++ b/base/types/gfsptask/upload.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math"
+	"sync/atomic"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -433,7 +434,7 @@ func (m *GfSpReplicatePieceTask) SetPriority(priority coretask.TPriority) {
 }
 
 func (m *GfSpReplicatePieceTask) SetNotAvailableSpIdx(idx int32) {
-	m.NotAvailableSpIdx = idx
+	atomic.StoreInt32(&m.NotAvailableSpIdx, idx)
 }
 
 func (m *GfSpReplicatePieceTask) EstimateLimit() corercmgr.Limit {


### PR DESCRIPTION
### Description

fixes a issue that remaining jobs are not terminated if there is error during any replicating job.


### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
