### PR TITLE
release: prepare release for v0.2.5-alpha.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.2.5-alpha.3
+
+FEATURES
+* [#1129](https://github.com/bnb-chain/greenfield-storage-provider/pull/1129) feat: add back metadata go routine listener
+* [#1128](https://github.com/bnb-chain/greenfield-storage-provider/pull/1128) feat: support expire time check of SP task info
+
+BUGFIX
+* [#1092](https://github.com/bnb-chain/greenfield-storage-provider/pull/1092) fix: support reimburse quota if download consumed extra quota
+* [#1127](https://github.com/bnb-chain/greenfield-storage-provider/pull/1127) fix:bs groups unique index
+* [#1125](https://github.com/bnb-chain/greenfield-storage-provider/pull/1125) fix: expiration time for statement
+
+TEST
+* [#1126](https://github.com/bnb-chain/greenfield-storage-provider/pull/1126) test: modular/executor pkg adds UTs
+
 ## v0.2.5-alpha.2
 
 FEATURES

--- a/base/gfspapp/download_server.go
+++ b/base/gfspapp/download_server.go
@@ -175,3 +175,15 @@ func (g *GfSpBaseApp) OnChallengePieceTask(ctx context.Context, challengePieceTa
 	log.CtxDebugw(ctx, "succeed to challenge piece")
 	return integrity, checksums, data, nil
 }
+
+func (g *GfSpBaseApp) GfSpReimburseQuota(ctx context.Context, fixRequest *gfspserver.GfSpReimburseQuotaRequest) (*gfspserver.GfSpReimburseQuotaResponse, error) {
+	err := g.GfSpDB().UpdateExtraQuota(fixRequest.GetBucketId(), fixRequest.GetExtraQuota(), fixRequest.YearMonth)
+	if err != nil {
+		log.CtxErrorw(ctx, "failed to reimburse extra quota", "error", err, "bucketID:", fixRequest.GetBucketId())
+	}
+
+	log.CtxDebugw(ctx, "succeed to reimburse extra quota", "bucketID:", fixRequest.GetBucketId(), "extra quota:", fixRequest.ExtraQuota)
+	return &gfspserver.GfSpReimburseQuotaResponse{
+		Err: gfsperrors.MakeGfSpError(err),
+	}, nil
+}

--- a/base/gfspclient/helper_test.go
+++ b/base/gfspclient/helper_test.go
@@ -224,6 +224,11 @@ func (mockDownloaderServer) GfSpGetChallengeInfo(ctx context.Context, req *gfsps
 	}
 }
 
+func (mockDownloaderServer) GfSpReimburseQuota(ctx context.Context, req *gfspserver.GfSpReimburseQuotaRequest) (
+	*gfspserver.GfSpReimburseQuotaResponse, error) {
+	return &gfspserver.GfSpReimburseQuotaResponse{Err: ErrExceptionsStream}, nil
+}
+
 type mockManagerServer struct{}
 
 func (mockManagerServer) GfSpBeginTask(ctx context.Context, req *gfspserver.GfSpBeginTaskRequest) (

--- a/base/gfspclient/interface.go
+++ b/base/gfspclient/interface.go
@@ -62,6 +62,7 @@ type DownloaderAPI interface {
 	GetObject(ctx context.Context, downloadObjectTask coretask.DownloadObjectTask, opts ...grpc.DialOption) ([]byte, error)
 	GetPiece(ctx context.Context, downloadPieceTask coretask.DownloadPieceTask, opts ...grpc.DialOption) ([]byte, error)
 	GetChallengeInfo(ctx context.Context, challengePieceTask coretask.ChallengePieceTask, opts ...grpc.DialOption) ([]byte, [][]byte, []byte, error)
+	RecoupQuota(ctx context.Context, bucketID, extraQuota uint64, yearMonth string, opts ...grpc.DialOption) error
 }
 
 // GaterAPI for mock use

--- a/base/gfspclient/interface.go
+++ b/base/gfspclient/interface.go
@@ -18,9 +18,7 @@ import (
 	payment_types "github.com/bnb-chain/greenfield/x/payment/types"
 	permission_types "github.com/bnb-chain/greenfield/x/permission/types"
 	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
-	storage_types "github.com/bnb-chain/greenfield/x/storage/types"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
-	virtual_types "github.com/bnb-chain/greenfield/x/virtualgroup/types"
 	virtualgrouptypes "github.com/bnb-chain/greenfield/x/virtualgroup/types"
 )
 
@@ -102,26 +100,26 @@ type MetadataAPI interface {
 	VerifyPermission(ctx context.Context, Operator string, bucketName string, objectName string, actionType permission_types.ActionType, opts ...grpc.DialOption) (*permission_types.Effect, error)
 	GetBucketMeta(ctx context.Context, bucketName string, includePrivate bool, opts ...grpc.DialOption) (*types.Bucket, *payment_types.StreamRecord, error)
 	GetEndpointBySpID(ctx context.Context, spID uint32, opts ...grpc.DialOption) (string, error)
-	GetBucketReadQuota(ctx context.Context, bucket *storage_types.BucketInfo, yearMonth string, opts ...grpc.DialOption) (uint64, uint64, uint64, uint64, error)
-	ListBucketReadRecord(ctx context.Context, bucket *storage_types.BucketInfo, startTimestampUs, endTimestampUs, maxRecordNum int64, opts ...grpc.DialOption) ([]*types.ReadRecord, int64, error)
+	GetBucketReadQuota(ctx context.Context, bucket *storagetypes.BucketInfo, yearMonth string, opts ...grpc.DialOption) (uint64, uint64, uint64, uint64, error)
+	ListBucketReadRecord(ctx context.Context, bucket *storagetypes.BucketInfo, startTimestampUs, endTimestampUs, maxRecordNum int64, opts ...grpc.DialOption) ([]*types.ReadRecord, int64, error)
 	GetUploadObjectState(ctx context.Context, objectID uint64, opts ...grpc.DialOption) (int32, string, error)
 	GetUploadObjectSegment(ctx context.Context, objectID uint64, opts ...grpc.DialOption) (uint32, error)
 	GetGroupList(ctx context.Context, name string, prefix string, sourceType string, limit int64, offset int64, includeRemoved bool, opts ...grpc.DialOption) ([]*types.Group, int64, error)
 	ListBucketsByIDs(ctx context.Context, bucketIDs []uint64, includeRemoved bool, opts ...grpc.DialOption) (map[uint64]*types.Bucket, error)
 	ListObjectsByIDs(ctx context.Context, objectIDs []uint64, includeRemoved bool, opts ...grpc.DialOption) (map[uint64]*types.Object, error)
-	ListVirtualGroupFamiliesSpID(ctx context.Context, spID uint32, opts ...grpc.DialOption) ([]*virtual_types.GlobalVirtualGroupFamily, error)
-	GetGlobalVirtualGroupByGvgID(ctx context.Context, gvgID uint32, opts ...grpc.DialOption) (*virtual_types.GlobalVirtualGroup, error)
+	ListVirtualGroupFamiliesSpID(ctx context.Context, spID uint32, opts ...grpc.DialOption) ([]*virtualgrouptypes.GlobalVirtualGroupFamily, error)
+	GetGlobalVirtualGroupByGvgID(ctx context.Context, gvgID uint32, opts ...grpc.DialOption) (*virtualgrouptypes.GlobalVirtualGroup, error)
 	ListObjectsInGVGAndBucket(ctx context.Context, gvgID uint32, bucketID uint64, startAfter uint64, limit uint32, opts ...grpc.DialOption) ([]*types.ObjectDetails, error)
 	ListObjectsInGVG(ctx context.Context, gvgID uint32, startAfter uint64, limit uint32, opts ...grpc.DialOption) ([]*types.ObjectDetails, error)
 	ListObjectsByGVGAndBucketForGC(ctx context.Context, gvgID uint32, bucketID uint64, startAfter uint64, limit uint32, opts ...grpc.DialOption) ([]*types.ObjectDetails, error)
-	GetVirtualGroupFamily(ctx context.Context, vgfID uint32, opts ...grpc.DialOption) (*virtual_types.GlobalVirtualGroupFamily, error)
-	GetGlobalVirtualGroup(ctx context.Context, bucketID uint64, lvgID uint32, opts ...grpc.DialOption) (*virtual_types.GlobalVirtualGroup, error)
-	ListGlobalVirtualGroupsByBucket(ctx context.Context, bucketID uint64, opts ...grpc.DialOption) ([]*virtual_types.GlobalVirtualGroup, error)
-	ListGlobalVirtualGroupsBySecondarySP(ctx context.Context, spID uint32, opts ...grpc.DialOption) ([]*virtual_types.GlobalVirtualGroup, error)
+	GetVirtualGroupFamily(ctx context.Context, vgfID uint32, opts ...grpc.DialOption) (*virtualgrouptypes.GlobalVirtualGroupFamily, error)
+	GetGlobalVirtualGroup(ctx context.Context, bucketID uint64, lvgID uint32, opts ...grpc.DialOption) (*virtualgrouptypes.GlobalVirtualGroup, error)
+	ListGlobalVirtualGroupsByBucket(ctx context.Context, bucketID uint64, opts ...grpc.DialOption) ([]*virtualgrouptypes.GlobalVirtualGroup, error)
+	ListGlobalVirtualGroupsBySecondarySP(ctx context.Context, spID uint32, opts ...grpc.DialOption) ([]*virtualgrouptypes.GlobalVirtualGroup, error)
 	ListMigrateBucketEvents(ctx context.Context, blockID uint64, spID uint32, opts ...grpc.DialOption) ([]*types.ListMigrateBucketEvents, error)
 	ListSwapOutEvents(ctx context.Context, blockID uint64, spID uint32, opts ...grpc.DialOption) ([]*types.ListSwapOutEvents, error)
 	ListSpExitEvents(ctx context.Context, blockID uint64, spID uint32, opts ...grpc.DialOption) (*types.ListSpExitEvents, error)
-	GetObjectByID(ctx context.Context, objectID uint64, opts ...grpc.DialOption) (*storage_types.ObjectInfo, error)
+	GetObjectByID(ctx context.Context, objectID uint64, opts ...grpc.DialOption) (*storagetypes.ObjectInfo, error)
 	VerifyPermissionByID(ctx context.Context, Operator string, resourceType resource.ResourceType, resourceID uint64, actionType permission_types.ActionType, opts ...grpc.DialOption) (*permission_types.Effect, error)
 	GetSPInfo(ctx context.Context, operatorAddress string, opts ...grpc.DialOption) (*sptypes.StorageProvider, error)
 	GetStatus(ctx context.Context, opts ...grpc.DialOption) (*types.Status, error)
@@ -202,4 +200,5 @@ type GfSpConnAPI interface {
 // nolint:unused
 type stdLib interface {
 	io.Reader
+	io.ReadCloser
 }

--- a/base/gfspclient/interface_mock.go
+++ b/base/gfspclient/interface_mock.go
@@ -670,6 +670,23 @@ func (mr *MockGfSpClientAPIMockRecorder) GetPiece(ctx, downloadPieceTask interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPiece", reflect.TypeOf((*MockGfSpClientAPI)(nil).GetPiece), varargs...)
 }
 
+func (m *MockGfSpClientAPI) RecoupQuota(ctx context.Context, bucketID, extraQuota uint64, yearMonth string, opts ...grpc.DialOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, bucketID, extraQuota, yearMonth}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RecoupQuota", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (mr *MockGfSpClientAPIMockRecorder) RecoupQuota(ctx context.Context, bucketID, extraQuota,yearMonth interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, bucketID, extraQuota, yearMonth}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecoupQuota", reflect.TypeOf((*MockGfSpClientAPI)(nil).RecoupQuota), varargs...)
+}
+
 // GetPieceFromECChunks mocks base method.
 func (m *MockGfSpClientAPI) GetPieceFromECChunks(ctx context.Context, endpoint string, task task.RecoveryPieceTask) (io.ReadCloser, error) {
 	m.ctrl.T.Helper()
@@ -2214,6 +2231,23 @@ func (mr *MockDownloaderAPIMockRecorder) GetPiece(ctx, downloadPieceTask interfa
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, downloadPieceTask}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPiece", reflect.TypeOf((*MockDownloaderAPI)(nil).GetPiece), varargs...)
+}
+
+func (m *MockDownloaderAPI) RecoupQuota(ctx context.Context, bucketID, extraQuota uint64, yearMonth string, opts ...grpc.DialOption)  error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, bucketID,extraQuota,yearMonth}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RecoupQuota", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (mr *MockDownloaderAPIMockRecorder) RecoupQuota(ctx, bucketID, extraQuota, yearMonth interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, bucketID, extraQuota, yearMonth}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecoupQuota", reflect.TypeOf((*MockDownloaderAPI)(nil).RecoupQuota), varargs...)
 }
 
 // MockGaterAPI is a mock of GaterAPI interface.

--- a/base/gfspclient/interface_mock.go
+++ b/base/gfspclient/interface_mock.go
@@ -4191,6 +4191,20 @@ func (m *MockstdLib) EXPECT() *MockstdLibMockRecorder {
 	return m.recorder
 }
 
+// Close mocks base method.
+func (m *MockstdLib) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockstdLibMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockstdLib)(nil).Close))
+}
+
 // Read mocks base method.
 func (m *MockstdLib) Read(p []byte) (int, error) {
 	m.ctrl.T.Helper()

--- a/base/types/gfspserver/download.pb.go
+++ b/base/types/gfspserver/download.pb.go
@@ -333,6 +333,111 @@ func (m *GfSpGetChallengeInfoResponse) GetChecksums() [][]byte {
 	return nil
 }
 
+type GfSpReimburseQuotaRequest struct {
+	BucketId   uint64 `protobuf:"varint,1,opt,name=bucket_id,json=bucketId,proto3" json:"bucket_id,omitempty"`
+	ExtraQuota uint64 `protobuf:"varint,2,opt,name=extra_quota,json=extraQuota,proto3" json:"extra_quota,omitempty"`
+	// year_month is the query bucket quota's month, like "2023-03"
+	YearMonth string `protobuf:"bytes,3,opt,name=year_month,json=yearMonth,proto3" json:"year_month,omitempty"`
+}
+
+func (m *GfSpReimburseQuotaRequest) Reset()         { *m = GfSpReimburseQuotaRequest{} }
+func (m *GfSpReimburseQuotaRequest) String() string { return proto.CompactTextString(m) }
+func (*GfSpReimburseQuotaRequest) ProtoMessage()    {}
+func (*GfSpReimburseQuotaRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_4e9c5d8fc8df4b20, []int{6}
+}
+func (m *GfSpReimburseQuotaRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *GfSpReimburseQuotaRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_GfSpReimburseQuotaRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *GfSpReimburseQuotaRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GfSpReimburseQuotaRequest.Merge(m, src)
+}
+func (m *GfSpReimburseQuotaRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *GfSpReimburseQuotaRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_GfSpReimburseQuotaRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GfSpReimburseQuotaRequest proto.InternalMessageInfo
+
+func (m *GfSpReimburseQuotaRequest) GetBucketId() uint64 {
+	if m != nil {
+		return m.BucketId
+	}
+	return 0
+}
+
+func (m *GfSpReimburseQuotaRequest) GetExtraQuota() uint64 {
+	if m != nil {
+		return m.ExtraQuota
+	}
+	return 0
+}
+
+func (m *GfSpReimburseQuotaRequest) GetYearMonth() string {
+	if m != nil {
+		return m.YearMonth
+	}
+	return ""
+}
+
+type GfSpReimburseQuotaResponse struct {
+	Err *gfsperrors.GfSpError `protobuf:"bytes,1,opt,name=err,proto3" json:"err,omitempty"`
+}
+
+func (m *GfSpReimburseQuotaResponse) Reset()         { *m = GfSpReimburseQuotaResponse{} }
+func (m *GfSpReimburseQuotaResponse) String() string { return proto.CompactTextString(m) }
+func (*GfSpReimburseQuotaResponse) ProtoMessage()    {}
+func (*GfSpReimburseQuotaResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_4e9c5d8fc8df4b20, []int{7}
+}
+func (m *GfSpReimburseQuotaResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *GfSpReimburseQuotaResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_GfSpReimburseQuotaResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *GfSpReimburseQuotaResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GfSpReimburseQuotaResponse.Merge(m, src)
+}
+func (m *GfSpReimburseQuotaResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *GfSpReimburseQuotaResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_GfSpReimburseQuotaResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GfSpReimburseQuotaResponse proto.InternalMessageInfo
+
+func (m *GfSpReimburseQuotaResponse) GetErr() *gfsperrors.GfSpError {
+	if m != nil {
+		return m.Err
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterType((*GfSpDownloadObjectRequest)(nil), "base.types.gfspserver.GfSpDownloadObjectRequest")
 	proto.RegisterType((*GfSpDownloadObjectResponse)(nil), "base.types.gfspserver.GfSpDownloadObjectResponse")
@@ -340,6 +445,8 @@ func init() {
 	proto.RegisterType((*GfSpDownloadPieceResponse)(nil), "base.types.gfspserver.GfSpDownloadPieceResponse")
 	proto.RegisterType((*GfSpGetChallengeInfoRequest)(nil), "base.types.gfspserver.GfSpGetChallengeInfoRequest")
 	proto.RegisterType((*GfSpGetChallengeInfoResponse)(nil), "base.types.gfspserver.GfSpGetChallengeInfoResponse")
+	proto.RegisterType((*GfSpReimburseQuotaRequest)(nil), "base.types.gfspserver.GfSpReimburseQuotaRequest")
+	proto.RegisterType((*GfSpReimburseQuotaResponse)(nil), "base.types.gfspserver.GfSpReimburseQuotaResponse")
 }
 
 func init() {
@@ -347,39 +454,45 @@ func init() {
 }
 
 var fileDescriptor_4e9c5d8fc8df4b20 = []byte{
-	// 505 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x54, 0xdd, 0x6e, 0xd3, 0x30,
-	0x14, 0x6e, 0xe8, 0x84, 0x84, 0x19, 0x48, 0xf3, 0x86, 0x14, 0xc2, 0x14, 0x95, 0x08, 0xa4, 0x0a,
-	0xd4, 0x78, 0x74, 0x6f, 0xc0, 0xdf, 0xe0, 0x0a, 0x94, 0x71, 0x35, 0x09, 0x15, 0xc7, 0x39, 0x4d,
-	0x42, 0x3b, 0x3b, 0xd8, 0x6e, 0x61, 0xc0, 0x0d, 0x6f, 0xb0, 0xf7, 0xe0, 0x45, 0xb8, 0xdc, 0x25,
-	0x97, 0xa8, 0x7d, 0x11, 0x14, 0xf7, 0x2f, 0x24, 0x29, 0xdb, 0xa4, 0xdd, 0x24, 0xd6, 0x39, 0xe7,
-	0xfb, 0x3e, 0x7f, 0x3e, 0xc7, 0x46, 0x0f, 0x42, 0xaa, 0x80, 0xe8, 0x93, 0x0c, 0x14, 0x89, 0xfb,
-	0x2a, 0x53, 0x20, 0xc7, 0x20, 0x49, 0x24, 0x3e, 0xf3, 0xa1, 0xa0, 0x91, 0x9f, 0x49, 0xa1, 0x05,
-	0xbe, 0x93, 0x57, 0xf9, 0xa6, 0xca, 0x5f, 0x55, 0x39, 0xf7, 0x4b, 0x60, 0x90, 0x52, 0x48, 0x45,
-	0xcc, 0x6f, 0x86, 0x74, 0xdc, 0x52, 0x89, 0xa6, 0x6a, 0x40, 0xf2, 0xcf, 0x2c, 0xef, 0x7d, 0x45,
-	0x77, 0x0f, 0xfa, 0x87, 0xd9, 0xf3, 0xb9, 0xde, 0x9b, 0xf0, 0x23, 0x30, 0x1d, 0xc0, 0xa7, 0x11,
-	0x28, 0x8d, 0xdf, 0xa3, 0x9d, 0xc5, 0x46, 0x7a, 0xc2, 0x64, 0x7a, 0x39, 0xd4, 0xb6, 0x5a, 0x56,
-	0xfb, 0x66, 0xf7, 0xb1, 0x5f, 0xda, 0x95, 0xa1, 0xad, 0xb2, 0xbd, 0xa3, 0x6a, 0x10, 0xe0, 0xa8,
-	0x12, 0xf3, 0x22, 0xe4, 0xd4, 0x69, 0xab, 0x4c, 0x70, 0x05, 0xb8, 0x8b, 0x9a, 0x20, 0xe5, 0x5c,
-	0xab, 0x55, 0xd6, 0x9a, 0x59, 0x35, 0x6a, 0x2f, 0xf2, 0x65, 0x90, 0x17, 0x63, 0x8c, 0x36, 0x22,
-	0xaa, 0xa9, 0x7d, 0xad, 0x65, 0xb5, 0x37, 0x03, 0xb3, 0xf6, 0xc6, 0xc8, 0x2e, 0xaa, 0xbc, 0x4d,
-	0x81, 0xc1, 0xc2, 0xe0, 0x11, 0xda, 0x5e, 0x1a, 0xcc, 0xf2, 0x44, 0xd1, 0xdf, 0xa3, 0x73, 0xfd,
-	0x19, 0x2e, 0x63, 0x6f, 0x2b, 0x2a, 0x87, 0x3c, 0xf6, 0xef, 0xc9, 0xce, 0x75, 0xaf, 0xd8, 0xdc,
-	0x77, 0x74, 0x2f, 0xaf, 0x3a, 0x00, 0xfd, 0x2c, 0xa1, 0xc3, 0x21, 0xf0, 0x18, 0x5e, 0xf3, 0xbe,
-	0x28, 0x34, 0x90, 0x2d, 0xe2, 0x55, 0x83, 0xeb, 0x1b, 0xb8, 0x24, 0x5b, 0x39, 0xc4, 0xac, 0x12,
-	0xf3, 0x7e, 0x5a, 0x68, 0xb7, 0x5e, 0xfe, 0x6a, 0x6d, 0xe2, 0x87, 0xe8, 0x76, 0xca, 0x35, 0xc4,
-	0x32, 0xd5, 0x27, 0xbd, 0x84, 0xaa, 0xc4, 0x6e, 0x9a, 0xec, 0xad, 0x65, 0xf4, 0x15, 0x55, 0x09,
-	0xde, 0x45, 0x37, 0x58, 0x02, 0x6c, 0xa0, 0x46, 0xc7, 0xca, 0xde, 0x68, 0x35, 0xdb, 0x9b, 0xc1,
-	0x2a, 0xd0, 0x3d, 0x6d, 0xa2, 0xed, 0x62, 0x47, 0x0e, 0x41, 0x8e, 0x53, 0x06, 0xf8, 0x1b, 0xc2,
-	0xd5, 0x31, 0xc4, 0x7b, 0x7e, 0xed, 0x9d, 0xf3, 0xd7, 0xde, 0x16, 0xe7, 0xc9, 0x25, 0x10, 0xb3,
-	0xf3, 0xf1, 0x1a, 0xf8, 0x0b, 0xda, 0xaa, 0x4c, 0x09, 0x26, 0x17, 0x60, 0x2a, 0xce, 0xb1, 0xb3,
-	0x77, 0x71, 0xc0, 0x52, 0xf9, 0x87, 0x85, 0x76, 0xea, 0x9a, 0x87, 0xbb, 0xff, 0x21, 0x5b, 0x33,
-	0x68, 0xce, 0xfe, 0xa5, 0x30, 0x8b, 0x3d, 0x3c, 0xfd, 0xf0, 0x6b, 0xe2, 0x5a, 0x67, 0x13, 0xd7,
-	0xfa, 0x33, 0x71, 0xad, 0xd3, 0xa9, 0xdb, 0x38, 0x9b, 0xba, 0x8d, 0xdf, 0x53, 0xb7, 0x71, 0xf4,
-	0x32, 0x4e, 0x75, 0x32, 0x0a, 0x7d, 0x26, 0x8e, 0x49, 0xc8, 0xc3, 0x0e, 0x4b, 0x68, 0xca, 0x49,
-	0x2c, 0x01, 0x78, 0x3f, 0x85, 0x61, 0xd4, 0x51, 0x5a, 0x48, 0x1a, 0x43, 0x27, 0x93, 0x62, 0x9c,
-	0x46, 0x20, 0x49, 0xed, 0x43, 0x1a, 0x5e, 0x37, 0xcf, 0xdc, 0xfe, 0xdf, 0x00, 0x00, 0x00, 0xff,
-	0xff, 0x6f, 0xd6, 0xc1, 0x00, 0x68, 0x05, 0x00, 0x00,
+	// 602 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x55, 0xcb, 0x6e, 0xd3, 0x40,
+	0x14, 0x8d, 0x69, 0x84, 0xc8, 0xb4, 0x20, 0x75, 0x5a, 0xa4, 0xe0, 0x16, 0x13, 0x2c, 0x90, 0x2a,
+	0x50, 0xed, 0x92, 0xfe, 0x01, 0xaf, 0xd2, 0x05, 0xa2, 0xb8, 0xac, 0x2a, 0x21, 0x33, 0xb6, 0x6f,
+	0x6c, 0x93, 0xc4, 0xe3, 0xce, 0x8c, 0x43, 0x02, 0x6c, 0xf8, 0x00, 0x24, 0xfe, 0x83, 0x1f, 0x61,
+	0xd9, 0x25, 0x4b, 0x94, 0xfc, 0x08, 0xf2, 0x38, 0xaf, 0xda, 0x4e, 0x68, 0x51, 0x37, 0x89, 0x75,
+	0xee, 0xe3, 0xdc, 0x73, 0x1f, 0x36, 0x7a, 0xe0, 0x10, 0x0e, 0xa6, 0x18, 0xc4, 0xc0, 0x4d, 0xbf,
+	0xc5, 0x63, 0x0e, 0xac, 0x07, 0xcc, 0xf4, 0xe8, 0xa7, 0xa8, 0x43, 0x89, 0x67, 0xc4, 0x8c, 0x0a,
+	0x8a, 0x6f, 0xa7, 0x5e, 0x86, 0xf4, 0x32, 0x66, 0x5e, 0xea, 0xfd, 0x5c, 0x30, 0x30, 0x46, 0x19,
+	0x37, 0xe5, 0x5f, 0x16, 0xa9, 0x6a, 0x39, 0x17, 0x41, 0x78, 0xdb, 0x4c, 0x7f, 0x32, 0xbb, 0xfe,
+	0x19, 0xdd, 0x39, 0x68, 0x1d, 0xc7, 0xcf, 0xc7, 0x7c, 0x6f, 0x9c, 0x8f, 0xe0, 0x0a, 0x0b, 0x4e,
+	0x13, 0xe0, 0x02, 0xbf, 0x47, 0x9b, 0x93, 0x42, 0x6c, 0x2a, 0x2d, 0x76, 0x1a, 0x5a, 0x57, 0x1a,
+	0xca, 0xce, 0x6a, 0xf3, 0xb1, 0x91, 0xab, 0x4a, 0xa6, 0x2d, 0x66, 0x7b, 0x47, 0x78, 0xdb, 0xc2,
+	0x5e, 0x01, 0xd3, 0x3d, 0xa4, 0x96, 0x71, 0xf3, 0x98, 0x46, 0x1c, 0x70, 0x13, 0xad, 0x00, 0x63,
+	0x63, 0xae, 0x46, 0x9e, 0x2b, 0x93, 0x2a, 0xd9, 0x5e, 0xa4, 0x8f, 0x56, 0xea, 0x8c, 0x31, 0xaa,
+	0x7a, 0x44, 0x90, 0xfa, 0xb5, 0x86, 0xb2, 0xb3, 0x66, 0xc9, 0x67, 0xbd, 0x87, 0xea, 0xf3, 0x2c,
+	0x47, 0x21, 0xb8, 0x30, 0x11, 0x78, 0x82, 0x36, 0xa6, 0x02, 0xe3, 0xd4, 0x30, 0xaf, 0xef, 0xd1,
+	0x3f, 0xf5, 0xc9, 0x5c, 0x52, 0xde, 0xba, 0x97, 0x87, 0x74, 0xf7, 0x7c, 0x67, 0xc7, 0xbc, 0x57,
+	0x2c, 0xee, 0x2b, 0xda, 0x4a, 0xbd, 0x0e, 0x40, 0x3c, 0x0b, 0x48, 0xa7, 0x03, 0x91, 0x0f, 0x87,
+	0x51, 0x8b, 0xce, 0x0d, 0xd0, 0x9d, 0xe0, 0x45, 0x81, 0x8b, 0x07, 0x38, 0x4d, 0x36, 0x53, 0x88,
+	0xdd, 0x02, 0xa6, 0xff, 0x54, 0xd0, 0x76, 0x39, 0xfd, 0xd5, 0xca, 0xc4, 0x0f, 0xd1, 0xad, 0x30,
+	0x12, 0xe0, 0xb3, 0x50, 0x0c, 0xec, 0x80, 0xf0, 0xa0, 0xbe, 0x22, 0xad, 0x37, 0xa7, 0xe8, 0x2b,
+	0xc2, 0x03, 0xbc, 0x8d, 0x6a, 0x6e, 0x00, 0x6e, 0x9b, 0x27, 0x5d, 0x5e, 0xaf, 0x36, 0x56, 0x76,
+	0xd6, 0xac, 0x19, 0xa0, 0xf7, 0xb3, 0x81, 0x58, 0x10, 0x76, 0x9d, 0x84, 0x71, 0x78, 0x9b, 0x50,
+	0x41, 0x26, 0x9d, 0xda, 0x42, 0x35, 0x27, 0x71, 0xdb, 0x20, 0xec, 0xd0, 0x93, 0xf5, 0x56, 0xad,
+	0x1b, 0x19, 0x70, 0xe8, 0xe1, 0x7b, 0x68, 0x15, 0xfa, 0x82, 0x11, 0xfb, 0x34, 0x0d, 0x91, 0x95,
+	0x55, 0x2d, 0x24, 0x21, 0x99, 0x04, 0xdf, 0x45, 0x68, 0x00, 0x84, 0xd9, 0x5d, 0x1a, 0x89, 0xac,
+	0xb6, 0x9a, 0x55, 0x4b, 0x91, 0xd7, 0x29, 0xa0, 0x1f, 0x65, 0x8b, 0x9e, 0x67, 0xfe, 0xff, 0x26,
+	0x35, 0xbf, 0x57, 0xd1, 0xc6, 0xfc, 0x76, 0x1d, 0x03, 0xeb, 0x85, 0x2e, 0xe0, 0x2f, 0x08, 0x17,
+	0x4f, 0x0a, 0xef, 0x19, 0xa5, 0xef, 0x0f, 0x63, 0xe1, 0xe5, 0xab, 0x4f, 0x2e, 0x11, 0x91, 0xc9,
+	0xd0, 0x2b, 0xb8, 0x8f, 0xd6, 0x0b, 0x1b, 0x8f, 0xcd, 0x0b, 0x64, 0x9a, 0xbf, 0x49, 0x75, 0xef,
+	0xe2, 0x01, 0x53, 0xe6, 0x6f, 0x0a, 0xda, 0x2c, 0x5b, 0x44, 0xdc, 0x5c, 0x92, 0x6c, 0xc1, 0xd1,
+	0xa8, 0xfb, 0x97, 0x8a, 0x99, 0xd6, 0x30, 0x6e, 0xfd, 0xf9, 0x21, 0x2f, 0x6d, 0x7d, 0xe9, 0x26,
+	0x2e, 0x6d, 0x7d, 0xf9, 0x06, 0xe9, 0x95, 0xa7, 0x1f, 0x7e, 0x0d, 0x35, 0xe5, 0x6c, 0xa8, 0x29,
+	0x7f, 0x86, 0x9a, 0xf2, 0x63, 0xa4, 0x55, 0xce, 0x46, 0x5a, 0xe5, 0xf7, 0x48, 0xab, 0x9c, 0xbc,
+	0xf4, 0x43, 0x11, 0x24, 0x8e, 0xe1, 0xd2, 0xae, 0xe9, 0x44, 0xce, 0xae, 0x1b, 0x90, 0x30, 0x32,
+	0x7d, 0x06, 0x10, 0xb5, 0x42, 0xe8, 0x78, 0xbb, 0x5c, 0x50, 0x46, 0x7c, 0xd8, 0x8d, 0x19, 0xed,
+	0x85, 0x1e, 0x30, 0xb3, 0xf4, 0x8b, 0xe4, 0x5c, 0x97, 0xdf, 0x8b, 0xfd, 0xbf, 0x01, 0x00, 0x00,
+	0xff, 0xff, 0x74, 0x6d, 0x4b, 0x17, 0xb1, 0x06, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -397,6 +510,7 @@ type GfSpDownloadServiceClient interface {
 	GfSpDownloadObject(ctx context.Context, in *GfSpDownloadObjectRequest, opts ...grpc.CallOption) (*GfSpDownloadObjectResponse, error)
 	GfSpDownloadPiece(ctx context.Context, in *GfSpDownloadPieceRequest, opts ...grpc.CallOption) (*GfSpDownloadPieceResponse, error)
 	GfSpGetChallengeInfo(ctx context.Context, in *GfSpGetChallengeInfoRequest, opts ...grpc.CallOption) (*GfSpGetChallengeInfoResponse, error)
+	GfSpReimburseQuota(ctx context.Context, in *GfSpReimburseQuotaRequest, opts ...grpc.CallOption) (*GfSpReimburseQuotaResponse, error)
 }
 
 type gfSpDownloadServiceClient struct {
@@ -434,11 +548,21 @@ func (c *gfSpDownloadServiceClient) GfSpGetChallengeInfo(ctx context.Context, in
 	return out, nil
 }
 
+func (c *gfSpDownloadServiceClient) GfSpReimburseQuota(ctx context.Context, in *GfSpReimburseQuotaRequest, opts ...grpc.CallOption) (*GfSpReimburseQuotaResponse, error) {
+	out := new(GfSpReimburseQuotaResponse)
+	err := c.cc.Invoke(ctx, "/base.types.gfspserver.GfSpDownloadService/GfSpReimburseQuota", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // GfSpDownloadServiceServer is the server API for GfSpDownloadService service.
 type GfSpDownloadServiceServer interface {
 	GfSpDownloadObject(context.Context, *GfSpDownloadObjectRequest) (*GfSpDownloadObjectResponse, error)
 	GfSpDownloadPiece(context.Context, *GfSpDownloadPieceRequest) (*GfSpDownloadPieceResponse, error)
 	GfSpGetChallengeInfo(context.Context, *GfSpGetChallengeInfoRequest) (*GfSpGetChallengeInfoResponse, error)
+	GfSpReimburseQuota(context.Context, *GfSpReimburseQuotaRequest) (*GfSpReimburseQuotaResponse, error)
 }
 
 // UnimplementedGfSpDownloadServiceServer can be embedded to have forward compatible implementations.
@@ -453,6 +577,9 @@ func (*UnimplementedGfSpDownloadServiceServer) GfSpDownloadPiece(ctx context.Con
 }
 func (*UnimplementedGfSpDownloadServiceServer) GfSpGetChallengeInfo(ctx context.Context, req *GfSpGetChallengeInfoRequest) (*GfSpGetChallengeInfoResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GfSpGetChallengeInfo not implemented")
+}
+func (*UnimplementedGfSpDownloadServiceServer) GfSpReimburseQuota(ctx context.Context, req *GfSpReimburseQuotaRequest) (*GfSpReimburseQuotaResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GfSpReimburseQuota not implemented")
 }
 
 func RegisterGfSpDownloadServiceServer(s grpc1.Server, srv GfSpDownloadServiceServer) {
@@ -513,6 +640,24 @@ func _GfSpDownloadService_GfSpGetChallengeInfo_Handler(srv interface{}, ctx cont
 	return interceptor(ctx, in, info, handler)
 }
 
+func _GfSpDownloadService_GfSpReimburseQuota_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GfSpReimburseQuotaRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(GfSpDownloadServiceServer).GfSpReimburseQuota(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/base.types.gfspserver.GfSpDownloadService/GfSpReimburseQuota",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(GfSpDownloadServiceServer).GfSpReimburseQuota(ctx, req.(*GfSpReimburseQuotaRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _GfSpDownloadService_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "base.types.gfspserver.GfSpDownloadService",
 	HandlerType: (*GfSpDownloadServiceServer)(nil),
@@ -528,6 +673,10 @@ var _GfSpDownloadService_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GfSpGetChallengeInfo",
 			Handler:    _GfSpDownloadService_GfSpGetChallengeInfo_Handler,
+		},
+		{
+			MethodName: "GfSpReimburseQuota",
+			Handler:    _GfSpDownloadService_GfSpReimburseQuota_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -781,6 +930,81 @@ func (m *GfSpGetChallengeInfoResponse) MarshalToSizedBuffer(dAtA []byte) (int, e
 	return len(dAtA) - i, nil
 }
 
+func (m *GfSpReimburseQuotaRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GfSpReimburseQuotaRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *GfSpReimburseQuotaRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.YearMonth) > 0 {
+		i -= len(m.YearMonth)
+		copy(dAtA[i:], m.YearMonth)
+		i = encodeVarintDownload(dAtA, i, uint64(len(m.YearMonth)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.ExtraQuota != 0 {
+		i = encodeVarintDownload(dAtA, i, uint64(m.ExtraQuota))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.BucketId != 0 {
+		i = encodeVarintDownload(dAtA, i, uint64(m.BucketId))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GfSpReimburseQuotaResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GfSpReimburseQuotaResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *GfSpReimburseQuotaResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Err != nil {
+		{
+			size, err := m.Err.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintDownload(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintDownload(dAtA []byte, offset int, v uint64) int {
 	offset -= sovDownload(v)
 	base := offset
@@ -888,6 +1112,38 @@ func (m *GfSpGetChallengeInfoResponse) Size() (n int) {
 			l = len(b)
 			n += 1 + l + sovDownload(uint64(l))
 		}
+	}
+	return n
+}
+
+func (m *GfSpReimburseQuotaRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.BucketId != 0 {
+		n += 1 + sovDownload(uint64(m.BucketId))
+	}
+	if m.ExtraQuota != 0 {
+		n += 1 + sovDownload(uint64(m.ExtraQuota))
+	}
+	l = len(m.YearMonth)
+	if l > 0 {
+		n += 1 + l + sovDownload(uint64(l))
+	}
+	return n
+}
+
+func (m *GfSpReimburseQuotaResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Err != nil {
+		l = m.Err.Size()
+		n += 1 + l + sovDownload(uint64(l))
 	}
 	return n
 }
@@ -1560,6 +1816,212 @@ func (m *GfSpGetChallengeInfoResponse) Unmarshal(dAtA []byte) error {
 			}
 			m.Checksums = append(m.Checksums, make([]byte, postIndex-iNdEx))
 			copy(m.Checksums[len(m.Checksums)-1], dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipDownload(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthDownload
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GfSpReimburseQuotaRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowDownload
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GfSpReimburseQuotaRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GfSpReimburseQuotaRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BucketId", wireType)
+			}
+			m.BucketId = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDownload
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.BucketId |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExtraQuota", wireType)
+			}
+			m.ExtraQuota = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDownload
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ExtraQuota |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field YearMonth", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDownload
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthDownload
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthDownload
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.YearMonth = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipDownload(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthDownload
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GfSpReimburseQuotaResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowDownload
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GfSpReimburseQuotaResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GfSpReimburseQuotaResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Err", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDownload
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthDownload
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthDownload
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Err == nil {
+				m.Err = &gfsperrors.GfSpError{}
+			}
+			if err := m.Err.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/base/types/gfsptask/recovery.go
+++ b/base/types/gfsptask/recovery.go
@@ -187,7 +187,7 @@ func (m *GfSpRecoverPieceTask) GetSignBytes() []byte {
 	fakeMsg := &GfSpRecoverPieceTask{
 		ObjectInfo:    m.GetObjectInfo(),
 		StorageParams: m.GetStorageParams(),
-		Task:          &GfSpTask{CreateTime: m.GetCreateTime()},
+		Task:          &GfSpTask{CreateTime: m.GetCreateTime(), UpdateTime: m.GetUpdateTime()},
 		PieceSize:     m.GetPieceSize(),
 		SegmentIdx:    m.GetSegmentIdx(),
 		// TODO rename EcIdx to ReplicateIdx

--- a/base/types/gfsptask/upload.go
+++ b/base/types/gfsptask/upload.go
@@ -687,7 +687,7 @@ func (m *GfSpReceivePieceTask) GetSignBytes() []byte {
 	fakeMsg := &GfSpReceivePieceTask{
 		ObjectInfo:    m.GetObjectInfo(),
 		StorageParams: m.GetStorageParams(),
-		Task:          &GfSpTask{CreateTime: m.GetCreateTime()},
+		Task:          &GfSpTask{CreateTime: m.GetCreateTime(), UpdateTime: m.GetUpdateTime()},
 		SegmentIdx:    m.GetSegmentIdx(),
 		RedundancyIdx: m.GetRedundancyIdx(),
 		PieceSize:     m.GetPieceSize(),

--- a/core/module/modular.go
+++ b/core/module/modular.go
@@ -125,7 +125,6 @@ type Downloader interface {
 	// PostDownloadPiece is called after HandleDownloadPieceTask, it can recycle
 	// resources, make statistics and do some other operations.
 	PostDownloadPiece(ctx context.Context, task task.DownloadPieceTask)
-
 	// PreChallengePiece prepares to handle ChallengePiece, it can do some checks
 	// such as checking for duplicates, if limitation of SP has been reached, etc.
 	PreChallengePiece(ctx context.Context, task task.ChallengePieceTask) error

--- a/core/spdb/spdb.go
+++ b/core/spdb/spdb.go
@@ -95,6 +95,8 @@ type TrafficDB interface {
 	// GetBucketTraffic return bucket traffic info,
 	// notice maybe return (nil, nil) while there is no bucket traffic.
 	GetBucketTraffic(bucketID uint64, yearMonth string) (*BucketTraffic, error)
+	// UpdateExtraQuota update the read consumed quota and free consumed quota in traffic db with the extra quota
+	UpdateExtraQuota(bucketID, extraQuota uint64, yearMonth string) error
 	// GetReadRecord return record list by time range.
 	GetReadRecord(timeRange *TrafficTimeRange) ([]*ReadRecord, error)
 	// GetBucketReadRecord return bucket record list by time range.

--- a/core/spdb/spdb_mock.go
+++ b/core/spdb/spdb_mock.go
@@ -262,6 +262,20 @@ func (mr *MockSPDBMockRecorder) GetBucketTraffic(bucketID, yearMonth interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketTraffic", reflect.TypeOf((*MockSPDB)(nil).GetBucketTraffic), bucketID, yearMonth)
 }
 
+// FixExtraQuota  mocks base method.
+func (m *MockSPDB) UpdateExtraQuota(bucketID, extraQuota uint64, yearMonth string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateExtraQuota", bucketID, extraQuota,yearMonth)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+//  FixExtraQuota indicates an expected call of FixExtraQuota.
+func (mr *MockSPDBMockRecorder) UpdateExtraQuota(bucketID, extraQuota,yearMonth interface{})  *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateExtraQuota", reflect.TypeOf((*MockSPDB)(nil).UpdateExtraQuota), bucketID, extraQuota, yearMonth)
+}
+
 // GetGCMetasToGC mocks base method.
 func (m *MockSPDB) GetGCMetasToGC(limit int) ([]*GCObjectMeta, error) {
 	m.ctrl.T.Helper()
@@ -1292,6 +1306,18 @@ func (m *MockTrafficDB) GetBucketTraffic(bucketID uint64, yearMonth string) (*Bu
 func (mr *MockTrafficDBMockRecorder) GetBucketTraffic(bucketID, yearMonth interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketTraffic", reflect.TypeOf((*MockTrafficDB)(nil).GetBucketTraffic), bucketID, yearMonth)
+}
+
+func (m *MockTrafficDB) UpdateExtraQuota(bucketID, extraQuota uint64, yearMonth string) error  {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateExtraQuota", bucketID, extraQuota, yearMonth)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (mr *MockTrafficDBMockRecorder) FixExtraQuota(bucketID, extraQuota, yearMonth interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateExtraQuota", reflect.TypeOf((*MockTrafficDB)(nil).GetBucketTraffic), bucketID, extraQuota, yearMonth)
 }
 
 // GetObjectReadRecord mocks base method.

--- a/modular/approver/approver_test.go
+++ b/modular/approver/approver_test.go
@@ -20,6 +20,7 @@ import (
 var mockErr = errors.New("mock error")
 
 func setup(t *testing.T) *ApprovalModular {
+	t.Helper()
 	return &ApprovalModular{baseApp: &gfspapp.GfSpBaseApp{}}
 }
 

--- a/modular/blocksyncer/modules/group/module.go
+++ b/modular/blocksyncer/modules/group/module.go
@@ -2,13 +2,14 @@ package group
 
 import (
 	"context"
-
-	"github.com/bnb-chain/greenfield-storage-provider/modular/blocksyncer/database"
-
-	"gorm.io/gorm/schema"
+	"fmt"
 
 	"github.com/forbole/juno/v4/models"
 	"github.com/forbole/juno/v4/modules"
+	"gorm.io/gorm/schema"
+
+	"github.com/bnb-chain/greenfield-storage-provider/modular/blocksyncer/database"
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
 )
 
 const (
@@ -42,7 +43,47 @@ func (m *Module) PrepareTables() error {
 	return m.db.PrepareTables(context.TODO(), []schema.Tabler{&models.Group{}})
 }
 
+// In this version, we need to create a unique index for the groups table
+// Before creating, we need to remove duplicate data from the table
+// This code will be removed in the next version
+func (m *Module) temporaryFixGroupData() {
+	log.Infof("start fix groups data")
+	exist := m.db.Db.Migrator().HasTable("groups")
+	if !exist {
+		log.Infof("fix groups data success")
+		return
+	}
+	tx := m.db.Db.Begin()
+	err := tx.Exec("CREATE TABLE `groups_temp` LIKE `groups`").Error
+	if err != nil {
+		tx.Rollback()
+		panic(fmt.Sprintf("fix groups data failed err: %v", err))
+	}
+	err = tx.Exec("INSERT INTO `groups_temp` select c1.* FROM `groups` c1 INNER JOIN `groups` c2 WHERE c1.id < c2.id AND c1.account_id = c2.account_id and c1.group_id = c2.group_id order by c1.id").Error
+	if err != nil {
+		tx.Rollback()
+		panic(fmt.Sprintf("fix groups data failed err: %v", err))
+	}
+	err = tx.Exec("delete from `groups` where id in (select id from `groups_temp`)").Error
+	if err != nil {
+		tx.Rollback()
+		panic(fmt.Sprintf("fix groups data failed err: %v", err))
+	}
+	err = tx.Exec("DROP TABLE `groups_temp`").Error
+	if err != nil {
+		tx.Rollback()
+		panic(fmt.Sprintf("fix groups data failed err: %v", err))
+	}
+	err = tx.Commit().Error
+	if err != nil {
+		tx.Rollback()
+		panic(fmt.Sprintf("fix groups data failed err: %v", err))
+	}
+	log.Infof("fix groups data success")
+}
+
 // AutoMigrate implements
 func (m *Module) AutoMigrate() error {
+	m.temporaryFixGroupData()
 	return m.db.AutoMigrate(context.TODO(), []schema.Tabler{&models.Group{}})
 }

--- a/modular/downloader/download_task.go
+++ b/modular/downloader/download_task.go
@@ -279,17 +279,6 @@ func (d *DownloadModular) PreDownloadPiece(ctx context.Context, downloadPieceTas
 		bucketID := downloadPieceTask.GetBucketInfo().Id.Uint64()
 		bucketName := downloadPieceTask.GetBucketInfo().GetBucketName()
 
-		// if stream account has been frozen, it is not allowed to download
-		streamRecord, checkErr := d.baseApp.GfSpClient().GetPaymentByBucketName(ctx, bucketName, true)
-		if checkErr == nil {
-			if streamRecord.Status != payment_types.STREAM_ACCOUNT_STATUS_ACTIVE {
-				return ErrAccountFrozen
-			}
-		} else {
-			// the meta service happen error will not be return
-			log.CtxDebugw(ctx, "failed to get stream record info", "error", checkErr)
-		}
-
 		readRecord := &spdb.ReadRecord{
 			BucketID:        bucketID,
 			ObjectID:        downloadPieceTask.GetObjectInfo().Id.Uint64(),

--- a/modular/executor/execute_replicate.go
+++ b/modular/executor/execute_replicate.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/avast/retry-go/v4"
 	"github.com/prysmaticlabs/prysm/crypto/bls"
 
-	"github.com/avast/retry-go/v4"
 	"github.com/bnb-chain/greenfield-common/go/hash"
 	"github.com/bnb-chain/greenfield-common/go/redundancy"
 	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsptask"
@@ -294,17 +294,17 @@ func (e *ExecuteModular) doneReplicatePiece(ctx context.Context, rTask coretask.
 
 	// TODO:
 	// veritySignatureTime := time.Now()
-	// TODO get gvgID and blsPubKey from task, bls pub key alreay injected via key manager for current sp
+	// TODO get gvgID and blsPubKey from task, bls pub key already injected via key manager for current sp
 	// var blsPubKey bls.PublicKey
 	// err = veritySignature(ctx, rTask.GetObjectInfo().Id.Uint64(), rTask.GetGlobalVirtualGroupId(), integrity,
 	//	storagetypes.GenerateHash(rTask.GetObjectInfo().GetChecksums()[:]), signature, blsPubKey)
 	// metrics.PerfUploadTimeHistogram.WithLabelValues("background_verity_seal_signature_time").Observe(time.Since(veritySignatureTime).Seconds())
-	metrics.PerfPutObjectTime.WithLabelValues("background_verity_seal_signature_end_time").Observe(time.Since(signTime).Seconds())
-	if err != nil {
-		log.CtxErrorw(ctx, "failed verify secondary signature", "endpoint", spEndpoint,
-			"redundancy_idx", redundancyIdx, "error", err)
-		return nil, err
-	}
+	// metrics.PerfPutObjectTime.WithLabelValues("background_verity_seal_signature_end_time").Observe(time.Since(signTime).Seconds())
+	// if err != nil {
+	// 	log.CtxErrorw(ctx, "failed verify secondary signature", "endpoint", spEndpoint,
+	// 		"redundancy_idx", redundancyIdx, "error", err)
+	// 	return nil, err
+	// }
 	log.CtxDebugw(ctx, "succeed to done replicate", "endpoint", spEndpoint, "redundancy_idx", redundancyIdx)
 	return signature, nil
 }

--- a/modular/executor/execute_replicate_test.go
+++ b/modular/executor/execute_replicate_test.go
@@ -1,0 +1,1 @@
+package executor

--- a/modular/executor/executor.go
+++ b/modular/executor/executor.go
@@ -10,14 +10,14 @@ import (
 	"github.com/bnb-chain/greenfield-storage-provider/base/gfspapp"
 	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsperrors"
 	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsptask"
-	"github.com/bnb-chain/greenfield-storage-provider/core/module"
+	coremodule "github.com/bnb-chain/greenfield-storage-provider/core/module"
 	corercmgr "github.com/bnb-chain/greenfield-storage-provider/core/rcmgr"
 	coretask "github.com/bnb-chain/greenfield-storage-provider/core/task"
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/metrics"
 )
 
-var _ module.TaskExecutor = &ExecuteModular{}
+var _ coremodule.TaskExecutor = &ExecuteModular{}
 
 type ExecuteModular struct {
 	baseApp *gfspapp.GfSpBaseApp
@@ -51,7 +51,7 @@ type ExecuteModular struct {
 }
 
 func (e *ExecuteModular) Name() string {
-	return module.ExecuteModularName
+	return coremodule.ExecuteModularName
 }
 
 func (e *ExecuteModular) Start(ctx context.Context) error {
@@ -134,8 +134,8 @@ func (e *ExecuteModular) AskTask(ctx context.Context) error {
 	if askTask == nil {
 		metrics.ReqCounter.WithLabelValues(ExecutorFailureAskTask).Inc()
 		metrics.ReqTime.WithLabelValues(ExecutorFailureAskTask).Observe(time.Since(startTime).Seconds())
-		log.CtxErrorw(ctx, "failed to ask task due to dangling pointer",
-			"remaining", limit.String(), "error", err)
+		log.CtxErrorw(ctx, "failed to ask task due to dangling pointer", "remaining", limit.String(),
+			"error", err)
 		return ErrDanglingPointer
 	}
 	metrics.ReqCounter.WithLabelValues(ExecutorSuccessAskTask).Inc()
@@ -228,7 +228,7 @@ func (e *ExecuteModular) AskTask(ctx context.Context) error {
 	default:
 		log.CtxError(ctx, "unsupported task type")
 	}
-	log.CtxDebug(ctx, "finish to handle task")
+	log.CtxDebug(ctx, "finished to handle task")
 	return nil
 }
 
@@ -245,7 +245,7 @@ func (e *ExecuteModular) ReportTask(ctx context.Context, task coretask.Task) (er
 	}()
 
 	err = e.baseApp.GfSpClient().ReportTask(ctx, task)
-	log.CtxDebugw(ctx, "finish to report task", "task_info", task.Info(), "error", err)
+	log.CtxDebugw(ctx, "finished to report task", "task_info", task.Info(), "error", err)
 	return err
 }
 

--- a/modular/executor/executor_options.go
+++ b/modular/executor/executor_options.go
@@ -71,13 +71,11 @@ const (
 
 func NewExecuteModular(app *gfspapp.GfSpBaseApp, cfg *gfspconfig.GfSpConfig) (coremodule.Modular, error) {
 	executor := &ExecuteModular{baseApp: app}
-	if err := DefaultExecutorOptions(executor, cfg); err != nil {
-		return nil, err
-	}
+	defaultExecutorOptions(executor, cfg)
 	return executor, nil
 }
 
-func DefaultExecutorOptions(executor *ExecuteModular, cfg *gfspconfig.GfSpConfig) error {
+func defaultExecutorOptions(executor *ExecuteModular, cfg *gfspconfig.GfSpConfig) {
 	if cfg.Executor.MaxExecuteNumber == 0 {
 		// TODO:: DefaultExecutorMaxExecuteNum should core_num * multiple, the core_num is compatible with docker
 		cfg.Executor.MaxExecuteNumber = DefaultExecutorMaxExecuteNum
@@ -109,5 +107,4 @@ func DefaultExecutorOptions(executor *ExecuteModular, cfg *gfspconfig.GfSpConfig
 	executor.maxListenSealRetry = cfg.Executor.MaxListenSealRetry
 	executor.statisticsOutputInterval = DefaultStatisticsOutputInterval
 	executor.enableSkipFailedToMigrateObject = cfg.Executor.EnableSkipFailedToMigrateObject
-	return nil
 }

--- a/modular/executor/executor_options_test.go
+++ b/modular/executor/executor_options_test.go
@@ -1,0 +1,17 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/bnb-chain/greenfield-storage-provider/base/gfspapp"
+	"github.com/bnb-chain/greenfield-storage-provider/base/gfspconfig"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewExecuteModular(t *testing.T) {
+	app := &gfspapp.GfSpBaseApp{}
+	cfg := &gfspconfig.GfSpConfig{}
+	result, err := NewExecuteModular(app, cfg)
+	assert.Nil(t, err)
+	assert.NotNil(t, result)
+}

--- a/modular/executor/executor_task_test.go
+++ b/modular/executor/executor_task_test.go
@@ -1,0 +1,1258 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/bnb-chain/greenfield-storage-provider/base/gfspclient"
+	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsptask"
+	"github.com/bnb-chain/greenfield-storage-provider/core/consensus"
+	"github.com/bnb-chain/greenfield-storage-provider/core/piecestore"
+	"github.com/bnb-chain/greenfield-storage-provider/core/spdb"
+	corespdb "github.com/bnb-chain/greenfield-storage-provider/core/spdb"
+	coretask "github.com/bnb-chain/greenfield-storage-provider/core/task"
+	metadatatypes "github.com/bnb-chain/greenfield-storage-provider/modular/metadata/types"
+	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
+	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
+	virtual_types "github.com/bnb-chain/greenfield/x/virtualgroup/types"
+)
+
+func TestErrGfSpDBWithDetail(t *testing.T) {
+	err := ErrGfSpDBWithDetail("test")
+	assert.NotNil(t, err)
+}
+
+func TestErrPieceStoreWithDetail(t *testing.T) {
+	err := ErrPieceStoreWithDetail("test")
+	assert.NotNil(t, err)
+}
+
+func TestErrConsensusWithDetail(t *testing.T) {
+	err := ErrConsensusWithDetail("test")
+	assert.NotNil(t, err)
+}
+
+func TestExecuteModular_HandleSealObjectTask(t *testing.T) {
+	cases := []struct {
+		name      string
+		task      coretask.SealObjectTask
+		fn        func() *ExecuteModular
+		wantedErr error
+	}{
+		{
+			name:      "dangling pointer",
+			task:      &gfsptask.GfSpSealObjectTask{Task: &gfsptask.GfSpTask{}},
+			fn:        func() *ExecuteModular { return setup(t) },
+			wantedErr: ErrDanglingPointer,
+		},
+		{
+			name: "invalid secondary sig",
+			task: &gfsptask.GfSpSealObjectTask{
+				Task:                &gfsptask.GfSpTask{MaxRetry: 1},
+				ObjectInfo:          &storagetypes.ObjectInfo{Id: sdkmath.NewUint(1)},
+				StorageParams:       &storagetypes.Params{},
+				SecondarySignatures: [][]byte{[]byte("test")},
+			},
+			fn:        func() *ExecuteModular { return setup(t) },
+			wantedErr: ErrUnsealed,
+		},
+		{
+			name: "object is sealed",
+			task: &gfsptask.GfSpSealObjectTask{
+				Task:          &gfsptask.GfSpTask{MaxRetry: 1},
+				ObjectInfo:    &storagetypes.ObjectInfo{Id: sdkmath.NewUint(1)},
+				StorageParams: &storagetypes.Params{},
+				SecondarySignatures: [][]byte{
+					{0xab, 0xb0, 0x12, 0x4c, 0x75, 0x74, 0xf2, 0x81, 0xa2, 0x93, 0xf4, 0x18, 0x5c, 0xad, 0x3c, 0xb2, 0x26, 0x81, 0xd5, 0x20, 0x91, 0x7c, 0xe4, 0x66, 0x65, 0x24, 0x3e, 0xac, 0xb0, 0x51, 0x00, 0x0d, 0x8b, 0xac, 0xf7, 0x5e, 0x14, 0x51, 0x87, 0x0c, 0xa6, 0xb3, 0xb9, 0xe6, 0xc9, 0xd4, 0x1a, 0x7b, 0x02, 0xea, 0xd2, 0x68, 0x5a, 0x84, 0x18, 0x8a, 0x4f, 0xaf, 0xd3, 0x82, 0x5d, 0xaf, 0x6a, 0x98, 0x96, 0x25, 0xd7, 0x19, 0xcc, 0xd2, 0xd8, 0x3a, 0x40, 0x10, 0x1f, 0x4a, 0x45, 0x3f, 0xca, 0x62, 0x87, 0x8c, 0x89, 0x0e, 0xca, 0x62, 0x23, 0x63, 0xf9, 0xdd, 0xb8, 0xf3, 0x67, 0xa9, 0x1e, 0x84},
+					{0xb7, 0x86, 0xe5, 0x7, 0x43, 0xe2, 0x53, 0x6c, 0x15, 0x51, 0x9c, 0x6, 0x2a, 0xa7, 0xe5, 0x12, 0xf9, 0xb7, 0x77, 0x93, 0x3f, 0x55, 0xb3, 0xaf, 0x38, 0xf7, 0x39, 0xe4, 0x84, 0x6d, 0x88, 0x44, 0x52, 0x77, 0x65, 0x42, 0x95, 0xd9, 0x79, 0x93, 0x7e, 0xc8, 0x12, 0x60, 0xe3, 0x24, 0xea, 0x8, 0x10, 0x52, 0xcd, 0xd2, 0x7f, 0x5d, 0x25, 0x3a, 0xa8, 0x9b, 0xb7, 0x65, 0xa9, 0x31, 0xea, 0x7c, 0x85, 0x13, 0x53, 0xc0, 0xa3, 0x88, 0xd1, 0xa5, 0x54, 0x85, 0x2, 0x2d, 0xf8, 0xa1, 0xd7, 0xc1, 0x60, 0x58, 0x93, 0xec, 0x7c, 0xf9, 0x33, 0x43, 0x4, 0x48, 0x40, 0x97, 0xef, 0x67, 0x2a, 0x27},
+					{0xb2, 0x12, 0xd0, 0xec, 0x46, 0x76, 0x6b, 0x24, 0x71, 0x91, 0x2e, 0xa8, 0x53, 0x9a, 0x48, 0xa3, 0x78, 0x30, 0xc, 0xe8, 0xf0, 0x86, 0xa3, 0x68, 0xec, 0xe8, 0x96, 0x43, 0x34, 0xda, 0xf, 0xf4, 0x65, 0x48, 0xbb, 0xe0, 0x92, 0xa1, 0x8, 0x12, 0x18, 0x46, 0xe6, 0x4a, 0xd6, 0x92, 0x88, 0xe, 0x2, 0xf5, 0xf3, 0x2a, 0x96, 0xb1, 0x4, 0xf1, 0x11, 0xa9, 0x92, 0x79, 0x52, 0x0, 0x64, 0x34, 0xeb, 0x25, 0xe, 0xf4, 0x29, 0x6b, 0x39, 0x4e, 0x28, 0x78, 0xfe, 0x25, 0xa3, 0xc0, 0x88, 0x5a, 0x40, 0xfd, 0x71, 0x37, 0x63, 0x79, 0xcd, 0x6b, 0x56, 0xda, 0xee, 0x91, 0x26, 0x72, 0xfc, 0xbc},
+					{0x8f, 0xc0, 0xb4, 0x9e, 0x2e, 0xac, 0x50, 0x86, 0xe2, 0xe2, 0xaa, 0xf, 0xdc, 0x54, 0x23, 0x51, 0x6, 0xd8, 0x29, 0xf5, 0xae, 0x3, 0x5d, 0xb8, 0x31, 0x4d, 0x26, 0x3, 0x48, 0x18, 0xb9, 0x1f, 0x6b, 0xd7, 0x86, 0xb4, 0xa2, 0x69, 0xc7, 0xe7, 0xf5, 0xc0, 0x93, 0x19, 0x6e, 0xfd, 0x33, 0xb8, 0x1, 0xe1, 0x1f, 0x4e, 0xb4, 0xb1, 0xa0, 0x1, 0x30, 0x48, 0x8a, 0x6c, 0x97, 0x29, 0xd6, 0xcb, 0x1c, 0x45, 0xef, 0x87, 0xba, 0x4f, 0xce, 0x22, 0x84, 0x48, 0xad, 0x16, 0xf7, 0x5c, 0xb2, 0xa8, 0x34, 0xb9, 0xee, 0xb8, 0xbf, 0xe5, 0x58, 0x2c, 0x44, 0x7b, 0x1f, 0x9c, 0x22, 0x26, 0x3a, 0x22},
+				},
+			},
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				e.maxListenSealRetry = 1
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().SealObject(gomock.Any(), gomock.Any()).Return("", mockErr).Times(2)
+				e.baseApp.SetGfSpClient(m)
+
+				m1 := consensus.NewMockConsensus(ctrl)
+				m1.EXPECT().ListenObjectSeal(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
+				e.baseApp.SetConsensus(m1)
+				return e
+			},
+			wantedErr: ErrUnsealed,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.fn().HandleSealObjectTask(context.TODO(), tt.task)
+		})
+	}
+}
+
+func TestExecuteModular_sealObject(t *testing.T) {
+	cases := []struct {
+		name      string
+		fn        func() *ExecuteModular
+		wantedErr error
+	}{
+		{
+			name: "object unsealed",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				e.maxListenSealRetry = 1
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().SealObject(gomock.Any(), gomock.Any()).Return("", mockErr).Times(2)
+				e.baseApp.SetGfSpClient(m)
+
+				m1 := consensus.NewMockConsensus(ctrl)
+				m1.EXPECT().ListenObjectSeal(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
+				e.baseApp.SetConsensus(m1)
+				return e
+			},
+			wantedErr: ErrUnsealed,
+		},
+		{
+			name: "object is sealed",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				e.maxListenSealRetry = 1
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().SealObject(gomock.Any(), gomock.Any()).Return("txHash", nil).Times(1)
+				e.baseApp.SetGfSpClient(m)
+
+				m1 := consensus.NewMockConsensus(ctrl)
+				m1.EXPECT().ListenObjectSeal(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
+				e.baseApp.SetConsensus(m1)
+				return e
+			},
+			wantedErr: nil,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			objectInfo := &storagetypes.ObjectInfo{Id: sdkmath.NewUint(1)}
+			task := &gfsptask.GfSpUploadObjectTask{
+				Task:                 &gfsptask.GfSpTask{MaxRetry: 1},
+				VirtualGroupFamilyId: 1,
+				ObjectInfo:           objectInfo,
+				StorageParams:        &storagetypes.Params{},
+			}
+			sealMsg := &storagetypes.MsgSealObject{ObjectName: "mockObjectName"}
+			err := tt.fn().sealObject(context.TODO(), task, sealMsg)
+			assert.Equal(t, tt.wantedErr, err)
+		})
+	}
+}
+
+func TestExecuteModular_listenSealObject(t *testing.T) {
+	cases := []struct {
+		name      string
+		fn        func() *ExecuteModular
+		wantedErr error
+	}{
+		{
+			name: "failed to listen object seal",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				e.maxListenSealRetry = 1
+				ctrl := gomock.NewController(t)
+				m := consensus.NewMockConsensus(ctrl)
+				m.EXPECT().ListenObjectSeal(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, mockErr).Times(1)
+				e.baseApp.SetConsensus(m)
+				return e
+			},
+			wantedErr: mockErr,
+		},
+		{
+			name: "object unsealed",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				e.maxListenSealRetry = 1
+				ctrl := gomock.NewController(t)
+				m := consensus.NewMockConsensus(ctrl)
+				m.EXPECT().ListenObjectSeal(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
+				e.baseApp.SetConsensus(m)
+				return e
+			},
+			wantedErr: ErrUnsealed,
+		},
+		{
+			name: "object is sealed",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				e.maxListenSealRetry = 1
+				ctrl := gomock.NewController(t)
+				m := consensus.NewMockConsensus(ctrl)
+				m.EXPECT().ListenObjectSeal(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
+				e.baseApp.SetConsensus(m)
+				return e
+			},
+			wantedErr: nil,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			objectInfo := &storagetypes.ObjectInfo{Id: sdkmath.NewUint(1)}
+			task := &gfsptask.GfSpUploadObjectTask{
+				Task:                 &gfsptask.GfSpTask{},
+				VirtualGroupFamilyId: 1,
+				ObjectInfo:           objectInfo,
+				StorageParams:        &storagetypes.Params{},
+			}
+			err := tt.fn().listenSealObject(context.TODO(), task, objectInfo)
+			assert.Equal(t, tt.wantedErr, err)
+		})
+	}
+}
+
+func TestExecuteModular_HandleReceivePieceTask(t *testing.T) {
+	cases := []struct {
+		name string
+		task coretask.ReceivePieceTask
+		fn   func() *ExecuteModular
+	}{
+		{
+			name: "task pointer dangling",
+			task: &gfsptask.GfSpReceivePieceTask{},
+			fn:   func() *ExecuteModular { return setup(t) },
+		},
+		{
+			name: "failed to get object info",
+			task: &gfsptask.GfSpReceivePieceTask{
+				Task:          &gfsptask.GfSpTask{},
+				ObjectInfo:    &storagetypes.ObjectInfo{Id: sdkmath.NewUint(1)},
+				StorageParams: &storagetypes.Params{MaxPayloadSize: 10},
+			},
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().GetObjectByID(gomock.Any(), gomock.Any()).Return(nil, mockErr).Times(1)
+				e.baseApp.SetGfSpClient(m)
+				return e
+			},
+		},
+		{
+			name: "failed to confirm receive task, object is unsealed",
+			task: &gfsptask.GfSpReceivePieceTask{
+				Task:          &gfsptask.GfSpTask{},
+				ObjectInfo:    &storagetypes.ObjectInfo{Id: sdkmath.NewUint(1)},
+				StorageParams: &storagetypes.Params{MaxPayloadSize: 10},
+			},
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().GetObjectByID(gomock.Any(), gomock.Any()).Return(&storagetypes.ObjectInfo{
+					ObjectStatus: storagetypes.OBJECT_STATUS_CREATED}, nil).Times(1)
+				e.baseApp.SetGfSpClient(m)
+				return e
+			},
+		},
+		{
+			name: "failed to get bucket by bucket name",
+			task: &gfsptask.GfSpReceivePieceTask{
+				Task:          &gfsptask.GfSpTask{},
+				ObjectInfo:    &storagetypes.ObjectInfo{Id: sdkmath.NewUint(1)},
+				StorageParams: &storagetypes.Params{MaxPayloadSize: 10},
+			},
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().GetObjectByID(gomock.Any(), gomock.Any()).Return(&storagetypes.ObjectInfo{
+					ObjectStatus: storagetypes.OBJECT_STATUS_SEALED}, nil).Times(1)
+				m.EXPECT().GetBucketByBucketName(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, mockErr).Times(1)
+				e.baseApp.SetGfSpClient(m)
+				return e
+			},
+		},
+		{
+			name: "failed to get global virtual group",
+			task: &gfsptask.GfSpReceivePieceTask{
+				Task:          &gfsptask.GfSpTask{},
+				ObjectInfo:    &storagetypes.ObjectInfo{Id: sdkmath.NewUint(1)},
+				StorageParams: &storagetypes.Params{MaxPayloadSize: 10},
+			},
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().GetObjectByID(gomock.Any(), gomock.Any()).Return(&storagetypes.ObjectInfo{
+					ObjectStatus: storagetypes.OBJECT_STATUS_SEALED}, nil).Times(1)
+				m.EXPECT().GetBucketByBucketName(gomock.Any(), gomock.Any(), gomock.Any()).Return(&metadatatypes.Bucket{
+					BucketInfo: &storagetypes.BucketInfo{Id: sdkmath.NewUint(1)}}, nil).Times(1)
+				m.EXPECT().GetGlobalVirtualGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, mockErr).Times(1)
+				e.baseApp.SetGfSpClient(m)
+				return e
+			},
+		},
+		{
+			name: "replicate idx out of bounds",
+			task: &gfsptask.GfSpReceivePieceTask{
+				Task:          &gfsptask.GfSpTask{},
+				ObjectInfo:    &storagetypes.ObjectInfo{Id: sdkmath.NewUint(1)},
+				StorageParams: &storagetypes.Params{MaxPayloadSize: 10},
+			},
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().GetObjectByID(gomock.Any(), gomock.Any()).Return(&storagetypes.ObjectInfo{
+					ObjectStatus: storagetypes.OBJECT_STATUS_SEALED}, nil).Times(1)
+				m.EXPECT().GetBucketByBucketName(gomock.Any(), gomock.Any(), gomock.Any()).Return(&metadatatypes.Bucket{
+					BucketInfo: &storagetypes.BucketInfo{Id: sdkmath.NewUint(1)}}, nil).Times(1)
+				m.EXPECT().GetGlobalVirtualGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(&virtual_types.GlobalVirtualGroup{
+					SecondarySpIds: []uint32{}}, nil).Times(1)
+				e.baseApp.SetGfSpClient(m)
+				return e
+			},
+		},
+		{
+			name: "failed to get sp id",
+			task: &gfsptask.GfSpReceivePieceTask{
+				Task:          &gfsptask.GfSpTask{},
+				ObjectInfo:    &storagetypes.ObjectInfo{Id: sdkmath.NewUint(1)},
+				StorageParams: &storagetypes.Params{MaxPayloadSize: 10},
+			},
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().GetObjectByID(gomock.Any(), gomock.Any()).Return(&storagetypes.ObjectInfo{
+					ObjectStatus: storagetypes.OBJECT_STATUS_SEALED}, nil).Times(1)
+				m.EXPECT().GetBucketByBucketName(gomock.Any(), gomock.Any(), gomock.Any()).Return(&metadatatypes.Bucket{
+					BucketInfo: &storagetypes.BucketInfo{Id: sdkmath.NewUint(1)}}, nil).Times(1)
+				m.EXPECT().GetGlobalVirtualGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(&virtual_types.GlobalVirtualGroup{
+					SecondarySpIds: []uint32{1}}, nil).Times(1)
+				e.baseApp.SetGfSpClient(m)
+
+				m1 := consensus.NewMockConsensus(ctrl)
+				m1.EXPECT().QuerySP(gomock.Any(), gomock.Any()).Return(nil, mockErr).Times(1)
+				e.baseApp.SetConsensus(m1)
+				return e
+			},
+		},
+		{
+			name: "success",
+			task: &gfsptask.GfSpReceivePieceTask{
+				Task:          &gfsptask.GfSpTask{},
+				ObjectInfo:    &storagetypes.ObjectInfo{Id: sdkmath.NewUint(1)},
+				StorageParams: &storagetypes.Params{MaxPayloadSize: 10},
+			},
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().GetObjectByID(gomock.Any(), gomock.Any()).Return(&storagetypes.ObjectInfo{
+					ObjectStatus: storagetypes.OBJECT_STATUS_SEALED}, nil).Times(1)
+				m.EXPECT().GetBucketByBucketName(gomock.Any(), gomock.Any(), gomock.Any()).Return(&metadatatypes.Bucket{
+					BucketInfo: &storagetypes.BucketInfo{Id: sdkmath.NewUint(1)}}, nil).Times(1)
+				m.EXPECT().GetGlobalVirtualGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(&virtual_types.GlobalVirtualGroup{
+					SecondarySpIds: []uint32{1}}, nil).Times(1)
+				e.baseApp.SetGfSpClient(m)
+
+				m1 := consensus.NewMockConsensus(ctrl)
+				m1.EXPECT().QuerySP(gomock.Any(), gomock.Any()).Return(&sptypes.StorageProvider{Id: 1}, nil).Times(1)
+				e.baseApp.SetConsensus(m1)
+				return e
+			},
+		},
+		{
+			name: "failed to delete integrity, REDUNDANCY_EC_TYPE and failed to delete piece data",
+			task: &gfsptask.GfSpReceivePieceTask{
+				Task: &gfsptask.GfSpTask{},
+				ObjectInfo: &storagetypes.ObjectInfo{
+					Id:             sdkmath.NewUint(1),
+					RedundancyType: storagetypes.REDUNDANCY_EC_TYPE,
+				},
+				StorageParams: &storagetypes.Params{MaxPayloadSize: 10},
+			},
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().GetObjectByID(gomock.Any(), gomock.Any()).Return(&storagetypes.ObjectInfo{
+					ObjectStatus: storagetypes.OBJECT_STATUS_SEALED, Id: sdkmath.NewUint(1)}, nil).Times(1)
+				m.EXPECT().GetBucketByBucketName(gomock.Any(), gomock.Any(), gomock.Any()).Return(&metadatatypes.Bucket{
+					BucketInfo: &storagetypes.BucketInfo{Id: sdkmath.NewUint(1)}}, nil).Times(1)
+				m.EXPECT().GetGlobalVirtualGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(&virtual_types.GlobalVirtualGroup{
+					SecondarySpIds: []uint32{2}}, nil).Times(1)
+				e.baseApp.SetGfSpClient(m)
+
+				m1 := consensus.NewMockConsensus(ctrl)
+				m1.EXPECT().QuerySP(gomock.Any(), gomock.Any()).Return(&sptypes.StorageProvider{Id: 1}, nil).Times(1)
+				e.baseApp.SetConsensus(m1)
+
+				m2 := corespdb.NewMockSPDB(ctrl)
+				m2.EXPECT().DeleteObjectIntegrity(gomock.Any(), gomock.Any()).Return(mockErr).Times(1)
+				e.baseApp.SetGfSpDB(m2)
+
+				m3 := piecestore.NewMockPieceOp(ctrl)
+				m3.EXPECT().SegmentPieceCount(gomock.Any(), gomock.Any()).Return(uint32(1)).Times(1)
+				m3.EXPECT().ECPieceKey(gomock.Any(), gomock.Any(), gomock.Any()).Return("test").Times(1)
+				e.baseApp.SetPieceOp(m3)
+
+				m4 := piecestore.NewMockPieceStore(ctrl)
+				m4.EXPECT().DeletePiece(gomock.Any(), gomock.Any()).Return(mockErr).Times(1)
+				e.baseApp.SetPieceStore(m4)
+				return e
+			},
+		},
+		{
+			name: "non REDUNDANCY_EC_TYPE and succeed to delete piece data",
+			task: &gfsptask.GfSpReceivePieceTask{
+				Task: &gfsptask.GfSpTask{},
+				ObjectInfo: &storagetypes.ObjectInfo{
+					Id:             sdkmath.NewUint(1),
+					RedundancyType: storagetypes.REDUNDANCY_REPLICA_TYPE,
+				},
+				StorageParams: &storagetypes.Params{MaxPayloadSize: 10},
+			},
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().GetObjectByID(gomock.Any(), gomock.Any()).Return(&storagetypes.ObjectInfo{
+					ObjectStatus: storagetypes.OBJECT_STATUS_SEALED, Id: sdkmath.NewUint(1)}, nil).Times(1)
+				m.EXPECT().GetBucketByBucketName(gomock.Any(), gomock.Any(), gomock.Any()).Return(&metadatatypes.Bucket{
+					BucketInfo: &storagetypes.BucketInfo{Id: sdkmath.NewUint(1)}}, nil).Times(1)
+				m.EXPECT().GetGlobalVirtualGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(&virtual_types.GlobalVirtualGroup{
+					SecondarySpIds: []uint32{2}}, nil).Times(1)
+				e.baseApp.SetGfSpClient(m)
+
+				m1 := consensus.NewMockConsensus(ctrl)
+				m1.EXPECT().QuerySP(gomock.Any(), gomock.Any()).Return(&sptypes.StorageProvider{Id: 1}, nil).Times(1)
+				e.baseApp.SetConsensus(m1)
+
+				m2 := spdb.NewMockSPDB(ctrl)
+				m2.EXPECT().DeleteObjectIntegrity(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				e.baseApp.SetGfSpDB(m2)
+
+				m3 := piecestore.NewMockPieceOp(ctrl)
+				m3.EXPECT().SegmentPieceCount(gomock.Any(), gomock.Any()).Return(uint32(1)).Times(1)
+				m3.EXPECT().SegmentPieceKey(gomock.Any(), gomock.Any()).Return("test").Times(1)
+				e.baseApp.SetPieceOp(m3)
+
+				m4 := piecestore.NewMockPieceStore(ctrl)
+				m4.EXPECT().DeletePiece(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				e.baseApp.SetPieceStore(m4)
+				return e
+			},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.fn().HandleReceivePieceTask(context.TODO(), tt.task)
+		})
+	}
+}
+
+func TestExecuteModular_HandleGCObjectTask(t *testing.T) {
+	cases := []struct {
+		name string
+		task coretask.GCObjectTask
+		fn   func() *ExecuteModular
+	}{
+		{
+			name: "failed to query deleted object list",
+			task: &gfsptask.GfSpGCObjectTask{
+				Task: &gfsptask.GfSpTask{},
+			},
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().ListDeletedObjectsByBlockNumberRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any()).Return(nil, uint64(0), mockErr).Times(1)
+				m.EXPECT().ReportTask(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				e.baseApp.SetGfSpClient(m)
+				return e
+			},
+		},
+		{
+			name: "metadata is not latest",
+			task: &gfsptask.GfSpGCObjectTask{
+				Task:             &gfsptask.GfSpTask{},
+				StartBlockNumber: 1,
+			},
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().ListDeletedObjectsByBlockNumberRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any()).Return(nil, uint64(0), nil).Times(1)
+				m.EXPECT().ReportTask(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				e.baseApp.SetGfSpClient(m)
+				return e
+			},
+		},
+		{
+			name: "no waiting gc objects",
+			task: &gfsptask.GfSpGCObjectTask{
+				Task: &gfsptask.GfSpTask{},
+			},
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().ListDeletedObjectsByBlockNumberRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any()).Return(nil, uint64(0), nil).Times(1)
+				m.EXPECT().ReportTask(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				e.baseApp.SetGfSpClient(m)
+				return e
+			},
+		},
+		{
+			name: "failed to query storage params",
+			task: &gfsptask.GfSpGCObjectTask{
+				Task: &gfsptask.GfSpTask{},
+			},
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				waitingGCObjects := []*metadatatypes.Object{
+					{
+						ObjectInfo: &storagetypes.ObjectInfo{Id: sdkmath.NewUint(1)},
+					},
+				}
+				m.EXPECT().ListDeletedObjectsByBlockNumberRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any()).Return(waitingGCObjects, uint64(0), nil).Times(1)
+				m.EXPECT().ReportTask(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				e.baseApp.SetGfSpClient(m)
+
+				m1 := consensus.NewMockConsensus(ctrl)
+				m1.EXPECT().QueryStorageParamsByTimestamp(gomock.Any(), gomock.Any()).Return(nil, mockErr).Times(1)
+				e.baseApp.SetConsensus(m1)
+				return e
+			},
+		},
+		{
+			name: "failed to get bucket by bucket name",
+			task: &gfsptask.GfSpGCObjectTask{
+				Task:               &gfsptask.GfSpTask{},
+				CurrentBlockNumber: 0,
+			},
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				waitingGCObjects := []*metadatatypes.Object{
+					{
+						ObjectInfo: &storagetypes.ObjectInfo{Id: sdkmath.NewUint(1)},
+					},
+				}
+				m.EXPECT().ListDeletedObjectsByBlockNumberRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any()).Return(waitingGCObjects, uint64(0), nil).Times(1)
+				m.EXPECT().ReportTask(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				m.EXPECT().GetBucketByBucketName(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, mockErr).Times(1)
+				e.baseApp.SetGfSpClient(m)
+
+				m1 := consensus.NewMockConsensus(ctrl)
+				m1.EXPECT().QueryStorageParamsByTimestamp(gomock.Any(), gomock.Any()).Return(&storagetypes.Params{
+					VersionedParams: storagetypes.VersionedParams{MaxSegmentSize: 10}}, nil).Times(1)
+				e.baseApp.SetConsensus(m1)
+
+				m2 := piecestore.NewMockPieceOp(ctrl)
+				m2.EXPECT().SegmentPieceCount(gomock.Any(), gomock.Any()).Return(uint32(1)).Times(1)
+				m2.EXPECT().SegmentPieceKey(gomock.Any(), gomock.Any()).Return("test").Times(1)
+				e.baseApp.SetPieceOp(m2)
+
+				m3 := piecestore.NewMockPieceStore(ctrl)
+				m3.EXPECT().DeletePiece(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				e.baseApp.SetPieceStore(m3)
+				return e
+			},
+		},
+		{
+			name: "failed to get global virtual group",
+			task: &gfsptask.GfSpGCObjectTask{
+				Task:               &gfsptask.GfSpTask{},
+				CurrentBlockNumber: 0,
+			},
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				waitingGCObjects := []*metadatatypes.Object{
+					{
+						ObjectInfo: &storagetypes.ObjectInfo{Id: sdkmath.NewUint(1)},
+					},
+				}
+				m.EXPECT().ListDeletedObjectsByBlockNumberRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any()).Return(waitingGCObjects, uint64(0), nil).Times(1)
+				m.EXPECT().ReportTask(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				m.EXPECT().GetBucketByBucketName(gomock.Any(), gomock.Any(), gomock.Any()).Return(&metadatatypes.Bucket{
+					BucketInfo: &storagetypes.BucketInfo{Id: sdkmath.NewUint(1)}}, nil).Times(1)
+				m.EXPECT().GetGlobalVirtualGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, mockErr).Times(1)
+				e.baseApp.SetGfSpClient(m)
+
+				m1 := consensus.NewMockConsensus(ctrl)
+				m1.EXPECT().QueryStorageParamsByTimestamp(gomock.Any(), gomock.Any()).Return(&storagetypes.Params{
+					VersionedParams: storagetypes.VersionedParams{MaxSegmentSize: 10}}, nil).Times(1)
+				e.baseApp.SetConsensus(m1)
+
+				m2 := piecestore.NewMockPieceOp(ctrl)
+				m2.EXPECT().SegmentPieceCount(gomock.Any(), gomock.Any()).Return(uint32(1)).Times(1)
+				m2.EXPECT().SegmentPieceKey(gomock.Any(), gomock.Any()).Return("test").Times(1)
+				e.baseApp.SetPieceOp(m2)
+
+				m3 := piecestore.NewMockPieceStore(ctrl)
+				m3.EXPECT().DeletePiece(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				e.baseApp.SetPieceStore(m3)
+				return e
+			},
+		},
+		{
+			name: "failed to get sp id",
+			task: &gfsptask.GfSpGCObjectTask{
+				Task:               &gfsptask.GfSpTask{},
+				CurrentBlockNumber: 0,
+			},
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				waitingGCObjects := []*metadatatypes.Object{
+					{
+						ObjectInfo: &storagetypes.ObjectInfo{Id: sdkmath.NewUint(1)},
+					},
+				}
+				m.EXPECT().ListDeletedObjectsByBlockNumberRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any()).Return(waitingGCObjects, uint64(0), nil).Times(1)
+				m.EXPECT().ReportTask(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				m.EXPECT().GetBucketByBucketName(gomock.Any(), gomock.Any(), gomock.Any()).Return(&metadatatypes.Bucket{
+					BucketInfo: &storagetypes.BucketInfo{Id: sdkmath.NewUint(1)}}, nil).Times(1)
+				m.EXPECT().GetGlobalVirtualGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(&virtual_types.GlobalVirtualGroup{
+					SecondarySpIds: []uint32{1}}, nil).Times(1)
+				e.baseApp.SetGfSpClient(m)
+
+				m1 := consensus.NewMockConsensus(ctrl)
+				m1.EXPECT().QueryStorageParamsByTimestamp(gomock.Any(), gomock.Any()).Return(&storagetypes.Params{
+					VersionedParams: storagetypes.VersionedParams{MaxSegmentSize: 10}}, nil).Times(1)
+				m1.EXPECT().QuerySP(gomock.Any(), gomock.Any()).Return(nil, mockErr).Times(1)
+				e.baseApp.SetConsensus(m1)
+
+				m2 := piecestore.NewMockPieceOp(ctrl)
+				m2.EXPECT().SegmentPieceCount(gomock.Any(), gomock.Any()).Return(uint32(1)).Times(1)
+				m2.EXPECT().SegmentPieceKey(gomock.Any(), gomock.Any()).Return("test").Times(1)
+				e.baseApp.SetPieceOp(m2)
+
+				m3 := piecestore.NewMockPieceStore(ctrl)
+				m3.EXPECT().DeletePiece(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				e.baseApp.SetPieceStore(m3)
+				return e
+			},
+		},
+		{
+			name: "succeed to gc an object",
+			task: &gfsptask.GfSpGCObjectTask{
+				Task:               &gfsptask.GfSpTask{},
+				CurrentBlockNumber: 0,
+			},
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				waitingGCObjects := []*metadatatypes.Object{
+					{
+						ObjectInfo: &storagetypes.ObjectInfo{Id: sdkmath.NewUint(1)},
+					},
+				}
+				m.EXPECT().ListDeletedObjectsByBlockNumberRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any()).Return(waitingGCObjects, uint64(0), nil).AnyTimes()
+				m.EXPECT().ReportTask(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				m.EXPECT().GetBucketByBucketName(gomock.Any(), gomock.Any(), gomock.Any()).Return(&metadatatypes.Bucket{
+					BucketInfo: &storagetypes.BucketInfo{Id: sdkmath.NewUint(1)}}, nil).Times(1)
+				m.EXPECT().GetGlobalVirtualGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(&virtual_types.GlobalVirtualGroup{
+					SecondarySpIds: []uint32{1}}, nil).Times(1)
+				e.baseApp.SetGfSpClient(m)
+
+				m1 := consensus.NewMockConsensus(ctrl)
+				m1.EXPECT().QueryStorageParamsByTimestamp(gomock.Any(), gomock.Any()).Return(&storagetypes.Params{
+					VersionedParams: storagetypes.VersionedParams{MaxSegmentSize: 10}}, nil).Times(1)
+				m1.EXPECT().QuerySP(gomock.Any(), gomock.Any()).Return(&sptypes.StorageProvider{Id: 1}, nil).Times(1)
+				e.baseApp.SetConsensus(m1)
+
+				m2 := piecestore.NewMockPieceOp(ctrl)
+				m2.EXPECT().SegmentPieceCount(gomock.Any(), gomock.Any()).Return(uint32(1)).Times(1)
+				m2.EXPECT().SegmentPieceKey(gomock.Any(), gomock.Any()).Return("test").Times(1)
+				m2.EXPECT().ECPieceKey(gomock.Any(), gomock.Any(), gomock.Any()).Return("test").Times(1)
+				e.baseApp.SetPieceOp(m2)
+
+				m3 := piecestore.NewMockPieceStore(ctrl)
+				m3.EXPECT().DeletePiece(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+				e.baseApp.SetPieceStore(m3)
+
+				m4 := corespdb.NewMockSPDB(ctrl)
+				m4.EXPECT().DeleteObjectIntegrity(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				e.baseApp.SetGfSpDB(m4)
+				return e
+			},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.fn().HandleGCObjectTask(context.TODO(), tt.task)
+		})
+	}
+}
+
+func TestExecuteModular_HandleGCZombiePieceTask(t *testing.T) {
+	e := setup(t)
+	e.HandleGCZombiePieceTask(context.TODO(), nil)
+}
+
+func TestExecuteModular_HandleGCMetaTask(t *testing.T) {
+	e := setup(t)
+	e.HandleGCMetaTask(context.TODO(), nil)
+}
+
+func TestExecuteModular_HandleRecoverPieceTaskFailure1(t *testing.T) {
+	t.Log("Failure case description: ErrDanglingPointer")
+	e := setup(t)
+	task := &gfsptask.GfSpRecoverPieceTask{
+		Task:          &gfsptask.GfSpTask{},
+		StorageParams: &storagetypes.Params{},
+	}
+	e.HandleRecoverPieceTask(context.TODO(), task)
+}
+
+func TestExecuteModular_HandleRecoverPieceTaskFailure2(t *testing.T) {
+	t.Log("Failure case description: ErrRecoveryRedundancyType")
+	e := setup(t)
+	task := &gfsptask.GfSpRecoverPieceTask{
+		Task: &gfsptask.GfSpTask{},
+		ObjectInfo: &storagetypes.ObjectInfo{
+			Id:             sdkmath.NewUint(1),
+			RedundancyType: storagetypes.REDUNDANCY_REPLICA_TYPE,
+		},
+		StorageParams: &storagetypes.Params{},
+	}
+	e.HandleRecoverPieceTask(context.TODO(), task)
+}
+
+func TestExecuteModular_HandleRecoverPieceTaskFailure3(t *testing.T) {
+	t.Log("Failure case description: ErrRecoveryPieceIndex")
+	e := setup(t)
+	task := &gfsptask.GfSpRecoverPieceTask{
+		Task: &gfsptask.GfSpTask{},
+		ObjectInfo: &storagetypes.ObjectInfo{
+			Id:             sdkmath.NewUint(1),
+			RedundancyType: storagetypes.REDUNDANCY_EC_TYPE,
+		},
+		StorageParams: &storagetypes.Params{},
+		EcIdx:         -2,
+	}
+	e.HandleRecoverPieceTask(context.TODO(), task)
+}
+
+func TestExecuteModular_recoverByPrimarySPSuccess(t *testing.T) {
+	e := setup(t)
+
+	ctrl := gomock.NewController(t)
+	m := gfspclient.NewMockGfSpClientAPI(ctrl)
+	m.EXPECT().GetBucketMeta(gomock.Any(), gomock.Any(), true).Return(&metadatatypes.Bucket{
+		BucketInfo: &storagetypes.BucketInfo{Id: sdkmath.NewUint(1)}}, nil, nil).Times(1)
+	m.EXPECT().SignRecoveryTask(gomock.Any(), gomock.Any()).Return([]byte("mockSig"), nil).Times(1)
+	m.EXPECT().GetPieceFromECChunks(gomock.Any(), gomock.Any(), gomock.Any()).Return(io.NopCloser(
+		strings.NewReader("body")), nil).Times(1)
+	e.baseApp.SetGfSpClient(m)
+
+	m1 := consensus.NewMockConsensus(ctrl)
+	m1.EXPECT().QueryVirtualGroupFamily(gomock.Any(), gomock.Any()).Return(&virtual_types.GlobalVirtualGroupFamily{
+		PrimarySpId: 1}, nil).Times(1)
+	m1.EXPECT().ListSPs(gomock.Any()).Return([]*sptypes.StorageProvider{
+		{Id: 1, Endpoint: "endpoint"}}, nil).Times(1)
+	e.baseApp.SetConsensus(m1)
+
+	m2 := corespdb.NewMockSPDB(ctrl)
+	m2.EXPECT().GetObjectIntegrity(gomock.Any(), gomock.Any()).Return(&corespdb.IntegrityMeta{
+		PieceChecksumList: [][]byte{[]byte{35, 13, 131, 88, 220, 142, 136, 144, 180, 197, 141, 238, 182, 41, 18, 238, 47,
+			32, 53, 122, 233, 42, 92, 200, 97, 185, 142, 104, 254, 49, 172, 181}}}, nil).Times(1)
+	e.baseApp.SetGfSpDB(m2)
+
+	m3 := piecestore.NewMockPieceOp(ctrl)
+	m3.EXPECT().ECPieceKey(gomock.Any(), gomock.Any(), gomock.Any()).Return("test").Times(1)
+	e.baseApp.SetPieceOp(m3)
+
+	m4 := piecestore.NewMockPieceStore(ctrl)
+	m4.EXPECT().PutPiece(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	e.baseApp.SetPieceStore(m4)
+
+	task := &gfsptask.GfSpRecoverPieceTask{
+		Task:          &gfsptask.GfSpTask{},
+		ObjectInfo:    &storagetypes.ObjectInfo{Id: sdkmath.NewUint(1)},
+		StorageParams: &storagetypes.Params{},
+	}
+	err := e.recoverByPrimarySP(context.TODO(), task)
+	assert.Nil(t, err)
+}
+
+func TestExecuteModular_recoverBySecondarySPFailure1(t *testing.T) {
+	e := setup(t)
+
+	ctrl := gomock.NewController(t)
+	m := gfspclient.NewMockGfSpClientAPI(ctrl)
+	m.EXPECT().GetBucketByBucketName(gomock.Any(), gomock.Any(), true).Return(nil, mockErr).Times(1)
+	e.baseApp.SetGfSpClient(m)
+
+	task := &gfsptask.GfSpRecoverPieceTask{
+		Task:          &gfsptask.GfSpTask{},
+		ObjectInfo:    &storagetypes.ObjectInfo{Id: sdkmath.NewUint(1)},
+		StorageParams: &storagetypes.Params{},
+	}
+	err := e.recoverBySecondarySP(context.TODO(), task, true)
+	assert.Equal(t, mockErr, err)
+}
+
+func TestExecuteModular_recoverBySecondarySPFailure2(t *testing.T) {
+	e := setup(t)
+
+	ctrl := gomock.NewController(t)
+	m := gfspclient.NewMockGfSpClientAPI(ctrl)
+	m.EXPECT().GetBucketByBucketName(gomock.Any(), gomock.Any(), true).Return(
+		&metadatatypes.Bucket{BucketInfo: &storagetypes.BucketInfo{Id: sdkmath.NewUint(1)}}, nil).Times(1)
+	m.EXPECT().GetGlobalVirtualGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&virtual_types.GlobalVirtualGroup{SecondarySpIds: []uint32{1}}, nil).Times(1)
+	e.baseApp.SetGfSpClient(m)
+
+	m1 := consensus.NewMockConsensus(ctrl)
+	m1.EXPECT().ListSPs(gomock.Any()).Return([]*sptypes.StorageProvider{{Id: 1, Endpoint: "endpoint"}}, nil).Times(1)
+	e.baseApp.SetConsensus(m1)
+
+	task := &gfsptask.GfSpRecoverPieceTask{
+		Task:          &gfsptask.GfSpTask{},
+		ObjectInfo:    &storagetypes.ObjectInfo{Id: sdkmath.NewUint(1)},
+		StorageParams: &storagetypes.Params{},
+	}
+	err := e.recoverBySecondarySP(context.TODO(), task, true)
+	assert.Equal(t, ErrRecoveryPieceNotEnough, err)
+}
+
+func TestExecuteModular_getECPieceBySegment(t *testing.T) {
+	cases := []struct {
+		name          string
+		redundancyIdx int32
+		objectInfo    *storagetypes.ObjectInfo
+		params        *storagetypes.Params
+		fn            func() *ExecuteModular
+		wantedIsErr   bool
+		wantedErrStr  string
+	}{
+		{
+			name:          "invalid redundancyIdx",
+			redundancyIdx: -1,
+			objectInfo:    &storagetypes.ObjectInfo{},
+			params:        &storagetypes.Params{},
+			fn:            func() *ExecuteModular { return setup(t) },
+			wantedIsErr:   true,
+			wantedErrStr:  "invalid redundancyIdx",
+		},
+		{
+			name:          "no error",
+			redundancyIdx: 1,
+			objectInfo:    &storagetypes.ObjectInfo{},
+			params:        &storagetypes.Params{VersionedParams: storagetypes.VersionedParams{RedundantDataChunkNum: 4}},
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := piecestore.NewMockPieceOp(ctrl)
+				m.EXPECT().ECPieceSize(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(int64(1)).Times(1)
+				e.baseApp.SetPieceOp(m)
+				return e
+			},
+			wantedIsErr: false,
+		},
+		{
+			name:          "no error",
+			redundancyIdx: 4,
+			objectInfo:    &storagetypes.ObjectInfo{},
+			params: &storagetypes.Params{VersionedParams: storagetypes.VersionedParams{RedundantDataChunkNum: 4,
+				RedundantParityChunkNum: 2}},
+			fn:          func() *ExecuteModular { return setup(t) },
+			wantedIsErr: false,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.fn().getECPieceBySegment(context.TODO(), tt.redundancyIdx, tt.objectInfo, tt.params,
+				[]byte("test"), 1)
+			if tt.wantedIsErr {
+				assert.Contains(t, err.Error(), tt.wantedErrStr)
+				assert.Nil(t, result)
+			} else {
+				assert.Nil(t, err)
+				assert.NotNil(t, result)
+			}
+		})
+	}
+}
+
+func TestExecuteModular_checkRecoveryChecksum(t *testing.T) {
+	cases := []struct {
+		name         string
+		fn           func() *ExecuteModular
+		wantedIsErr  bool
+		wantedErrStr string
+	}{
+		{
+			name: "failed to get object integrity hash",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := corespdb.NewMockSPDB(ctrl)
+				m.EXPECT().GetObjectIntegrity(gomock.Any(), gomock.Any()).Return(nil, mockErr).Times(1)
+				e.baseApp.SetGfSpDB(m)
+				return e
+			},
+			wantedIsErr:  true,
+			wantedErrStr: "failed to get object integrity hash in db",
+		},
+		{
+			name: "check integrity hash of recovery data err",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := corespdb.NewMockSPDB(ctrl)
+				m.EXPECT().GetObjectIntegrity(gomock.Any(), gomock.Any()).Return(&corespdb.IntegrityMeta{
+					PieceChecksumList: [][]byte{[]byte("a")}}, nil).Times(1)
+				e.baseApp.SetGfSpDB(m)
+				return e
+			},
+			wantedIsErr:  true,
+			wantedErrStr: ErrRecoveryPieceChecksum.Error(),
+		},
+		{
+			name: "success",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := corespdb.NewMockSPDB(ctrl)
+				m.EXPECT().GetObjectIntegrity(gomock.Any(), gomock.Any()).Return(&corespdb.IntegrityMeta{
+					PieceChecksumList: [][]byte{[]byte("test")}}, nil).Times(1)
+				e.baseApp.SetGfSpDB(m)
+				return e
+			},
+			wantedIsErr: false,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fn().checkRecoveryChecksum(context.TODO(), &gfsptask.GfSpRecoverPieceTask{
+				Task: &gfsptask.GfSpTask{},
+				ObjectInfo: &storagetypes.ObjectInfo{
+					ObjectName: "mockObjectName",
+					Id:         sdkmath.NewUint(1),
+				}}, []byte{116, 101, 115, 116})
+			if tt.wantedIsErr {
+				assert.Contains(t, err.Error(), tt.wantedErrStr)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestExecuteModular_doRecoveryPiece(t *testing.T) {
+	cases := []struct {
+		name        string
+		fn          func() *ExecuteModular
+		wantedIsErr bool
+		wantedErr   error
+	}{
+		{
+			name: "failed to sign recovery task",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().SignRecoveryTask(gomock.Any(), gomock.Any()).Return(nil, mockErr).Times(1)
+				e.baseApp.SetGfSpClient(m)
+				return e
+			},
+			wantedIsErr: true,
+			wantedErr:   mockErr,
+		},
+		{
+			name: "failed to get piece from ec chunks",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().SignRecoveryTask(gomock.Any(), gomock.Any()).Return([]byte("mockSig"), nil).Times(1)
+				m.EXPECT().GetPieceFromECChunks(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, mockErr).Times(1)
+				e.baseApp.SetGfSpClient(m)
+				return e
+			},
+			wantedIsErr: true,
+			wantedErr:   mockErr,
+		},
+		{
+			name: "failed to read recovery piece data from sp",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				e.baseApp.SetGfSpClient(m)
+				m.EXPECT().SignRecoveryTask(gomock.Any(), gomock.Any()).Return([]byte("mockSig"), nil).Times(1)
+
+				m1 := gfspclient.NewMockstdLib(ctrl)
+				m1.EXPECT().Read(gomock.Any()).Return(0, mockErr).Times(1)
+				m1.EXPECT().Close().AnyTimes()
+				m.EXPECT().GetPieceFromECChunks(gomock.Any(), gomock.Any(), gomock.Any()).Return(m1, nil).Times(1)
+				return e
+			},
+			wantedIsErr: true,
+			wantedErr:   mockErr,
+		},
+		{
+			name: "success",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				e.baseApp.SetGfSpClient(m)
+				m.EXPECT().SignRecoveryTask(gomock.Any(), gomock.Any()).Return([]byte("mockSig"), nil).Times(1)
+				m.EXPECT().GetPieceFromECChunks(gomock.Any(), gomock.Any(), gomock.Any()).Return(io.NopCloser(
+					strings.NewReader("body")), nil).Times(1)
+				return e
+			},
+			wantedIsErr: false,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.fn().doRecoveryPiece(context.TODO(), &gfsptask.GfSpRecoverPieceTask{
+				Task: &gfsptask.GfSpTask{},
+				ObjectInfo: &storagetypes.ObjectInfo{
+					ObjectName: "mockObjectName",
+					Id:         sdkmath.NewUint(1),
+				}}, "mockEndpoint")
+			if tt.wantedIsErr {
+				assert.Equal(t, tt.wantedErr, err)
+				assert.Nil(t, result)
+			} else {
+				assert.Nil(t, err)
+				assert.NotNil(t, result)
+			}
+		})
+	}
+}
+
+func TestExecuteModular_getObjectSecondaryEndpoints(t *testing.T) {
+	cases := []struct {
+		name        string
+		fn          func() *ExecuteModular
+		wantedIsErr bool
+		wantedErr   error
+	}{
+		{
+			name: "failed to GetBucketByBucketName",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().GetBucketByBucketName(gomock.Any(), gomock.Any(), true).Return(nil, mockErr).Times(1)
+				e.baseApp.SetGfSpClient(m)
+				return e
+			},
+			wantedIsErr: true,
+			wantedErr:   mockErr,
+		},
+		{
+			name: "failed to GetGlobalVirtualGroup",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().GetBucketByBucketName(gomock.Any(), gomock.Any(), true).Return(
+					&metadatatypes.Bucket{BucketInfo: &storagetypes.BucketInfo{Id: sdkmath.NewUint(1)}}, nil).Times(1)
+				m.EXPECT().GetGlobalVirtualGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, mockErr).Times(1)
+				e.baseApp.SetGfSpClient(m)
+				return e
+			},
+			wantedIsErr: true,
+			wantedErr:   mockErr,
+		},
+		{
+			name: "failed to ListSPs",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().GetBucketByBucketName(gomock.Any(), gomock.Any(), true).Return(
+					&metadatatypes.Bucket{BucketInfo: &storagetypes.BucketInfo{Id: sdkmath.NewUint(1)}}, nil).Times(1)
+				m.EXPECT().GetGlobalVirtualGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&virtual_types.GlobalVirtualGroup{SecondarySpIds: []uint32{1}}, nil).Times(1)
+				e.baseApp.SetGfSpClient(m)
+
+				m1 := consensus.NewMockConsensus(ctrl)
+				m1.EXPECT().ListSPs(gomock.Any()).Return(nil, mockErr).Times(1)
+				e.baseApp.SetConsensus(m1)
+				return e
+			},
+			wantedIsErr: true,
+			wantedErr:   mockErr,
+		},
+		{
+			name: "success",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().GetBucketByBucketName(gomock.Any(), gomock.Any(), true).Return(
+					&metadatatypes.Bucket{BucketInfo: &storagetypes.BucketInfo{Id: sdkmath.NewUint(1)}}, nil).Times(1)
+				m.EXPECT().GetGlobalVirtualGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&virtual_types.GlobalVirtualGroup{SecondarySpIds: []uint32{1}}, nil).Times(1)
+				e.baseApp.SetGfSpClient(m)
+
+				m1 := consensus.NewMockConsensus(ctrl)
+				m1.EXPECT().ListSPs(gomock.Any()).Return([]*sptypes.StorageProvider{{Id: 1, Endpoint: "endpoint"}}, nil).Times(1)
+				e.baseApp.SetConsensus(m1)
+				return e
+			},
+			wantedIsErr: false,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			result1, result2, err := tt.fn().getObjectSecondaryEndpoints(context.TODO(), &storagetypes.ObjectInfo{
+				BucketName: "mockBucketName", LocalVirtualGroupId: 1})
+			if tt.wantedIsErr {
+				assert.Equal(t, tt.wantedErr, err)
+				assert.Nil(t, result1)
+				assert.Equal(t, 0, result2)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, []string{"endpoint"}, result1)
+				assert.Equal(t, 1, result2)
+			}
+		})
+	}
+}
+
+func TestExecuteModular_getBucketPrimarySPEndpoint(t *testing.T) {
+	cases := []struct {
+		name        string
+		fn          func() *ExecuteModular
+		wantedIsErr bool
+		wantedErr   error
+	}{
+		{
+			name: "failed to GetBucketMeta",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().GetBucketMeta(gomock.Any(), gomock.Any(), true).Return(nil, nil, mockErr).Times(1)
+				e.baseApp.SetGfSpClient(m)
+				return e
+			},
+			wantedIsErr: true,
+			wantedErr:   mockErr,
+		},
+		{
+			name: "failed to GetBucketPrimarySPID",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().GetBucketMeta(gomock.Any(), gomock.Any(), true).Return(&metadatatypes.Bucket{
+					BucketInfo: &storagetypes.BucketInfo{Id: sdkmath.NewUint(1)}}, nil, nil).Times(1)
+				e.baseApp.SetGfSpClient(m)
+
+				m1 := consensus.NewMockConsensus(ctrl)
+				m1.EXPECT().QueryVirtualGroupFamily(gomock.Any(), gomock.Any()).Return(nil, mockErr).Times(1)
+				e.baseApp.SetConsensus(m1)
+				return e
+			},
+			wantedIsErr: true,
+			wantedErr:   mockErr,
+		},
+		{
+			name: "failed to ListSPs",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().GetBucketMeta(gomock.Any(), gomock.Any(), true).Return(&metadatatypes.Bucket{
+					BucketInfo: &storagetypes.BucketInfo{Id: sdkmath.NewUint(1)}}, nil, nil).Times(1)
+				e.baseApp.SetGfSpClient(m)
+
+				m1 := consensus.NewMockConsensus(ctrl)
+				m1.EXPECT().QueryVirtualGroupFamily(gomock.Any(), gomock.Any()).Return(&virtual_types.GlobalVirtualGroupFamily{
+					PrimarySpId: 1}, nil).Times(1)
+				m1.EXPECT().ListSPs(gomock.Any()).Return(nil, mockErr).Times(1)
+				e.baseApp.SetConsensus(m1)
+				return e
+			},
+			wantedIsErr: true,
+			wantedErr:   mockErr,
+		},
+		{
+			name: "ErrPrimaryNotFound",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().GetBucketMeta(gomock.Any(), gomock.Any(), true).Return(&metadatatypes.Bucket{
+					BucketInfo: &storagetypes.BucketInfo{Id: sdkmath.NewUint(1)}}, nil, nil).Times(1)
+				e.baseApp.SetGfSpClient(m)
+
+				m1 := consensus.NewMockConsensus(ctrl)
+				m1.EXPECT().QueryVirtualGroupFamily(gomock.Any(), gomock.Any()).Return(&virtual_types.GlobalVirtualGroupFamily{
+					PrimarySpId: 1}, nil).Times(1)
+				m1.EXPECT().ListSPs(gomock.Any()).Return([]*sptypes.StorageProvider{{Id: 2}}, nil).Times(1)
+				e.baseApp.SetConsensus(m1)
+				return e
+			},
+			wantedIsErr: true,
+			wantedErr:   ErrPrimaryNotFound,
+		},
+		{
+			name: "success",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := gfspclient.NewMockGfSpClientAPI(ctrl)
+				m.EXPECT().GetBucketMeta(gomock.Any(), gomock.Any(), true).Return(&metadatatypes.Bucket{
+					BucketInfo: &storagetypes.BucketInfo{Id: sdkmath.NewUint(1)}}, nil, nil).Times(1)
+				e.baseApp.SetGfSpClient(m)
+
+				m1 := consensus.NewMockConsensus(ctrl)
+				m1.EXPECT().QueryVirtualGroupFamily(gomock.Any(), gomock.Any()).Return(&virtual_types.GlobalVirtualGroupFamily{
+					PrimarySpId: 1}, nil).Times(1)
+				m1.EXPECT().ListSPs(gomock.Any()).Return([]*sptypes.StorageProvider{
+					{Id: 1, Endpoint: "endpoint"}}, nil).Times(1)
+				e.baseApp.SetConsensus(m1)
+				return e
+			},
+			wantedIsErr: false,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.fn().getBucketPrimarySPEndpoint(context.TODO(), "bucketName")
+			if tt.wantedIsErr {
+				assert.Equal(t, tt.wantedErr, err)
+				assert.Empty(t, result)
+			} else {
+				assert.Nil(t, err)
+				assert.NotEmpty(t, result)
+			}
+		})
+	}
+}

