### PR TITLE
fix: refactoring code for getObject and Universal apis

### DIFF
--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -483,6 +483,8 @@ func (g *GateModular) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// downloadObject this is common method, which does the actual download action.
+// It is called by both getObjectHandler and getObjectByUniversalEndpointHandler after passing the authentication and authorization.
 func (g *GateModular) downloadObject(w http.ResponseWriter, reqCtx *RequestContext) error {
 	var (
 		err                       error

--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -614,7 +614,7 @@ func (g *GateModular) downloadObject(w http.ResponseWriter, reqCtx *RequestConte
 			log.CtxErrorw(reqCtx.Context(), "failed to write the data to connection", "objectName", objectInfo.ObjectName, "error", err)
 			extraQuota = downloadSize - consumedQuota
 			err = ErrReplyData
-			return
+			return err
 		}
 		// the quota value should be computed by the reply content length
 		consumedQuota += uint64(replyDataSize)


### PR DESCRIPTION
### Description

fix: refactoring code for getObject and Universal apis
### Rationale

1. When returning 406 in getObject, the http connection was closed and causing go-sdk can't parse the response
2. In Universal endpoint, it used "download Object" API, which can take up lots of memory.  
3. Many logic code are duplicates in both getObject and Universal apis. In this PR, they are refined and organized into private method and shared by both apis.



### Changes

Notable changes: 
* Remove unnecessary headers in error response
* Refactor  both getObject and Universal apis so that they can use the exact same download logic

