### PR TITLE
fix: recovery object status should be sealed

### DIFF
--- a/modular/executor/execute_task.go
+++ b/modular/executor/execute_task.go
@@ -46,6 +46,7 @@ var (
 	ErrInvalidRedundancyIndex     = gfsperrors.Register(module.ExecuteModularName, http.StatusInternalServerError, 45212, "invalid redundancy index")
 	ErrSetObjectIntegrity         = gfsperrors.Register(module.ExecuteModularName, http.StatusInternalServerError, 45213, "failed to set object integrity into spdb")
 	ErrInvalidPieceChecksumLength = gfsperrors.Register(module.ExecuteModularName, http.StatusInternalServerError, 45214, "invalid piece checksum length")
+	ErrRecoveryObjectStatus       = gfsperrors.Register(module.ExecuteModularName, http.StatusNotAcceptable, 45215, "the recovered object has not been sealed state")
 )
 
 func ErrGfSpDBWithDetail(detail string) *gfsperrors.GfSpError {
@@ -377,6 +378,11 @@ func (e *ExecuteModular) HandleRecoverPieceTask(ctx context.Context, task coreta
 
 	if task == nil || task.GetObjectInfo() == nil || task.GetStorageParams() == nil {
 		err = ErrDanglingPointer
+		return
+	}
+
+	if task.GetObjectInfo().ObjectStatus != storagetypes.OBJECT_STATUS_SEALED {
+		err = ErrRecoveryObjectStatus
 		return
 	}
 

--- a/modular/gater/admin_handler.go
+++ b/modular/gater/admin_handler.go
@@ -452,7 +452,7 @@ func (g *GateModular) replicateHandler(w http.ResponseWriter, r *http.Request) {
 
 	err = g.checkReplicatePermission(reqCtx.Context(), receiveTask, signatureAddr.String())
 	if err != nil {
-		log.CtxErrorw(reqCtx.Context(), "failed to check the replicate permission", "error", err)
+		log.CtxErrorw(reqCtx.Context(), "failed to check the replicate permission", "object name", receiveTask.ObjectInfo.ObjectName, "error", err)
 		return
 	}
 

--- a/modular/gater/admin_handler.go
+++ b/modular/gater/admin_handler.go
@@ -634,6 +634,11 @@ func (g *GateModular) getRecoverDataHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	if chainObjectInfo.ObjectStatus != storagetypes.OBJECT_STATUS_SEALED {
+		err = ErrNotSealedState
+		return
+	}
+
 	redundancyIdx := recoveryTask.EcIdx
 	maxRedundancyIndex := int32(params.GetRedundantParityChunkNum()+params.GetRedundantDataChunkNum()) - 1
 	if redundancyIdx < int32(RecoveryMinEcIndex) || redundancyIdx > maxRedundancyIndex {
@@ -706,7 +711,7 @@ func (g *GateModular) getRecoverPiece(ctx context.Context, objectInfo *storagety
 		sspAddress = append(sspAddress, sp.OperatorAddress)
 	}
 
-	// if myself is secondary, the sender of the request can be both of  the primary SP or the secondary SP of the gvg
+	// if myself is secondary, the sender of the request can be both of the primary SP or the secondary SP of the gvg
 	if primarySp.OperatorAddress != signatureAddr.String() {
 		log.CtxDebug(ctx, "recovery request not come from primary sp", "secondary sp", signatureAddr.String())
 		// judge if the sender is not one of the secondary SP

--- a/modular/gater/errors.go
+++ b/modular/gater/errors.go
@@ -54,9 +54,9 @@ var (
 	ErrReplyData              = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50037, "reply the downloaded data to client failed")
 	ErrTaskMsgExpired         = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50038, "the update time of the task has exceed the expire time")
 	ErrSecondaryMismatch      = gfsperrors.Register(module.GateModularName, http.StatusNotAcceptable, 50039, "secondary sp mismatch")
-	ErrPrimaryMismatch        = gfsperrors.Register(module.GateModularName, http.StatusNotAcceptable, 50040, "primary sp mismatch")
-	ErrNotCreatedState        = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50041, "object has not been created state")
-	ErrNotSealedState         = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50041, "object has not been sealed state")
+	ErrPrimaryMismatch        = gfsperrors.Register(module.GateModularName, http.StatusNotAcceptable, 50041, "primary sp mismatch")
+	ErrNotCreatedState        = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50042, "object has not been created state")
+	ErrNotSealedState         = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50043, "object has not been sealed state")
 )
 
 func ErrEncodeResponseWithDetail(detail string) *gfsperrors.GfSpError {


### PR DESCRIPTION
### Description


The previous way was to use integrity hash for verification of the recovered data , so there is not much risk .

This pr add checking to make sure the object is sealed when recovery object or pieces. Semantically speaking, only the seal object can be considered uploaded, so it can be not recovered if seal not finished.

### Rationale

add checking

### Example

NA

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
