### PR TITLE
docs: release: draft release for v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.5
+
+BUGFIX
+* [#1135](https://github.com/bnb-chain/greenfield-storage-provider/pull/1135) fix: effect allow issue
+
 ## v0.2.5-alpha.3
 
 FEATURES


### PR DESCRIPTION
### Description

Draft release for v0.2.5.

### Rationale

BUGFIX
* [#1135](https://github.com/bnb-chain/greenfield-storage-provider/pull/1135) fix: effect allow issue

### Example

N/A.

### Changes

Notable changes: 
* changelog
