### PR TITLE
fix: fix a  executor panic issue

### DIFF
--- a/base/types/gfsptask/upload.go
+++ b/base/types/gfsptask/upload.go
@@ -434,7 +434,9 @@ func (m *GfSpReplicatePieceTask) SetPriority(priority coretask.TPriority) {
 }
 
 func (m *GfSpReplicatePieceTask) SetNotAvailableSpIdx(idx int32) {
-	atomic.StoreInt32(&m.NotAvailableSpIdx, idx)
+	if atomic.LoadInt32(&m.NotAvailableSpIdx) != idx {
+		atomic.StoreInt32(&m.NotAvailableSpIdx, idx)
+	}
 }
 
 func (m *GfSpReplicatePieceTask) EstimateLimit() corercmgr.Limit {


### PR DESCRIPTION
### Description

need to wait for all go-routines are done, becasue there are modification made by those routines even failure occur.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