--- a/modular/executor/executor_test.go
+++ b/modular/executor/executor_test.go
@@ -1,0 +1,417 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/bnb-chain/greenfield-storage-provider/base/gfspapp"
+	"github.com/bnb-chain/greenfield-storage-provider/base/gfspclient"
+	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsptask"
+	"github.com/bnb-chain/greenfield-storage-provider/core/consensus"
+	coremodule "github.com/bnb-chain/greenfield-storage-provider/core/module"
+	corercmgr "github.com/bnb-chain/greenfield-storage-provider/core/rcmgr"
+	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
+	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
+)
+
+var mockErr = errors.New("mock error")
+
+func setup(t *testing.T) *ExecuteModular {
+	t.Helper()
+	return &ExecuteModular{baseApp: &gfspapp.GfSpBaseApp{}}
+}
+
+func TestExecuteModular_Name(t *testing.T) {
+	e := setup(t)
+	result := e.Name()
+	assert.Equal(t, coremodule.ExecuteModularName, result)
+}
+
+func TestExecuteModular_StartSuccess(t *testing.T) {
+	e := setup(t)
+	e.statisticsOutputInterval = 1
+	ctrl := gomock.NewController(t)
+	m := corercmgr.NewMockResourceManager(ctrl)
+	e.baseApp.SetResourceManager(m)
+	m1 := corercmgr.NewMockResourceScope(ctrl)
+	m.EXPECT().OpenService(gomock.Any()).DoAndReturn(func(svc string) (corercmgr.ResourceScope, error) {
+		return m1, nil
+	}).Times(1)
+	err := e.Start(context.TODO())
+	assert.Nil(t, err)
+}
+
+func TestExecuteModular_StartFailure(t *testing.T) {
+	e := setup(t)
+	e.statisticsOutputInterval = 1
+	ctrl := gomock.NewController(t)
+	m := corercmgr.NewMockResourceManager(ctrl)
+	e.baseApp.SetResourceManager(m)
+	m.EXPECT().OpenService(gomock.Any()).DoAndReturn(func(svc string) (corercmgr.ResourceScope, error) {
+		return nil, mockErr
+	}).Times(1)
+	err := e.Start(context.TODO())
+	assert.Equal(t, mockErr, err)
+}
+
+func TestExecuteModular_omitError(t *testing.T) {
+	cases := []struct {
+		name         string
+		err          error
+		wantedResult bool
+	}{
+		{
+			name:         "1",
+			err:          gfspapp.ErrNoTaskMatchLimit,
+			wantedResult: true,
+		},
+		{
+			name:         "2",
+			err:          mockErr,
+			wantedResult: false,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			e := setup(t)
+			result := e.omitError(tt.err)
+			assert.Equal(t, tt.wantedResult, result)
+		})
+	}
+}
+
+func TestExecuteModular_eventLoop1(t *testing.T) {
+	t.Log("Case description: context cancel")
+	e := setup(t)
+	e.maxExecuteNum = 2
+	e.statisticsOutputInterval = 1
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*2)
+	cancel()
+	e.eventLoop(ctx)
+}
+
+func TestExecuteModular_eventLoop2(t *testing.T) {
+	t.Log("Case description: ask task")
+	e := setup(t)
+	e.maxExecuteNum = 1
+	e.statisticsOutputInterval = 1
+	ctrl := gomock.NewController(t)
+	m := corercmgr.NewMockResourceScope(ctrl)
+	e.scope = m
+	m.EXPECT().RemainingResource().Return(nil, mockErr).AnyTimes()
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Millisecond*10)
+	e.eventLoop(ctx)
+	defer cancel()
+}
+
+func TestExecuteModular_eventLoop3(t *testing.T) {
+	t.Log("Case description: statistics ticker")
+	e := setup(t)
+	e.statisticsOutputInterval = 1
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*1)
+	e.eventLoop(ctx)
+	defer cancel()
+}
+
+func TestExecuteModular_AskTask(t *testing.T) {
+	cases := []struct {
+		name      string
+		fn        func() *ExecuteModular
+		wantedErr error
+	}{
+		{
+			name: "failed to get remaining resource",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := corercmgr.NewMockResourceScope(ctrl)
+				e.scope = m
+				m.EXPECT().RemainingResource().Return(nil, mockErr).Times(1)
+				return e
+			},
+			wantedErr: mockErr,
+		},
+		{
+			name: "failed to ask task omitError",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				scopeMock := corercmgr.NewMockResourceScope(ctrl)
+				e.scope = scopeMock
+				limitMock := corercmgr.NewMockLimit(ctrl)
+				limitMock.EXPECT().GetMemoryLimit().Return(int64(1)).Times(1)
+				limitMock.EXPECT().GetTaskTotalLimit().Return(1).Times(1)
+				limitMock.EXPECT().GetTaskLimit(corercmgr.ReserveTaskPriorityHigh).Return(1).Times(1)
+				limitMock.EXPECT().GetTaskLimit(corercmgr.ReserveTaskPriorityMedium).Return(1).Times(1)
+				limitMock.EXPECT().GetTaskLimit(corercmgr.ReserveTaskPriorityLow).Return(1).Times(1)
+				scopeMock.EXPECT().RemainingResource().Return(limitMock, nil).Times(1)
+
+				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
+				clientMock.EXPECT().AskTask(gomock.Any(), gomock.Any()).Return(nil,
+					gfspapp.ErrNoTaskMatchLimit).Times(1)
+				e.baseApp.SetGfSpClient(clientMock)
+				return e
+			},
+			wantedErr: gfspapp.ErrNoTaskMatchLimit,
+		},
+		{
+			name: "failed to ask task",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				scopeMock := corercmgr.NewMockResourceScope(ctrl)
+				e.scope = scopeMock
+				limitMock := corercmgr.NewMockLimit(ctrl)
+				limitMock.EXPECT().String().Return("1").Times(1)
+				limitMock.EXPECT().GetMemoryLimit().Return(int64(1)).Times(1)
+				limitMock.EXPECT().GetTaskTotalLimit().Return(1).Times(1)
+				limitMock.EXPECT().GetTaskLimit(corercmgr.ReserveTaskPriorityHigh).Return(1).Times(1)
+				limitMock.EXPECT().GetTaskLimit(corercmgr.ReserveTaskPriorityMedium).Return(1).Times(1)
+				limitMock.EXPECT().GetTaskLimit(corercmgr.ReserveTaskPriorityLow).Return(1).Times(1)
+				scopeMock.EXPECT().RemainingResource().Return(limitMock, nil).Times(1)
+
+				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
+				clientMock.EXPECT().AskTask(gomock.Any(), gomock.Any()).Return(nil, mockErr).Times(1)
+				e.baseApp.SetGfSpClient(clientMock)
+				return e
+			},
+			wantedErr: mockErr,
+		},
+		{
+			name: "dangling pointer",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				scopeMock := corercmgr.NewMockResourceScope(ctrl)
+				e.scope = scopeMock
+				limitMock := corercmgr.NewMockLimit(ctrl)
+				limitMock.EXPECT().String().Return("1").Times(1)
+				limitMock.EXPECT().GetMemoryLimit().Return(int64(1)).Times(1)
+				limitMock.EXPECT().GetTaskTotalLimit().Return(1).Times(1)
+				limitMock.EXPECT().GetTaskLimit(corercmgr.ReserveTaskPriorityHigh).Return(1).Times(1)
+				limitMock.EXPECT().GetTaskLimit(corercmgr.ReserveTaskPriorityMedium).Return(1).Times(1)
+				limitMock.EXPECT().GetTaskLimit(corercmgr.ReserveTaskPriorityLow).Return(1).Times(1)
+				scopeMock.EXPECT().RemainingResource().Return(limitMock, nil).Times(1)
+
+				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
+				clientMock.EXPECT().AskTask(gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+				e.baseApp.SetGfSpClient(clientMock)
+				return e
+			},
+			wantedErr: ErrDanglingPointer,
+		},
+		{
+			name: "failed to reserve resource",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				scopeMock := corercmgr.NewMockResourceScope(ctrl)
+				e.scope = scopeMock
+				limitMock := corercmgr.NewMockLimit(ctrl)
+				limitMock.EXPECT().String().Return("1").Times(1)
+				limitMock.EXPECT().GetMemoryLimit().Return(int64(1)).Times(1)
+				limitMock.EXPECT().GetTaskTotalLimit().Return(1).Times(1)
+				limitMock.EXPECT().GetTaskLimit(corercmgr.ReserveTaskPriorityHigh).Return(1).Times(1)
+				limitMock.EXPECT().GetTaskLimit(corercmgr.ReserveTaskPriorityMedium).Return(1).Times(1)
+				limitMock.EXPECT().GetTaskLimit(corercmgr.ReserveTaskPriorityLow).Return(1).Times(1)
+				scopeMock.EXPECT().RemainingResource().Return(limitMock, nil).Times(1)
+				scopeMock.EXPECT().BeginSpan().DoAndReturn(func() (corercmgr.ResourceScopeSpan, error) {
+					return nil, mockErr
+				}).Times(1)
+
+				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
+				clientMock.EXPECT().AskTask(gomock.Any(), gomock.Any()).Return(&gfsptask.GfSpReplicatePieceTask{
+					Task:          &gfsptask.GfSpTask{},
+					ObjectInfo:    &storagetypes.ObjectInfo{Id: sdkmath.NewUint(1)},
+					StorageParams: &storagetypes.Params{VersionedParams: storagetypes.VersionedParams{}},
+				}, nil).Times(1)
+				e.baseApp.SetGfSpClient(clientMock)
+				return e
+			},
+			wantedErr: mockErr,
+		},
+		// {
+		// 	name: "GfSpReplicatePieceTask",
+		// 	fn: func() *ExecuteModular {
+		// 		e := setup(t)
+		// 		ctrl := gomock.NewController(t)
+		// 		scopeMock := corercmgr.NewMockResourceScope(ctrl)
+		// 		e.scope = scopeMock
+		// 		limitMock := corercmgr.NewMockLimit(ctrl)
+		// 		limitMock.EXPECT().String().Return("1").Times(1)
+		// 		limitMock.EXPECT().GetMemoryLimit().Return(int64(1)).Times(1)
+		// 		limitMock.EXPECT().GetTaskTotalLimit().Return(1).Times(1)
+		// 		limitMock.EXPECT().GetTaskLimit(corercmgr.ReserveTaskPriorityHigh).Return(1).Times(1)
+		// 		limitMock.EXPECT().GetTaskLimit(corercmgr.ReserveTaskPriorityMedium).Return(1).Times(1)
+		// 		limitMock.EXPECT().GetTaskLimit(corercmgr.ReserveTaskPriorityLow).Return(1).Times(1)
+		// 		scopeMock.EXPECT().RemainingResource().Return(limitMock, nil).Times(1)
+		// 		spanMock := corercmgr.NewMockResourceScopeSpan(ctrl)
+		// 		scopeMock.EXPECT().BeginSpan().DoAndReturn(func() (corercmgr.ResourceScopeSpan, error) {
+		// 			return spanMock, nil
+		// 		}).Times(1)
+		// 		spanMock.EXPECT().ReserveResources(gomock.Any()).Return(nil).AnyTimes()
+		// 		spanMock.EXPECT().Done().AnyTimes()
+		//
+		// 		clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
+		// 		clientMock.EXPECT().AskTask(gomock.Any(), gomock.Any()).Return(&gfsptask.GfSpReplicatePieceTask{
+		// 			Task:          &gfsptask.GfSpTask{},
+		// 			ObjectInfo:    &storagetypes.ObjectInfo{Id: sdkmath.NewUint(1)},
+		// 			StorageParams: &storagetypes.Params{VersionedParams: storagetypes.VersionedParams{}},
+		// 		}, nil).Times(1)
+		// 		e.baseApp.SetGfSpClient(clientMock)
+		// 		return e
+		// 	},
+		// 	wantedErr: nil,
+		// },
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fn().AskTask(context.TODO())
+			assert.Equal(t, tt.wantedErr, err)
+		})
+	}
+}
+
+func TestExecuteModular_ReportTask(t *testing.T) {
+	e := setup(t)
+	ctrl := gomock.NewController(t)
+	m := gfspclient.NewMockGfSpClientAPI(ctrl)
+	m.EXPECT().ReportTask(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	e.baseApp.SetGfSpClient(m)
+	err := e.ReportTask(context.TODO(), &gfsptask.GfSpReplicatePieceTask{
+		Task:          &gfsptask.GfSpTask{},
+		ObjectInfo:    &storagetypes.ObjectInfo{Id: sdkmath.NewUint(1)},
+		StorageParams: &storagetypes.Params{VersionedParams: storagetypes.VersionedParams{}},
+	})
+	assert.Nil(t, err)
+}
+
+func TestExecuteModular_Stop(t *testing.T) {
+	e := setup(t)
+	ctrl := gomock.NewController(t)
+	m := corercmgr.NewMockResourceScope(ctrl)
+	e.scope = m
+	m.EXPECT().Release().AnyTimes()
+	err := e.Stop(context.TODO())
+	assert.Nil(t, err)
+}
+
+func TestExecuteModular_ReserveResourceSuccess(t *testing.T) {
+	e := setup(t)
+	ctrl := gomock.NewController(t)
+	m := corercmgr.NewMockResourceScope(ctrl)
+	e.scope = m
+	m1 := corercmgr.NewMockResourceScopeSpan(ctrl)
+	m.EXPECT().BeginSpan().DoAndReturn(func() (corercmgr.ResourceScopeSpan, error) {
+		return m1, nil
+	}).Times(1)
+	m1.EXPECT().ReserveResources(gomock.Any()).DoAndReturn(func(st *corercmgr.ScopeStat) error { return nil }).AnyTimes()
+	result, err := e.ReserveResource(context.TODO(), &corercmgr.ScopeStat{Memory: 1})
+	assert.Nil(t, err)
+	assert.NotNil(t, result)
+}
+
+func TestAExecuteModular_ReserveResourceFailure1(t *testing.T) {
+	t.Log("Failure case description: mock BeginSpan returns error")
+	e := setup(t)
+	ctrl := gomock.NewController(t)
+	m := corercmgr.NewMockResourceScope(ctrl)
+	e.scope = m
+	m.EXPECT().BeginSpan().DoAndReturn(func() (corercmgr.ResourceScopeSpan, error) {
+		return nil, mockErr
+	}).Times(1)
+	result, err := e.ReserveResource(context.TODO(), &corercmgr.ScopeStat{Memory: 1})
+	assert.Equal(t, mockErr, err)
+	assert.Nil(t, result)
+}
+
+func TestExecuteModular_ReserveResourceFailure2(t *testing.T) {
+	t.Log("Failure case description: mock ReserveResources returns error")
+	e := setup(t)
+	ctrl := gomock.NewController(t)
+	m := corercmgr.NewMockResourceScope(ctrl)
+	e.scope = m
+	m1 := corercmgr.NewMockResourceScopeSpan(ctrl)
+	m.EXPECT().BeginSpan().DoAndReturn(func() (corercmgr.ResourceScopeSpan, error) {
+		return m1, nil
+	}).Times(1)
+	m1.EXPECT().ReserveResources(gomock.Any()).DoAndReturn(func(st *corercmgr.ScopeStat) error { return mockErr }).AnyTimes()
+	result, err := e.ReserveResource(context.TODO(), &corercmgr.ScopeStat{Memory: 1})
+	assert.Equal(t, mockErr, err)
+	assert.Nil(t, result)
+}
+
+func TestExecuteModular_ReleaseResource(t *testing.T) {
+	e := setup(t)
+	ctrl := gomock.NewController(t)
+	m := corercmgr.NewMockResourceScopeSpan(ctrl)
+	m.EXPECT().Done().AnyTimes()
+	e.ReleaseResource(context.TODO(), m)
+}
+
+func TestExecuteModular_Statistics(t *testing.T) {
+	e := setup(t)
+	result := e.Statistics()
+	assert.NotEmpty(t, result)
+}
+
+func TestExecuteModular_getSPID(t *testing.T) {
+	cases := []struct {
+		name         string
+		fn           func() *ExecuteModular
+		wantedResult uint32
+		wantedErr    error
+	}{
+		{
+			name: "1",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				e.spID = 1
+				return e
+			},
+			wantedResult: 1,
+			wantedErr:    nil,
+		},
+		{
+			name: "2",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := consensus.NewMockConsensus(ctrl)
+				m.EXPECT().QuerySP(gomock.Any(), gomock.Any()).Return(nil, mockErr).Times(1)
+				e.baseApp.SetConsensus(m)
+				return e
+			},
+			wantedResult: 0,
+			wantedErr:    mockErr,
+		},
+		{
+			name: "3",
+			fn: func() *ExecuteModular {
+				e := setup(t)
+				ctrl := gomock.NewController(t)
+				m := consensus.NewMockConsensus(ctrl)
+				m.EXPECT().QuerySP(gomock.Any(), gomock.Any()).Return(&sptypes.StorageProvider{Id: 2}, nil).Times(1)
+				e.baseApp.SetConsensus(m)
+				return e
+			},
+			wantedResult: 2,
+			wantedErr:    nil,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.fn().getSPID()
+			assert.Equal(t, tt.wantedErr, err)
+			assert.Equal(t, tt.wantedResult, result)
+		})
+	}
+}

