### PR TITLE
added feature for inputting OSS accesskeyid and accessSecretkey

### DIFF
--- a/cmd/storage_provider/main.go
+++ b/cmd/storage_provider/main.go
@@ -144,6 +144,13 @@ func storageProvider(ctx *cli.Context) error {
 		log.Errorw("failed to make gf-sp config", "error", err)
 		return nil
 	}
+	
+	err = checkAndInput(cfg)
+	if err != nil {
+		log.Errorw("failed to input keys", "error", err)
+		return nil
+	}	
+	
 	err = utils.MakeEnv(ctx, cfg)
 	if err != nil {
 		log.Errorw("failed to make gf-sp env", "error", err)
@@ -156,3 +163,30 @@ func storageProvider(ctx *cli.Context) error {
 	}
 	return gfsp.Start(context.Background())
 }
+
+
+func checkAndInput(cfg *gfspconfig.GfSpConfig) error {
+
+	if strings.ToLower(cfg.PieceStore.Store.Storage) == "oss" &&
+		strings.ToLower(cfg.PieceStore.Store.IAMType) == "aksk" {
+		fmt.Println("please input AccessKeyId:")
+		reader := bufio.NewReader(os.Stdin)
+
+		text, err := reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		cfg.PieceStore.Store.AccessKeyID = strings.Trim(text, "\n")
+
+		fmt.Println("\nplease input AccessSecretKey:")
+		text, err = reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+
+		cfg.PieceStore.Store.AccessSecretKey = strings.Trim(text, "\n")
+	}
+
+	return nil
+}
+

--- a/cmd/storage_provider/main.go
+++ b/cmd/storage_provider/main.go
@@ -145,11 +145,7 @@ func storageProvider(ctx *cli.Context) error {
 		return nil
 	}
 	
-	err = checkAndInput(cfg)
-	if err != nil {
-		log.Errorw("failed to input keys", "error", err)
-		return nil
-	}	
+	checkAndInput(cfg)
 	
 	err = utils.MakeEnv(ctx, cfg)
 	if err != nil {
@@ -165,28 +161,33 @@ func storageProvider(ctx *cli.Context) error {
 }
 
 
-func checkAndInput(cfg *gfspconfig.GfSpConfig) error {
+func checkAndInput(cfg *gfspconfig.GfSpConfig) {
 
 	if strings.ToLower(cfg.PieceStore.Store.Storage) == "oss" &&
 		strings.ToLower(cfg.PieceStore.Store.IAMType) == "aksk" {
+
+		if cfg.PieceStore.Store.AccessKeyID != "" &&
+			cfg.PieceStore.Store.AccessSecretKey != "" {
+			return
+		}
+
 		fmt.Println("please input AccessKeyId:")
 		reader := bufio.NewReader(os.Stdin)
 
 		text, err := reader.ReadString('\n')
 		if err != nil {
-			return err
+			return
 		}
 		cfg.PieceStore.Store.AccessKeyID = strings.Trim(text, "\n")
 
 		fmt.Println("\nplease input AccessSecretKey:")
 		text, err = reader.ReadString('\n')
 		if err != nil {
-			return err
+			return
 		}
 
 		cfg.PieceStore.Store.AccessSecretKey = strings.Trim(text, "\n")
 	}
 
-	return nil
+	return
 }
-

--- a/store/piecestore/storage/oss.go
+++ b/store/piecestore/storage/oss.go
@@ -150,7 +150,17 @@ func newOSSStore(cfg ObjectStorageConfig) (ObjectStorage, error) {
 
 	switch cfg.IAMType {
 	case AKSKIAMType:
-		key := getOSSSecretKeyFromEnv(OSSRegion, OSSAccessKey, OSSSecretKey, OSSSessionToken)
+	
+		var key *ossStorageSecretKey
+		
+		if cfg.AccessKeyID != "" && cfg.AccessSecretKey != "" {
+			key = &ossStorageSecretKey{}
+			key.accessKey = cfg.AccessKeyID
+			key.secretKey = cfg.AccessSecretKey
+		} else {
+			key = getOSSSecretKeyFromEnv(OSSRegion, OSSAccessKey, OSSSecretKey, OSSSessionToken)
+		}
+
 		if key.accessKey != "" && key.secretKey != "" {
 			cli, err = oss.New(endpoint, key.accessKey, key.secretKey, oss.SecurityToken(key.sessionToken),
 				oss.Region(region), oss.HTTPClient(getHTTPClient(cfg.TLSInsecureSkipVerify)))

--- a/store/piecestore/storage/storage_config.go
+++ b/store/piecestore/storage/storage_config.go
@@ -22,4 +22,7 @@ type ObjectStorageConfig struct {
 	TLSInsecureSkipVerify bool `comment:"optional"`
 	// IAMType is identity and access management type which contains two types: AKSKIAMType/SAIAMType
 	IAMType string `comment:"required"`
+	//for input from console
+	AccessKeyID     string `comment:"optional"`
+	AccessSecretKey string `comment:"optional"`	
 }


### PR DESCRIPTION
### Description
Hello，I am from Atomstaking
Recent days we tried to deployed one SP node on aliyun server, when we tried to start sp node with vairable accesskeyid and accessSecretkey in OS ENV, it is not so convinient:( and it is not so easy to set ENV variable if program is started in service mod on linux system.

so we think it is more convient to input these value at the start time if the program is stated in console
or use config file to set  accesskeyid and accessSecretkey for the program which is started in service mod on linux system

### Rationale
if this feature is added, now the program can be set variable value in 3 ways: console input, config file or enviroment variable.
it is more flexible and convenient


and I am just familiar with aliyun OSS , so I just changed code only for OSS
if you think this is reasonable and can be used for code, please add similiar function for other platform's piestore

Thanks

===============================================================
by the way we found there some wrong with the doc for starting SP node

in the doc :https://docs.bnbchain.org/greenfield-docs/docs/guide/storage-provider/run-book/piece-store

these seting for ENV enviroment is not correct:

PieceStore use environment variables of Alibaba Cloud OSS:

// OSSAccessKey defines env variable name for OSS access key
OSSAccessKey = "ALIBABA_CLOUD_ACCESS_KEY"
// OSSSecretKey defines env variable name for OSS secret key
OSSSecretKey = "ALIBABA_CLOUD_SECRET_KEY"
// OSSSessionToken defines env variable name for OSS session token
OSSSessionToken = "ALIBABA_CLOUD_SESSION_TOKEN"
// OSSRegion defines env variable name for OSS oss region
OSSRegion = "ALIBABA_CLOUD_OSS_REGION"

It should be like following according to your code:
	ALIBABA_CLOUD_ACCESS_KEY = "your aliyun accessKeyId"
	// OSSSecretKey defines env variable name for OSS secret key
	ALIBABA_CLOUD_SECRET_KEY = "your aliyun accessScretKey"
	// OSSSessionToken defines env variable name for OSS session token
	ALIBABA_CLOUD_SESSION_TOKEN =  "your aliyun session Key"
	// OSSRegion defines env variable name for OSS oss region
	ALIBABA_CLOUD_OSS_REGION = "your aliyun oss region"

please update your docs, otherwise other users will suffer same problem with me :(

thank

Atomstaker jia