### PR TITLE
fix: fix itegrity hash check

### DIFF
--- a/modular/uploader/upload_task.go
+++ b/modular/uploader/upload_task.go
@@ -131,6 +131,7 @@ func (u *UploadModular) HandleUploadObjectTask(ctx context.Context, uploadObject
 				log.CtxErrorw(ctx, "failed to put object due to check integrity hash not consistent",
 					"object_info", uploadObjectTask.GetObjectInfo(), "actual_integrity", hex.EncodeToString(integrity),
 					"expected_integrity", hex.EncodeToString(uploadObjectTask.GetObjectInfo().GetChecksums()[0]))
+				err = ErrInvalidIntegrity
 				return ErrInvalidIntegrity
 			}
 			integrityMeta := &corespdb.IntegrityMeta{
@@ -261,6 +262,7 @@ func (u *UploadModular) HandleResumableUploadObjectTask(ctx context.Context, tas
 				if !bytes.Equal(integrityHash, task.GetObjectInfo().GetChecksums()[0]) {
 					log.CtxErrorw(ctx, "invalid integrity hash", "object_info", task.GetObjectInfo(),
 						"actual", hex.EncodeToString(integrityHash), "expected", hex.EncodeToString(task.GetObjectInfo().GetChecksums()[0]))
+					err = ErrInvalidIntegrity
 					return ErrInvalidIntegrity
 				}
 				integrityMeta.IntegrityChecksum = integrityHash


### PR DESCRIPTION
### Description

Currently, If uploaded object to SP does not match object meta created onchain, the SP does not handle the error and let replication to SSP happen, which should be restricted and also validation from secondary sp on receiving pieces must be performed to grantee consistence. 
 
### Rationale

Ensure data consistence
 
### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