--- a/modular/executor/migrate_task.go
+++ b/modular/executor/migrate_task.go
@@ -158,7 +158,7 @@ func (e *ExecuteModular) doObjectMigration(ctx context.Context, task coretask.Mi
 func (e *ExecuteModular) checkGVGConflict(ctx context.Context, srcGvg, destGvg *virtualgrouptypes.GlobalVirtualGroup,
 	objectInfo *storagetypes.ObjectInfo, params *storagetypes.Params) error {
 	index := util.ContainOnlyOneDifferentElement(srcGvg.GetSecondarySpIds(), destGvg.GetSecondarySpIds())
-	if index == -1 {
+	if index == piecestore.PrimarySPRedundancyIndex {
 		// no conflict
 		return nil
 	}

--- a/modular/gater/admin_handler.go
+++ b/modular/gater/admin_handler.go
@@ -9,11 +9,6 @@ import (
 	"strings"
 	"time"
 
-	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
-	sdktypes "github.com/cosmos/cosmos-sdk/types"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/crypto/secp256k1"
-
 	commonhash "github.com/bnb-chain/greenfield-common/go/hash"
 	"github.com/bnb-chain/greenfield-common/go/redundancy"
 	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsperrors"
@@ -25,8 +20,12 @@ import (
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/metrics"
 	"github.com/bnb-chain/greenfield-storage-provider/util"
+	sptypes "github.com/bnb-chain/greenfield/x/sp/types"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
 )
+
+const MaxSpRequestExpiryAgeInSec int32 = 1000
 
 // getApprovalHandler handles the get create bucket/object approval request.
 // Before create bucket/object to the greenfield, the user should the primary
@@ -405,6 +404,7 @@ func (g *GateModular) replicateHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		log.CtxDebugw(reqCtx.Context(), reqCtx.String())
 	}()
+
 	// ignore the error, because the replicate request only between SPs, the request
 	// verification is by signature of the ReceivePieceTask
 	reqCtx, _ = NewRequestContext(r, g)
@@ -433,6 +433,15 @@ func (g *GateModular) replicateHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to verify receive task", "error", err, "task", receiveTask)
 		err = ErrSignature
+		return
+	}
+
+	// check if the update time of the task has expired
+	taskUpdateTime := receiveTask.GetUpdateTime()
+	timeDifference := time.Duration(time.Now().Unix()-taskUpdateTime) * time.Second
+	if int32(timeDifference.Seconds()) > MaxSpRequestExpiryAgeInSec {
+		log.CtxErrorw(reqCtx.Context(), "the update time of receive task has exceeded the expiration time", "object", receiveTask.ObjectInfo.ObjectName)
+		err = ErrTaskMsgExpired
 		return
 	}
 
@@ -528,18 +537,20 @@ func (g *GateModular) getRecoverDataHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// check signature consistent
-	taskSignature := recoveryTask.GetSignature()
-	signatureAddr, pk, err := commonhash.RecoverAddr(crypto.Keccak256(recoveryTask.GetSignBytes()), taskSignature)
+	// verify recovery task signature
+	signatureAddr, err := reqCtx.verifyTaskSignature(recoveryTask.GetSignBytes(), recoveryTask.GetSignature())
 	if err != nil {
-		log.CtxErrorw(reqCtx.Context(), "failed to get recover task address", "error", err)
+		log.CtxErrorw(reqCtx.Context(), "failed to verify recovery task", "error", err, "task", recoveryTask)
 		err = ErrSignature
 		return
 	}
 
-	if !secp256k1.VerifySignature(pk.Bytes(), crypto.Keccak256(recoveryTask.GetSignBytes()), taskSignature[:len(taskSignature)-1]) {
-		log.CtxErrorw(reqCtx.Context(), "failed to verify recovery task signature")
-		err = ErrSignature
+	// check if the update time of the task has expired
+	taskUpdateTime := recoveryTask.GetUpdateTime()
+	timeDifference := time.Duration(time.Now().Unix()-taskUpdateTime) * time.Second
+	if int32(timeDifference.Seconds()) > MaxSpRequestExpiryAgeInSec {
+		log.CtxErrorw(reqCtx.Context(), "the update time of recovery task has exceeded the expiration time", "object", recoveryTask.ObjectInfo.ObjectName)
+		err = ErrTaskMsgExpired
 		return
 	}
 

--- a/modular/gater/admin_handler_test.go
+++ b/modular/gater/admin_handler_test.go
@@ -1238,17 +1238,13 @@ func TestGateModular_getReplicateHandlerHandler(t *testing.T) {
 				g := setup(t)
 				ctrl := gomock.NewController(t)
 				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
-				clientMock.EXPECT().VerifyGNFD1EddsaSignature(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
-					false, nil).Times(1)
 				g.baseApp.SetGfSpClient(clientMock)
 				return g
 			},
 			request: func() *http.Request {
 				path := fmt.Sprintf("%s%s%s", scheme, testDomain, ReplicateObjectPiecePath)
 				req := httptest.NewRequest(http.MethodPut, path, strings.NewReader(""))
-				validExpiryDateStr := time.Now().Add(time.Hour * 60).Format(ExpiryDateFormat)
-				req.Header.Set(commonhttp.HTTPHeaderExpiryTimestamp, validExpiryDateStr)
-				req.Header.Set(GnfdAuthorizationHeader, "GNFD1-EDDSA,Signature=48656c6c6f20476f7068657221")
+				// no expire header was set between the http request of SPs, the expiry info is judged by the task update time info of the receive task
 				req.Header.Set(GnfdReceiveMsgHeader, "48656c6c6f20476f706865722")
 				return req
 			},
@@ -1260,17 +1256,13 @@ func TestGateModular_getReplicateHandlerHandler(t *testing.T) {
 				g := setup(t)
 				ctrl := gomock.NewController(t)
 				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
-				clientMock.EXPECT().VerifyGNFD1EddsaSignature(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
-					false, nil).Times(1)
 				g.baseApp.SetGfSpClient(clientMock)
 				return g
 			},
 			request: func() *http.Request {
 				path := fmt.Sprintf("%s%s%s", scheme, testDomain, ReplicateObjectPiecePath)
 				req := httptest.NewRequest(http.MethodPut, path, strings.NewReader(""))
-				validExpiryDateStr := time.Now().Add(time.Hour * 60).Format(ExpiryDateFormat)
-				req.Header.Set(commonhttp.HTTPHeaderExpiryTimestamp, validExpiryDateStr)
-				req.Header.Set(GnfdAuthorizationHeader, "GNFD1-EDDSA,Signature=48656c6c6f20476f7068657221")
+				// no expire header was set between the http request of SPs, the expiry info is judged by the task update time info of the receive task
 				req.Header.Set(GnfdRecoveryMsgHeader, "48656c6c6f20476f7068657221")
 				return req
 			},
@@ -1282,17 +1274,13 @@ func TestGateModular_getReplicateHandlerHandler(t *testing.T) {
 				g := setup(t)
 				ctrl := gomock.NewController(t)
 				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
-				clientMock.EXPECT().VerifyGNFD1EddsaSignature(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
-					false, nil).Times(1)
 				g.baseApp.SetGfSpClient(clientMock)
 				return g
 			},
 			request: func() *http.Request {
 				path := fmt.Sprintf("%s%s%s", scheme, testDomain, ReplicateObjectPiecePath)
 				req := httptest.NewRequest(http.MethodPut, path, strings.NewReader(""))
-				validExpiryDateStr := time.Now().Add(time.Hour * 60).Format(ExpiryDateFormat)
-				req.Header.Set(commonhttp.HTTPHeaderExpiryTimestamp, validExpiryDateStr)
-				req.Header.Set(GnfdAuthorizationHeader, "GNFD1-EDDSA,Signature=48656c6c6f20476f7068657221")
+				// no expire header was set between the http request of SPs, the expiry info is judged by the task update time info of the receive task
 				req.Header.Set(GnfdReceiveMsgHeader, "7b227461736b223a7b7d2c226f626a6563745f696e666f223a7b226f626a6563745f6e616d65223a226d6f636b2d6f626a6563742d6e616d65222c226964223a2230227d2c2273746f726167655f706172616d73223a7b2276657273696f6e65645f706172616d73223a7b7d2c226d61785f7061796c6f61645f73697a65223a31307d2c227365676d656e745f696478223a312c22726564756e64616e63795f696478223a327d")
 				return req
 			},
@@ -1329,17 +1317,13 @@ func TestGateModular_getRecoverDataHandler(t *testing.T) {
 				g := setup(t)
 				ctrl := gomock.NewController(t)
 				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
-				clientMock.EXPECT().VerifyGNFD1EddsaSignature(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
-					false, nil).Times(1)
 				g.baseApp.SetGfSpClient(clientMock)
 				return g
 			},
 			request: func() *http.Request {
 				path := fmt.Sprintf("%s%s%s", scheme, testDomain, RecoverObjectPiecePath)
 				req := httptest.NewRequest(http.MethodGet, path, strings.NewReader(""))
-				validExpiryDateStr := time.Now().Add(time.Hour * 60).Format(ExpiryDateFormat)
-				req.Header.Set(commonhttp.HTTPHeaderExpiryTimestamp, validExpiryDateStr)
-				req.Header.Set(GnfdAuthorizationHeader, "GNFD1-EDDSA,Signature=48656c6c6f20476f7068657221")
+				// no expire header was set between the http request of SPs, the expiry info is judged by the task update time info of the receive task
 				req.Header.Set(GnfdRecoveryMsgHeader, "48656c6c6f20476f706865722")
 				return req
 			},
@@ -1351,17 +1335,13 @@ func TestGateModular_getRecoverDataHandler(t *testing.T) {
 				g := setup(t)
 				ctrl := gomock.NewController(t)
 				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
-				clientMock.EXPECT().VerifyGNFD1EddsaSignature(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
-					false, nil).Times(1)
 				g.baseApp.SetGfSpClient(clientMock)
 				return g
 			},
 			request: func() *http.Request {
 				path := fmt.Sprintf("%s%s%s", scheme, testDomain, RecoverObjectPiecePath)
 				req := httptest.NewRequest(http.MethodGet, path, strings.NewReader(""))
-				validExpiryDateStr := time.Now().Add(time.Hour * 60).Format(ExpiryDateFormat)
-				req.Header.Set(commonhttp.HTTPHeaderExpiryTimestamp, validExpiryDateStr)
-				req.Header.Set(GnfdAuthorizationHeader, "GNFD1-EDDSA,Signature=48656c6c6f20476f7068657221")
+				// no expire header was set between the http request of SPs, the expiry info is judged by the task update time info of the receive task
 				req.Header.Set(GnfdRecoveryMsgHeader, "48656c6c6f20476f7068657221")
 				return req
 			},
@@ -1373,17 +1353,13 @@ func TestGateModular_getRecoverDataHandler(t *testing.T) {
 				g := setup(t)
 				ctrl := gomock.NewController(t)
 				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
-				clientMock.EXPECT().VerifyGNFD1EddsaSignature(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
-					false, nil).Times(1)
 				g.baseApp.SetGfSpClient(clientMock)
 				return g
 			},
 			request: func() *http.Request {
 				path := fmt.Sprintf("%s%s%s", scheme, testDomain, RecoverObjectPiecePath)
 				req := httptest.NewRequest(http.MethodGet, path, strings.NewReader(""))
-				validExpiryDateStr := time.Now().Add(time.Hour * 60).Format(ExpiryDateFormat)
-				req.Header.Set(commonhttp.HTTPHeaderExpiryTimestamp, validExpiryDateStr)
-				req.Header.Set(GnfdAuthorizationHeader, "GNFD1-EDDSA,Signature=48656c6c6f20476f7068657221")
+				// no expire header was set between the http request of SPs, the expiry info is judged by the task update time info of the receive task
 				req.Header.Set(GnfdRecoveryMsgHeader, "7b227461736b223a7b7d2c226f626a6563745f696e666f223a7b226f626a6563745f6e616d65223a226d6f636b2d6f626a6563742d6e616d65222c226964223a2230227d2c2273746f726167655f706172616d73223a7b2276657273696f6e65645f706172616d73223a7b7d2c226d61785f7061796c6f61645f73697a65223a31307d2c227365676d656e745f696478223a312c22726564756e64616e63795f696478223a327d")
 				return req
 			},

--- a/modular/gater/errors.go
+++ b/modular/gater/errors.go
@@ -52,6 +52,7 @@ var (
 	ErrInvalidRedundancyIndex = gfsperrors.Register(module.GateModularName, http.StatusInternalServerError, 50035, "invalid redundancy index")
 	ErrBucketUnavailable      = gfsperrors.Register(module.GateModularName, http.StatusForbidden, 50036, "bucket is not in service status")
 	ErrReplyDownloadData      = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50037, "reply the downloaded data to client failed")
+	ErrTaskMsgExpired         = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50038, "the update time of the task has exceed the expire time")
 )
 
 func ErrEncodeResponseWithDetail(detail string) *gfsperrors.GfSpError {

--- a/modular/gater/errors.go
+++ b/modular/gater/errors.go
@@ -51,6 +51,7 @@ var (
 	ErrRecoveryTimeout        = gfsperrors.Register(module.GateModularName, http.StatusInternalServerError, 50032, "System busy, try to request later")
 	ErrInvalidRedundancyIndex = gfsperrors.Register(module.GateModularName, http.StatusInternalServerError, 50035, "invalid redundancy index")
 	ErrBucketUnavailable      = gfsperrors.Register(module.GateModularName, http.StatusForbidden, 50036, "bucket is not in service status")
+	ErrReplyDownloadData      = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50037, "reply the downloaded data to client failed")
 )
 
 func ErrEncodeResponseWithDetail(detail string) *gfsperrors.GfSpError {

--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bnb-chain/greenfield-storage-provider/store/sqldb"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	commonhttp "github.com/bnb-chain/greenfield-common/go/http"
@@ -374,22 +375,34 @@ func (g *GateModular) queryResumeOffsetHandler(w http.ResponseWriter, r *http.Re
 // getObjectHandler handles the download object request.
 func (g *GateModular) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 	var (
-		err           error
-		reqCtxErr     error
-		reqCtx        *RequestContext
-		authenticated bool
-		objectInfo    *storagetypes.ObjectInfo
-		bucketInfo    *storagetypes.BucketInfo
-		params        *storagetypes.Params
-		lowOffset     int64
-		highOffset    int64
-		pieceInfos    []*downloader.SegmentPieceInfo
-		pieceData     []byte
+		err                       error
+		reqCtxErr                 error
+		reqCtx                    *RequestContext
+		authenticated             bool
+		objectInfo                *storagetypes.ObjectInfo
+		bucketInfo                *storagetypes.BucketInfo
+		params                    *storagetypes.Params
+		lowOffset                 int64
+		highOffset                int64
+		pieceInfos                []*downloader.SegmentPieceInfo
+		pieceData                 []byte
+		extraQuota, consumedQuota uint64
+		replyDataSize             int
+		dbUpdateTimeStamp         int64
 	)
 	getObjectStartTime := time.Now()
 	defer func() {
-		reqCtx.Cancel()
 		if err != nil {
+			// if the bucket exists extra quota when download object, recoup the quota to user
+			if extraQuota > 0 {
+				quotaUpdateErr := g.baseApp.GfSpClient().RecoupQuota(reqCtx.Context(), bucketInfo.Id.Uint64(), extraQuota, sqldb.TimestampYearMonth(dbUpdateTimeStamp))
+				// no need to return the db error to user
+				if quotaUpdateErr != nil {
+					log.CtxErrorw(reqCtx.Context(), "failed to recoup extra quota to user", "error", err)
+				}
+				log.CtxDebugw(reqCtx.Context(), "success to recoup extra quota to user", "extra quota:", extraQuota)
+			}
+
 			log.CtxDebugw(reqCtx.Context(), "get object error")
 			reqCtx.SetError(gfsperrors.MakeGfSpError(err))
 			reqCtx.SetHTTPCode(int(gfsperrors.MakeGfSpError(err).GetHttpStatusCode()))
@@ -406,6 +419,7 @@ func (g *GateModular) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 			metrics.ReqTime.WithLabelValues(GatewaySuccessGetObject).Observe(time.Since(getObjectStartTime).Seconds())
 		}
 		log.CtxDebugw(reqCtx.Context(), reqCtx.String())
+		reqCtx.Cancel()
 	}()
 
 	// GNFD1-ECDSA or GNFD1-EDDSA authentication, by checking the headers.
@@ -542,27 +556,47 @@ func (g *GateModular) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	getDataTime := time.Now()
+	consumedQuota = 0
+	extraQuota = 0
+	downloadSize := uint64(highOffset - lowOffset + 1)
 	for idx, pInfo := range pieceInfos {
 		enableCheck := false
 		if idx == 0 { // only check in first piece
 			enableCheck = true
+			dbUpdateTimeStamp = sqldb.GetCurrentTimestampUs()
 		}
 		pieceTask := &gfsptask.GfSpDownloadPieceTask{}
 		pieceTask.InitDownloadPieceTask(objectInfo, bucketInfo, params, g.baseApp.TaskPriority(task),
-			enableCheck, reqCtx.Account(), uint64(highOffset-lowOffset+1), pInfo.SegmentPieceKey, pInfo.Offset,
+			enableCheck, reqCtx.Account(), downloadSize, pInfo.SegmentPieceKey, pInfo.Offset,
 			pInfo.Length, g.baseApp.TaskTimeout(task, uint64(pieceTask.GetSize())), g.baseApp.TaskMaxRetry(task))
 		getSegmentTime := time.Now()
 		pieceData, err = g.baseApp.GfSpClient().GetPiece(reqCtx.Context(), pieceTask)
+
 		metrics.PerfGetObjectTimeHistogram.WithLabelValues("get_object_segment_data_time").Observe(time.Since(getSegmentTime).Seconds())
 		if err != nil {
 			log.CtxErrorw(reqCtx.Context(), "failed to download piece", "error", err)
+			downloaderErr := gfsperrors.MakeGfSpError(err)
+			// if it is the first piece and the quota db is not updated, no extra data need to updated
+			if idx >= 1 || (idx == 0 && downloaderErr.GetInnerCode() == 85101) {
+				extraQuota = downloadSize - consumedQuota
+			}
 			return
 		}
 
 		writeTime := time.Now()
-		_, _ = w.Write(pieceData)
+		replyDataSize, err = w.Write(pieceData)
+		// if the connection of client has been disconnected, the response will fail
+		if err != nil {
+			log.CtxErrorw(reqCtx.Context(), "failed to write the data to connection", "objectName", objectInfo.ObjectName, "error", err)
+			extraQuota = downloadSize - consumedQuota
+			err = ErrReplyDownloadData
+			return
+		}
+		// the quota value should be computed by the reply content length
+		consumedQuota += uint64(replyDataSize)
 		metrics.PerfGetObjectTimeHistogram.WithLabelValues("get_object_write_time").Observe(time.Since(writeTime).Seconds())
 	}
+
 	metrics.ReqPieceSize.WithLabelValues(GatewayGetObjectSize).Observe(float64(highOffset - lowOffset + 1))
 	metrics.PerfGetObjectTimeHistogram.WithLabelValues("get_object_get_data_time").Observe(time.Since(getDataTime).Seconds())
 }
@@ -666,18 +700,30 @@ func (g *GateModular) getObjectByUniversalEndpointHandler(w http.ResponseWriter,
 		reqCtx               *RequestContext
 		authenticated        bool
 		isRange              bool
-		rangeStart           int64
-		rangeEnd             int64
+		rangeStart, rangeEnd int64
 		redirectURL          string
 		params               *storagetypes.Params
+		bucketInfo           *storagetypes.BucketInfo
+		objectInfo           *storagetypes.ObjectInfo
 		isRequestFromBrowser bool
 		spEndpoint           string
 		getEndpointErr       error
+		dbUpdateTimeStamp    int64
+		extraQuota           uint64
 	)
 	startTime := time.Now()
 	defer func() {
 		reqCtx.Cancel()
 		if err != nil {
+			// if the bucket exists extra quota when download object, recoup the quota to user
+			if extraQuota > 0 {
+				quotaUpdateErr := g.baseApp.GfSpClient().RecoupQuota(reqCtx.Context(), bucketInfo.Id.Uint64(), extraQuota, sqldb.TimestampYearMonth(dbUpdateTimeStamp))
+				// no need to return the db error to user
+				if quotaUpdateErr != nil {
+					log.CtxErrorw(reqCtx.Context(), "failed to recoup extra quota to user", "error", err)
+				}
+				log.CtxDebugw(reqCtx.Context(), "success to recoup extra quota to user", "extra quota:", extraQuota)
+			}
 			spErrCode := gfsperrors.MakeGfSpError(err).GetInnerCode()
 			if isRequestFromBrowser {
 				reqCtx.SetHTTPCode(http.StatusOK)
@@ -732,6 +778,7 @@ func (g *GateModular) getObjectByUniversalEndpointHandler(w http.ResponseWriter,
 		return
 	}
 
+	bucketInfo = getBucketInfoRes.BucketInfo
 	// if bucket not in the current sp, 302 redirect to the sp that contains the bucket
 	// TODO get from config
 	spID, err := g.getSPID()
@@ -767,13 +814,14 @@ func (g *GateModular) getObjectByUniversalEndpointHandler(w http.ResponseWriter,
 		err = ErrNoSuchObject
 		return
 	}
-
-	if getObjectInfoRes.GetObjectInfo().GetObjectStatus() != storagetypes.OBJECT_STATUS_SEALED {
-		log.Errorw("object is not sealed", "status", getObjectInfoRes.GetObjectInfo().GetObjectStatus())
+	objectInfo = getObjectInfoRes.ObjectInfo
+	if objectInfo.GetObjectStatus() != storagetypes.OBJECT_STATUS_SEALED {
+		log.Errorw("object is not sealed",
+			"status", getObjectInfoRes.GetObjectInfo().GetObjectStatus())
 		err = ErrNoSuchObject
 		return
 	}
-	if isPrivateObject(getBucketInfoRes.GetBucketInfo(), getObjectInfoRes.GetObjectInfo()) {
+	if isPrivateObject(bucketInfo, objectInfo) {
 		// for private files, we return a built-in dapp and help users provide a signature for verification
 		var (
 			expiry    string
@@ -863,8 +911,7 @@ func (g *GateModular) getObjectByUniversalEndpointHandler(w http.ResponseWriter,
 
 	}
 
-	params, err = g.baseApp.Consensus().QueryStorageParamsByTimestamp(reqCtx.Context(),
-		getObjectInfoRes.GetObjectInfo().GetCreateAt())
+	params, err = g.baseApp.Consensus().QueryStorageParamsByTimestamp(reqCtx.Context(), objectInfo.GetCreateAt())
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get storage params from consensus", "error", err)
 		err = ErrConsensusWithDetail("failed to get storage params from consensus, error: " + err.Error())
@@ -878,15 +925,22 @@ func (g *GateModular) getObjectByUniversalEndpointHandler(w http.ResponseWriter,
 		high = rangeEnd
 	} else {
 		low = 0
-		high = int64(getObjectInfoRes.GetObjectInfo().GetPayloadSize()) - 1
+		high = int64(objectInfo.GetPayloadSize()) - 1
 	}
 
 	task := &gfsptask.GfSpDownloadObjectTask{}
-	task.InitDownloadObjectTask(getObjectInfoRes.GetObjectInfo(), getBucketInfoRes.GetBucketInfo(), params, g.baseApp.TaskPriority(task), reqCtx.Account(),
+	downloadSize := uint64(high - low + 1)
+	task.InitDownloadObjectTask(objectInfo, bucketInfo, params, g.baseApp.TaskPriority(task), reqCtx.Account(),
 		low, high, g.baseApp.TaskTimeout(task, uint64(high-low+1)), g.baseApp.TaskMaxRetry(task))
+
 	data, getObjectErr := g.baseApp.GfSpClient().GetObject(reqCtx.Context(), task)
 	if getObjectErr != nil {
 		err = getObjectErr
+		downloaderErr := gfsperrors.MakeGfSpError(err)
+		// if the error is  split piece error or piece store error, the traffic should have already consumed extra data
+		if downloaderErr.GetInnerCode() == 85101 || downloaderErr.GetInnerCode() == downloader.ErrInvalidParam.InnerCode {
+			extraQuota = downloadSize
+		}
 		log.CtxErrorw(reqCtx.Context(), "failed to download object", "error", err)
 		return
 	}
@@ -896,14 +950,22 @@ func (g *GateModular) getObjectByUniversalEndpointHandler(w http.ResponseWriter,
 	} else {
 		w.Header().Set(ContentDispositionHeader, ContentDispositionInlineValue)
 	}
-	w.Header().Set(ContentTypeHeader, getObjectInfoRes.GetObjectInfo().GetContentType())
+	w.Header().Set(ContentTypeHeader, objectInfo.GetContentType())
 	if isRange {
 		w.Header().Set(ContentRangeHeader, "bytes "+util.Uint64ToString(uint64(low))+
 			"-"+util.Uint64ToString(uint64(high)))
 	} else {
-		w.Header().Set(ContentLengthHeader, util.Uint64ToString(getObjectInfoRes.GetObjectInfo().GetPayloadSize()))
+		w.Header().Set(ContentLengthHeader, util.Uint64ToString(objectInfo.GetPayloadSize()))
 	}
-	_, _ = w.Write(data)
+
+	replyDataSize, err := w.Write(data)
+	// if the connection of client has been disconnected, the response will fail
+	if err != nil {
+		extraQuota = downloadSize - uint64(replyDataSize)
+		err = ErrReplyDownloadData
+		log.CtxErrorw(reqCtx.Context(), "failed to write the data to connection", "objectName", objectInfo.ObjectName, "error", err)
+		return
+	}
 	log.CtxDebugw(reqCtx.Context(), "succeed to download object for universal endpoint")
 }
 

--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -400,7 +400,8 @@ func (g *GateModular) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 				if quotaUpdateErr != nil {
 					log.CtxErrorw(reqCtx.Context(), "failed to recoup extra quota to user", "error", err)
 				}
-				log.CtxDebugw(reqCtx.Context(), "success to recoup extra quota to user", "extra quota:", extraQuota)
+				log.CtxDebugw(reqCtx.Context(), "//"+
+					"success to recoup extra quota to user", "extra quota:", extraQuota)
 			}
 
 			log.CtxDebugw(reqCtx.Context(), "get object error")

--- a/modular/metadata/metadata_options.go
+++ b/modular/metadata/metadata_options.go
@@ -1,10 +1,14 @@
 package metadata
 
 import (
+	"runtime"
+	"time"
+
 	"github.com/bnb-chain/greenfield-storage-provider/base/gfspapp"
 	"github.com/bnb-chain/greenfield-storage-provider/base/gfspconfig"
 	coremodule "github.com/bnb-chain/greenfield-storage-provider/core/module"
 	"github.com/bnb-chain/greenfield-storage-provider/modular/metadata/types"
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/metrics"
 )
 
 const (
@@ -51,5 +55,16 @@ func DefaultMetadataOptions(metadata *MetadataModular, cfg *gfspconfig.GfSpConfi
 	SpOperatorAddress = cfg.SpAccount.SpOperatorAddress
 	GatewayDomainName = cfg.Gateway.DomainName
 
+	startGoRoutineListener()
 	return nil
+}
+
+// startGoRoutineListener sets up a ticker to periodically check for go routine count of metadata service.
+func startGoRoutineListener() {
+	go func() {
+		dbSwitchTicker := time.NewTicker(500 * time.Millisecond)
+		for range dbSwitchTicker.C {
+			metrics.GoRoutineCount.Set(float64(runtime.NumGoroutine()))
+		}
+	}()
 }

--- a/proto/base/types/gfspserver/download.proto
+++ b/proto/base/types/gfspserver/download.proto
@@ -35,8 +35,20 @@ message GfSpGetChallengeInfoResponse {
   repeated bytes checksums = 4;
 }
 
+message GfSpReimburseQuotaRequest {
+  uint64 bucket_id = 1;
+  uint64 extra_quota = 2;
+  // year_month is the query bucket quota's month, like "2023-03"
+  string year_month = 3;
+}
+
+message GfSpReimburseQuotaResponse {
+  base.types.gfsperrors.GfSpError err = 1;
+}
+
 service GfSpDownloadService {
   rpc GfSpDownloadObject(GfSpDownloadObjectRequest) returns (GfSpDownloadObjectResponse) {}
   rpc GfSpDownloadPiece(GfSpDownloadPieceRequest) returns (GfSpDownloadPieceResponse) {}
   rpc GfSpGetChallengeInfo(GfSpGetChallengeInfoRequest) returns (GfSpGetChallengeInfoResponse) {}
+  rpc GfSpReimburseQuota(GfSpReimburseQuotaRequest) returns (GfSpReimburseQuotaResponse) {}
 }

--- a/store/bsdb/permission.go
+++ b/store/bsdb/permission.go
@@ -161,9 +161,9 @@ func (b *BsDBImpl) ListObjectPolicies(objectID common.Hash, actionType permtypes
 			permission.resource_type = ? AND 
 			permission.resource_id = ? AND 
 			permission.policy_id > ? AND 
-			permission.expiration_time > ? AND 
+			(permission.expiration_time > ? OR permission.expiration_time = 0) AND 
 			permission.removed = false AND 
-			statements.expiration_time > ? AND 
+			(statements.expiration_time > ? OR statements.expiration_time = 0)AND 
 			statements.action_value in (?) AND 
 			statements.removed = false`,
 			gnfdresource.RESOURCE_TYPE_OBJECT.String(),

--- a/store/sqldb/util.go
+++ b/store/sqldb/util.go
@@ -42,6 +42,17 @@ func TimestampYearMonth(ts int64) string {
 	return TimeToYearMonth(TimestampUsToTime(ts))
 }
 
+// IsNextMonth judge if the firstYearMonth is the next month of secondYearMonth
+func IsNextMonth(firstYearMonth, secondYearMonth string) bool {
+	layout := "2006-01"
+	time1, _ := time.Parse(layout, firstYearMonth)
+	time2, _ := time.Parse(layout, secondYearMonth)
+
+	nextMonth := time2.AddDate(0, 1, 0)
+
+	return time1.Equal(nextMonth)
+}
+
 func isAlreadyExists(err error) bool {
 	return strings.HasPrefix(err.Error(), TableAlreadyExistsErrorPrefix)
 }


### PR DESCRIPTION
### Description

Draft release for v0.2.5-alpha.3.

### Rationale

FEATURES
* [#1129](https://github.com/bnb-chain/greenfield-storage-provider/pull/1129) feat: add back metadata go routine listener
* [#1128](https://github.com/bnb-chain/greenfield-storage-provider/pull/1128) feat: support expire time check of SP task info

BUGFIX
* [#1092](https://github.com/bnb-chain/greenfield-storage-provider/pull/1092) fix: support reimburse quota if download consumed extra quota
* [#1127](https://github.com/bnb-chain/greenfield-storage-provider/pull/1127) fix:bs groups unique index
* [#1125](https://github.com/bnb-chain/greenfield-storage-provider/pull/1125) fix: expiration time for statement

TEST
* [#1126](https://github.com/bnb-chain/greenfield-storage-provider/pull/1126) test: modular/executor pkg adds UTs

### Example

N/A.

### Changes

Notable changes: 
* changelog
