### PR TITLE
docs:  draft release for v0.2.6-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.6-alpha.2
+
+BUGFIX
+* [#1151](https://github.com/bnb-chain/greenfield-storage-provider/pull/1151) fix: update new logic of metadata apis
+
 ## v0.2.6-alpha.1
 
 FEATURES


### PR DESCRIPTION
### Description

Draft release for v0.2.6 alpha.2

### Rationale

BUGFIX
* [#1151](https://github.com/bnb-chain/greenfield-storage-provider/pull/1151) fix: update new logic of metadata apis

### Example

N/A.

### Changes

Notable changes: 
* changelog
