### PR TITLE
release: prepare release for v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.5
+
+BUGFIX
+* [#1135](https://github.com/bnb-chain/greenfield-storage-provider/pull/1135) fix: effect allow issue
+
 ## v0.2.5-alpha.3
 
 FEATURES

--- a/store/bsdb/permission.go
+++ b/store/bsdb/permission.go
@@ -165,6 +165,7 @@ func (b *BsDBImpl) ListObjectPolicies(objectID common.Hash, actionType permtypes
 			permission.removed = false AND 
 			(statements.expiration_time > ? OR statements.expiration_time = 0)AND 
 			statements.action_value in (?) AND 
+			statements.effect = "EFFECT_ALLOW" AND
 			statements.removed = false`,
 			gnfdresource.RESOURCE_TYPE_OBJECT.String(),
 			objectID,


### PR DESCRIPTION
### Description

Draft release for v0.2.5.

### Rationale

BUGFIX
* [#1135](https://github.com/bnb-chain/greenfield-storage-provider/pull/1135) fix: effect allow issue

### Example

N/A.

### Changes

Notable changes: 
* changelog
