### PR TITLE
test: add metadata api UT

### DIFF
--- a/modular/metadata/metadata_bucket_service_test.go
+++ b/modular/metadata/metadata_bucket_service_test.go
@@ -1,0 +1,574 @@
+package metadata
+
+import (
+	"context"
+	"math/big"
+	"net/http"
+	"testing"
+
+	"github.com/forbole/juno/v4/common"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsperrors"
+	coremodule "github.com/bnb-chain/greenfield-storage-provider/core/module"
+	"github.com/bnb-chain/greenfield-storage-provider/modular/metadata/types"
+	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
+)
+
+func TestErrGfSpDBWithDetail(t *testing.T) {
+	testDetail := "test detail error"
+	expectedErr := &gfsperrors.GfSpError{
+		CodeSpace:      coremodule.MetadataModularName,
+		HttpStatusCode: int32(http.StatusInternalServerError),
+		InnerCode:      95202,
+		Description:    testDetail,
+	}
+
+	result := ErrGfSpDBWithDetail(testDetail)
+
+	assert.NotNil(t, result)
+	assert.Equal(t, expectedErr, result)
+}
+
+func TestMetadataModular_GfSpGetUserBuckets1(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	m.EXPECT().GetUserBuckets(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Address, bool) (*bsdb.Bucket, error) { return nil, nil },
+	).Times(1)
+	m.EXPECT().ListVirtualGroupFamiliesByVgfIDs(gomock.Any()).DoAndReturn(
+		func([]uint32) ([]*bsdb.GlobalVirtualGroupFamily, error) { return nil, nil },
+	).Times(1)
+	a.baseApp.SetGfBsDB(m)
+	_, err := a.GfSpGetUserBuckets(context.Background(), &types.GfSpGetUserBucketsRequest{
+		AccountId:      "0x6a45de47a2cd53084b4793fca7c1e706b9f54ed1",
+		IncludeRemoved: false,
+	})
+	assert.Nil(t, err)
+}
+
+func TestMetadataModular_GfSpGetUserBuckets2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	m.EXPECT().GetUserBuckets(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Address, bool) ([]*bsdb.Bucket, error) {
+			return []*bsdb.Bucket{&bsdb.Bucket{
+				ID:                         848,
+				Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				BucketName:                 "44yei",
+				Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+				BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000529"),
+				SourceType:                 "SOURCE_TYPE_ORIGIN",
+				CreateAt:                   0,
+				CreateTime:                 0,
+				CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				GlobalVirtualGroupFamilyID: 4,
+				ChargedReadQuota:           0,
+				PaymentPriceTime:           0,
+				Removed:                    false,
+				Status:                     "",
+				DeleteAt:                   0,
+				DeleteReason:               "",
+				UpdateAt:                   0,
+				UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				UpdateTime:                 0,
+			}}, nil
+		},
+	).Times(1)
+	m.EXPECT().ListVirtualGroupFamiliesByVgfIDs(gomock.Any()).DoAndReturn(
+		func([]uint32) ([]*bsdb.GlobalVirtualGroupFamily, error) {
+			return []*bsdb.GlobalVirtualGroupFamily{&bsdb.GlobalVirtualGroupFamily{
+				ID:                         4,
+				GlobalVirtualGroupFamilyId: 4,
+				PrimarySpId:                4,
+				GlobalVirtualGroupIds:      nil,
+				VirtualPaymentAddress:      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				CreateAt:                   0,
+				CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				CreateTime:                 0,
+				UpdateAt:                   0,
+				UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				UpdateTime:                 0,
+				Removed:                    false,
+			}}, nil
+		},
+	).Times(1)
+	a.baseApp.SetGfBsDB(m)
+	buckets, err := a.GfSpGetUserBuckets(context.Background(), &types.GfSpGetUserBucketsRequest{
+		AccountId:      "0x11E0A11A7A01E2E757447B52FBD7152004AC699D",
+		IncludeRemoved: true,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "44yei", buckets.Buckets[0].BucketInfo.BucketName)
+}
+
+func TestMetadataModular_GfSpGetUserBuckets_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	m.EXPECT().GetUserBuckets(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Address, bool) ([]*bsdb.Bucket, error) {
+			return []*bsdb.Bucket{&bsdb.Bucket{
+				ID:                         848,
+				Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				BucketName:                 "44yei",
+				Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+				BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000529"),
+				SourceType:                 "SOURCE_TYPE_ORIGIN",
+				CreateAt:                   0,
+				CreateTime:                 0,
+				CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				GlobalVirtualGroupFamilyID: 4,
+				ChargedReadQuota:           0,
+				PaymentPriceTime:           0,
+				Removed:                    false,
+				Status:                     "",
+				DeleteAt:                   0,
+				DeleteReason:               "",
+				UpdateAt:                   0,
+				UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				UpdateTime:                 0,
+			}}, nil
+		},
+	).Times(1)
+	m.EXPECT().ListVirtualGroupFamiliesByVgfIDs(gomock.Any()).DoAndReturn(
+		func([]uint32) ([]*bsdb.GlobalVirtualGroupFamily, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	a.baseApp.SetGfBsDB(m)
+	buckets, err := a.GfSpGetUserBuckets(context.Background(), &types.GfSpGetUserBucketsRequest{
+		AccountId:      "0x11E0A11A7A01E2E757447B52FBD7152004AC699D",
+		IncludeRemoved: true,
+	})
+	assert.NotNil(t, err)
+	assert.Nil(t, buckets, nil)
+}
+
+func TestMetadataModular_GfSpGetUserBuckets_Failed2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	m.EXPECT().GetUserBuckets(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Address, bool) ([]*bsdb.Bucket, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	a.baseApp.SetGfBsDB(m)
+	buckets, err := a.GfSpGetUserBuckets(context.Background(), &types.GfSpGetUserBucketsRequest{
+		AccountId:      "0x11E0A11A7A01E2E757447B52FBD7152004AC699D",
+		IncludeRemoved: true,
+	})
+	assert.NotNil(t, err)
+	assert.Nil(t, buckets, nil)
+}
+
+func TestMetadataModular_GfSpGetBucketByBucketName_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	m.EXPECT().GetBucketByName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, bool) (*bsdb.Bucket, error) { return nil, nil },
+	).Times(1)
+	a.baseApp.SetGfBsDB(m)
+	_, err := a.GfSpGetBucketByBucketName(context.Background(), &types.GfSpGetBucketByBucketNameRequest{
+		BucketName:     "11111",
+		IncludePrivate: true,
+	})
+	assert.Nil(t, err)
+}
+
+func TestMetadataModular_GfSpGetBucketByBucketName_Success2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	m.EXPECT().GetBucketByName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, bool) (*bsdb.Bucket, error) {
+			return &bsdb.Bucket{
+				ID:                         848,
+				Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				BucketName:                 "44yei",
+				Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+				BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000529"),
+				SourceType:                 "SOURCE_TYPE_ORIGIN",
+				CreateAt:                   0,
+				CreateTime:                 0,
+				CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				GlobalVirtualGroupFamilyID: 4,
+				ChargedReadQuota:           0,
+				PaymentPriceTime:           0,
+				Removed:                    false,
+				Status:                     "",
+				DeleteAt:                   0,
+				DeleteReason:               "",
+				UpdateAt:                   0,
+				UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				UpdateTime:                 0,
+			}, nil
+		},
+	).Times(1)
+	a.baseApp.SetGfBsDB(m)
+	b, err := a.GfSpGetBucketByBucketName(context.Background(), &types.GfSpGetBucketByBucketNameRequest{
+		BucketName:     "44yei",
+		IncludePrivate: true,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "44yei", b.Bucket.BucketInfo.BucketName)
+}
+
+func TestMetadataModular_GfSpGetBucketByBucketName_CheckValidBucketName_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	_, err := a.GfSpGetBucketByBucketName(context.Background(), &types.GfSpGetBucketByBucketNameRequest{
+		BucketName:     "0",
+		IncludePrivate: true,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpGetBucketByBucketName_GetBucketByName_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetBucketByName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, bool) (*bsdb.Bucket, error) { return nil, ErrExceedRequest },
+	).Times(1)
+	_, err := a.GfSpGetBucketByBucketName(context.Background(), &types.GfSpGetBucketByBucketNameRequest{
+		BucketName:     "hello",
+		IncludePrivate: true,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpGetBucketByBucketID_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	m.EXPECT().GetBucketByID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(int64, bool) (*bsdb.Bucket, error) { return nil, nil },
+	).Times(1)
+	a.baseApp.SetGfBsDB(m)
+	_, err := a.GfSpGetBucketByBucketID(context.Background(), &types.GfSpGetBucketByBucketIDRequest{
+		BucketId:       1,
+		IncludePrivate: true,
+	})
+	assert.Nil(t, err)
+}
+
+func TestMetadataModular_GfSpGetBucketByBucketID_Success2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	m.EXPECT().GetBucketByID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(int64, bool) (*bsdb.Bucket, error) {
+			return &bsdb.Bucket{
+				ID:                         848,
+				Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				BucketName:                 "44yei",
+				Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+				BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000529"),
+				SourceType:                 "SOURCE_TYPE_ORIGIN",
+				CreateAt:                   0,
+				CreateTime:                 0,
+				CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				GlobalVirtualGroupFamilyID: 4,
+				ChargedReadQuota:           0,
+				PaymentPriceTime:           0,
+				Removed:                    false,
+				Status:                     "",
+				DeleteAt:                   0,
+				DeleteReason:               "",
+				UpdateAt:                   0,
+				UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				UpdateTime:                 0,
+			}, nil
+		},
+	).Times(1)
+	a.baseApp.SetGfBsDB(m)
+	b, err := a.GfSpGetBucketByBucketID(context.Background(), &types.GfSpGetBucketByBucketIDRequest{
+		BucketId:       529,
+		IncludePrivate: true,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "44yei", b.Bucket.BucketInfo.BucketName)
+}
+
+func TestMetadataModular_GfSpGetBucketByBucketID_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetBucketByID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(int64, bool) (*bsdb.Bucket, error) { return nil, ErrExceedRequest },
+	).Times(1)
+	_, err := a.GfSpGetBucketByBucketID(context.Background(), &types.GfSpGetBucketByBucketIDRequest{
+		BucketId:       529,
+		IncludePrivate: true,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpGetUserBucketsCount_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	m.EXPECT().GetUserBucketsCount(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Address, bool) (int64, error) {
+			return 1, nil
+		},
+	).Times(1)
+	a.baseApp.SetGfBsDB(m)
+	count, err := a.GfSpGetUserBucketsCount(context.Background(), &types.GfSpGetUserBucketsCountRequest{
+		AccountId:      "0x11E0A11A7A01E2E757447B52FBD7152004AC699D",
+		IncludeRemoved: true,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1), count.Count)
+}
+
+func TestMetadataModular_GfSpGetUserBucketsCount_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetUserBucketsCount(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Address, bool) (int64, error) {
+			return 0, ErrExceedRequest
+		},
+	).Times(1)
+	a.baseApp.SetGfBsDB(m)
+	_, err := a.GfSpGetUserBucketsCount(context.Background(), &types.GfSpGetUserBucketsCountRequest{
+		AccountId:      "0x11E0A11A7A01E2E757447B52FBD7152004AC699D",
+		IncludeRemoved: true,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpListExpiredBucketsBySp_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListExpiredBucketsBySp(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(int64, uint32, int64) ([]*bsdb.Bucket, error) {
+			return []*bsdb.Bucket{&bsdb.Bucket{
+				ID:                         848,
+				Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				BucketName:                 "44yei",
+				Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+				BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000529"),
+				SourceType:                 "SOURCE_TYPE_ORIGIN",
+				CreateAt:                   0,
+				CreateTime:                 0,
+				CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				GlobalVirtualGroupFamilyID: 4,
+				ChargedReadQuota:           0,
+				PaymentPriceTime:           0,
+				Removed:                    false,
+				Status:                     "",
+				DeleteAt:                   0,
+				DeleteReason:               "",
+				UpdateAt:                   0,
+				UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				UpdateTime:                 0,
+			}}, nil
+		},
+	).Times(1)
+	a.baseApp.SetGfBsDB(m)
+	buckets, err := a.GfSpListExpiredBucketsBySp(context.Background(), &types.GfSpListExpiredBucketsBySpRequest{
+		CreateAt:    0,
+		PrimarySpId: 0,
+		Limit:       0,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "44yei", buckets.Buckets[0].BucketInfo.BucketName)
+}
+
+func TestMetadataModular_GfSpListExpiredBucketsBySp_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListExpiredBucketsBySp(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(int64, uint32, int64) ([]*bsdb.Bucket, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	a.baseApp.SetGfBsDB(m)
+	_, err := a.GfSpListExpiredBucketsBySp(context.Background(), &types.GfSpListExpiredBucketsBySpRequest{
+		CreateAt:    0,
+		PrimarySpId: 0,
+		Limit:       0,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpGetBucketMeta_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	big, _ := new(big.Int).SetString("123456789012345678901234567890", 10)
+	m.EXPECT().GetBucketMetaByName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, bool) (*bsdb.BucketFullMeta, error) {
+			return &bsdb.BucketFullMeta{
+				Bucket: bsdb.Bucket{
+					ID:                         848,
+					Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					BucketName:                 "44yei",
+					Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+					BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000529"),
+					SourceType:                 "SOURCE_TYPE_ORIGIN",
+					CreateAt:                   0,
+					CreateTime:                 0,
+					CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+					PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					GlobalVirtualGroupFamilyID: 4,
+					ChargedReadQuota:           0,
+					PaymentPriceTime:           0,
+					Removed:                    false,
+					Status:                     "",
+					DeleteAt:                   0,
+					DeleteReason:               "",
+					UpdateAt:                   0,
+					UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+					UpdateTime:                 0,
+				},
+				StreamRecord: bsdb.StreamRecord{
+					ID:                0,
+					Account:           common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					CrudTimestamp:     0,
+					NetflowRate:       (*common.Big)(big),
+					StaticBalance:     (*common.Big)(big),
+					BufferBalance:     (*common.Big)(big),
+					LockBalance:       (*common.Big)(big),
+					Status:            "STREAM_ACCOUNT_STATUS_ACTIVE",
+					SettleTimestamp:   0,
+					OutFlowCount:      0,
+					FrozenNetflowRate: (*common.Big)(big),
+				},
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().ListVirtualGroupFamiliesByVgfIDs(gomock.Any()).DoAndReturn(
+		func([]uint32) ([]*bsdb.GlobalVirtualGroupFamily, error) {
+			return []*bsdb.GlobalVirtualGroupFamily{
+				&bsdb.GlobalVirtualGroupFamily{
+					ID:                         1,
+					GlobalVirtualGroupFamilyId: 1,
+					PrimarySpId:                0,
+					GlobalVirtualGroupIds:      nil,
+					VirtualPaymentAddress:      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					CreateAt:                   0,
+					CreateTxHash:               common.HexToHash("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					CreateTime:                 0,
+					UpdateAt:                   0,
+					UpdateTxHash:               common.HexToHash("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					UpdateTime:                 0,
+					Removed:                    false,
+				},
+			}, nil
+		},
+	).Times(1)
+	a.baseApp.SetGfBsDB(m)
+	buckets, err := a.GfSpGetBucketMeta(context.Background(), &types.GfSpGetBucketMetaRequest{
+		BucketName:     "44yei",
+		IncludePrivate: true,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "44yei", buckets.Bucket.BucketInfo.BucketName)
+}
+
+func TestMetadataModular_GfSpGetBucketMeta_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetBucketMetaByName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, bool) (*bsdb.BucketFullMeta, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	a.baseApp.SetGfBsDB(m)
+	_, err := a.GfSpGetBucketMeta(context.Background(), &types.GfSpGetBucketMetaRequest{
+		BucketName:     "44yei",
+		IncludePrivate: true,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpListBucketsByIDs_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListBucketsByIDs(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Bucket, error) {
+			return []*bsdb.Bucket{&bsdb.Bucket{
+				ID:                         848,
+				Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				BucketName:                 "44yei",
+				Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+				BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				SourceType:                 "SOURCE_TYPE_ORIGIN",
+				CreateAt:                   0,
+				CreateTime:                 0,
+				CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				GlobalVirtualGroupFamilyID: 4,
+				ChargedReadQuota:           0,
+				PaymentPriceTime:           0,
+				Removed:                    false,
+				Status:                     "",
+				DeleteAt:                   0,
+				DeleteReason:               "",
+				UpdateAt:                   0,
+				UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				UpdateTime:                 0,
+			}}, nil
+		},
+	).Times(1)
+	a.baseApp.SetGfBsDB(m)
+	buckets, err := a.GfSpListBucketsByIDs(context.Background(), &types.GfSpListBucketsByIDsRequest{
+		BucketIds:      []uint64{1},
+		IncludeRemoved: true,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "44yei", buckets.Buckets[1].BucketInfo.BucketName)
+}
+
+func TestMetadataModular_GfSpListBucketsByIDs_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListBucketsByIDs(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Bucket, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	a.baseApp.SetGfBsDB(m)
+	_, err := a.GfSpListBucketsByIDs(context.Background(), &types.GfSpListBucketsByIDsRequest{
+		BucketIds:      []uint64{848},
+		IncludeRemoved: true,
+	})
+	assert.NotNil(t, err)
+}

--- a/modular/metadata/metadata_group_service_test.go
+++ b/modular/metadata/metadata_group_service_test.go
@@ -1,0 +1,422 @@
+package metadata
+
+import (
+	"context"
+	"testing"
+
+	"github.com/forbole/juno/v4/common"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/bnb-chain/greenfield-storage-provider/modular/metadata/types"
+	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
+)
+
+func TestMetadataModular_GfSpGetGroupList_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListGroupsByNameAndSourceType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, string, int, int, bool) ([]*bsdb.Group, int64, error) {
+			return []*bsdb.Group{&bsdb.Group{
+				ID:             1,
+				Owner:          common.HexToAddress("0x84A0D38D64498414B14CD979159D57557345CD8B"),
+				GroupID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				GroupName:      "test",
+				SourceType:     "SOURCE_TYPE_ORIGIN",
+				Extra:          "",
+				AccountID:      common.HexToAddress("0x00000000000000000000000000000000000000000x0000000000000000000000000000000000000000"),
+				Operator:       common.HexToAddress("0x0000000000000000000000000000000000000000"),
+				ExpirationTime: 0,
+				CreateAt:       0,
+				CreateTime:     0,
+				UpdateAt:       0,
+				UpdateTime:     0,
+				Removed:        false,
+			}}, 1, nil
+		},
+	).Times(1)
+	m.EXPECT().GetGroupMembersCount(gomock.Any()).DoAndReturn(
+		func([]common.Hash) ([]*bsdb.GroupCount, error) {
+			return []*bsdb.GroupCount{&bsdb.GroupCount{
+				GroupID: common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				Count:   1,
+			}}, nil
+		},
+	).Times(1)
+	groups, err := a.GfSpGetGroupList(context.Background(), &types.GfSpGetGroupListRequest{
+		Name:           "e",
+		Prefix:         "t",
+		SourceType:     "SOURCE_TYPE_ORIGIN",
+		Limit:          1,
+		Offset:         0,
+		IncludeRemoved: true,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1), groups.Count)
+}
+
+func TestMetadataModular_GfSpGetGroupList_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListGroupsByNameAndSourceType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, string, int, int, bool) ([]*bsdb.Group, int64, error) {
+			return nil, 0, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpGetGroupList(context.Background(), &types.GfSpGetGroupListRequest{
+		Name:           "e",
+		Prefix:         "t",
+		SourceType:     "SOURCE_TYPE_ORIGIN",
+		Limit:          1,
+		Offset:         0,
+		IncludeRemoved: true,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpGetGroupList_Failed2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListGroupsByNameAndSourceType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, string, int, int, bool) ([]*bsdb.Group, int64, error) {
+			return []*bsdb.Group{&bsdb.Group{
+				ID:             1,
+				Owner:          common.HexToAddress("0x84A0D38D64498414B14CD979159D57557345CD8B"),
+				GroupID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				GroupName:      "test",
+				SourceType:     "SOURCE_TYPE_ORIGIN",
+				Extra:          "",
+				AccountID:      common.HexToAddress("0x00000000000000000000000000000000000000000x0000000000000000000000000000000000000000"),
+				Operator:       common.HexToAddress("0x0000000000000000000000000000000000000000"),
+				ExpirationTime: 0,
+				CreateAt:       0,
+				CreateTime:     0,
+				UpdateAt:       0,
+				UpdateTime:     0,
+				Removed:        false,
+			}}, 1, nil
+		},
+	).Times(1)
+	m.EXPECT().GetGroupMembersCount(gomock.Any()).DoAndReturn(
+		func([]common.Hash) ([]*bsdb.GroupCount, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpGetGroupList(context.Background(), &types.GfSpGetGroupListRequest{
+		Name:           "e",
+		Prefix:         "t",
+		SourceType:     "SOURCE_TYPE_ORIGIN",
+		Limit:          1,
+		Offset:         0,
+		IncludeRemoved: true,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpGetUserGroups_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetUserGroups(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Address, common.Hash, int) ([]*bsdb.Group, error) {
+			return []*bsdb.Group{&bsdb.Group{
+				ID:             1,
+				Owner:          common.HexToAddress("0x84A0D38D64498414B14CD979159D57557345CD8B"),
+				GroupID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				GroupName:      "test",
+				SourceType:     "SOURCE_TYPE_ORIGIN",
+				Extra:          "",
+				AccountID:      common.HexToAddress("0x00000000000000000000000000000000000000000x0000000000000000000000000000000000000000"),
+				Operator:       common.HexToAddress("0x0000000000000000000000000000000000000000"),
+				ExpirationTime: 0,
+				CreateAt:       0,
+				CreateTime:     0,
+				UpdateAt:       0,
+				UpdateTime:     0,
+				Removed:        false,
+			}}, nil
+		},
+	).Times(1)
+	groups, err := a.GfSpGetUserGroups(context.Background(), &types.GfSpGetUserGroupsRequest{
+		AccountId:  "0x84A0D38D64498414B14CD979159D57557345CD8B",
+		Limit:      0,
+		StartAfter: 0,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "test", groups.Groups[0].Group.GroupName)
+}
+
+func TestMetadataModular_GfSpGetUserGroups_Success2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetUserGroups(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Address, common.Hash, int) ([]*bsdb.Group, error) {
+			return []*bsdb.Group{&bsdb.Group{
+				ID:             1,
+				Owner:          common.HexToAddress("0x84A0D38D64498414B14CD979159D57557345CD8B"),
+				GroupID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				GroupName:      "test",
+				SourceType:     "SOURCE_TYPE_ORIGIN",
+				Extra:          "",
+				AccountID:      common.HexToAddress("0x00000000000000000000000000000000000000000x0000000000000000000000000000000000000000"),
+				Operator:       common.HexToAddress("0x0000000000000000000000000000000000000000"),
+				ExpirationTime: 0,
+				CreateAt:       0,
+				CreateTime:     0,
+				UpdateAt:       0,
+				UpdateTime:     0,
+				Removed:        false,
+			}}, nil
+		},
+	).Times(1)
+	groups, err := a.GfSpGetUserGroups(context.Background(), &types.GfSpGetUserGroupsRequest{
+		AccountId:  "0x84A0D38D64498414B14CD979159D57557345CD8B",
+		Limit:      1111,
+		StartAfter: 0,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "test", groups.Groups[0].Group.GroupName)
+}
+
+func TestMetadataModular_GfSpGetUserGroups_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetUserGroups(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Address, common.Hash, int) ([]*bsdb.Group, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpGetUserGroups(context.Background(), &types.GfSpGetUserGroupsRequest{
+		AccountId:  "0x84A0D38D64498414B14CD979159D57557345CD8B",
+		Limit:      1,
+		StartAfter: 0,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpGetGroupMembers_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetGroupMembers(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, common.Address, int) ([]*bsdb.Group, error) {
+			return []*bsdb.Group{&bsdb.Group{
+				ID:             1,
+				Owner:          common.HexToAddress("0x84A0D38D64498414B14CD979159D57557345CD8B"),
+				GroupID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				GroupName:      "test",
+				SourceType:     "SOURCE_TYPE_ORIGIN",
+				Extra:          "",
+				AccountID:      common.HexToAddress("0x00000000000000000000000000000000000000000x0000000000000000000000000000000000000000"),
+				Operator:       common.HexToAddress("0x0000000000000000000000000000000000000000"),
+				ExpirationTime: 0,
+				CreateAt:       0,
+				CreateTime:     0,
+				UpdateAt:       0,
+				UpdateTime:     0,
+				Removed:        false,
+			}}, nil
+		},
+	).Times(1)
+	groups, err := a.GfSpGetGroupMembers(context.Background(), &types.GfSpGetGroupMembersRequest{
+		GroupId:    1,
+		Limit:      0,
+		StartAfter: "",
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "test", groups.Groups[0].Group.GroupName)
+}
+
+func TestMetadataModular_GfSpGetGroupMembers_Success2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetGroupMembers(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, common.Address, int) ([]*bsdb.Group, error) {
+			return []*bsdb.Group{&bsdb.Group{
+				ID:             1,
+				Owner:          common.HexToAddress("0x84A0D38D64498414B14CD979159D57557345CD8B"),
+				GroupID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				GroupName:      "test",
+				SourceType:     "SOURCE_TYPE_ORIGIN",
+				Extra:          "",
+				AccountID:      common.HexToAddress("0x00000000000000000000000000000000000000000x0000000000000000000000000000000000000000"),
+				Operator:       common.HexToAddress("0x0000000000000000000000000000000000000000"),
+				ExpirationTime: 0,
+				CreateAt:       0,
+				CreateTime:     0,
+				UpdateAt:       0,
+				UpdateTime:     0,
+				Removed:        false,
+			}}, nil
+		},
+	).Times(1)
+	groups, err := a.GfSpGetGroupMembers(context.Background(), &types.GfSpGetGroupMembersRequest{
+		GroupId:    1,
+		Limit:      11110,
+		StartAfter: "",
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "test", groups.Groups[0].Group.GroupName)
+}
+
+func TestMetadataModular_GfSpGetGroupMembers_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetGroupMembers(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, common.Address, int) ([]*bsdb.Group, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpGetGroupMembers(context.Background(), &types.GfSpGetGroupMembersRequest{
+		GroupId:    11111,
+		Limit:      0,
+		StartAfter: "",
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpGetUserOwnedGroups_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetUserOwnedGroups(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Address, common.Hash, int) ([]*bsdb.Group, error) {
+			return []*bsdb.Group{&bsdb.Group{
+				ID:             1,
+				Owner:          common.HexToAddress("0x84A0D38D64498414B14CD979159D57557345CD8B"),
+				GroupID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				GroupName:      "test",
+				SourceType:     "SOURCE_TYPE_ORIGIN",
+				Extra:          "",
+				AccountID:      common.HexToAddress("0x00000000000000000000000000000000000000000x0000000000000000000000000000000000000000"),
+				Operator:       common.HexToAddress("0x0000000000000000000000000000000000000000"),
+				ExpirationTime: 0,
+				CreateAt:       0,
+				CreateTime:     0,
+				UpdateAt:       0,
+				UpdateTime:     0,
+				Removed:        false,
+			}}, nil
+		},
+	).Times(1)
+	groups, err := a.GfSpGetUserOwnedGroups(context.Background(), &types.GfSpGetUserOwnedGroupsRequest{
+		AccountId:  "0x84A0D38D64498414B14CD979159D57557345CD8B",
+		Limit:      0,
+		StartAfter: 0,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "test", groups.Groups[0].Group.GroupName)
+}
+
+func TestMetadataModular_GfSpGetUserOwnedGroups_Success2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetUserOwnedGroups(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Address, common.Hash, int) ([]*bsdb.Group, error) {
+			return []*bsdb.Group{&bsdb.Group{
+				ID:             1,
+				Owner:          common.HexToAddress("0x84A0D38D64498414B14CD979159D57557345CD8B"),
+				GroupID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				GroupName:      "test",
+				SourceType:     "SOURCE_TYPE_ORIGIN",
+				Extra:          "",
+				AccountID:      common.HexToAddress("0x00000000000000000000000000000000000000000x0000000000000000000000000000000000000000"),
+				Operator:       common.HexToAddress("0x0000000000000000000000000000000000000000"),
+				ExpirationTime: 0,
+				CreateAt:       0,
+				CreateTime:     0,
+				UpdateAt:       0,
+				UpdateTime:     0,
+				Removed:        false,
+			}}, nil
+		},
+	).Times(1)
+	groups, err := a.GfSpGetUserOwnedGroups(context.Background(), &types.GfSpGetUserOwnedGroupsRequest{
+		AccountId:  "0x84A0D38D64498414B14CD979159D57557345CD8B",
+		Limit:      11111,
+		StartAfter: 0,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "test", groups.Groups[0].Group.GroupName)
+}
+
+func TestMetadataModular_GfSpGetUserOwnedGroups_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetUserOwnedGroups(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Address, common.Hash, int) ([]*bsdb.Group, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpGetUserOwnedGroups(context.Background(), &types.GfSpGetUserOwnedGroupsRequest{
+		AccountId:  "0x84A0D38D64498414B14CD979159D57557345CD8B",
+		Limit:      11111,
+		StartAfter: 0,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpListGroupsByIDs_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListGroupsByIDs(gomock.Any()).DoAndReturn(
+		func([]common.Hash) ([]*bsdb.Group, error) {
+			return []*bsdb.Group{&bsdb.Group{
+				ID:             1,
+				Owner:          common.HexToAddress("0x84A0D38D64498414B14CD979159D57557345CD8B"),
+				GroupID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				GroupName:      "test",
+				SourceType:     "SOURCE_TYPE_ORIGIN",
+				Extra:          "",
+				AccountID:      common.HexToAddress("0x00000000000000000000000000000000000000000x0000000000000000000000000000000000000000"),
+				Operator:       common.HexToAddress("0x0000000000000000000000000000000000000000"),
+				ExpirationTime: 0,
+				CreateAt:       0,
+				CreateTime:     0,
+				UpdateAt:       0,
+				UpdateTime:     0,
+				Removed:        false,
+			}}, nil
+		},
+	).Times(1)
+	groups, err := a.GfSpListGroupsByIDs(context.Background(), &types.GfSpListGroupsByIDsRequest{GroupIds: []uint64{1}})
+	assert.Nil(t, err)
+	assert.Equal(t, "test", groups.Groups[1].Group.GroupName)
+}
+
+func TestMetadataModular_GfSpListGroupsByIDs_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListGroupsByIDs(gomock.Any()).DoAndReturn(
+		func([]common.Hash) ([]*bsdb.Group, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpListGroupsByIDs(context.Background(), &types.GfSpListGroupsByIDsRequest{GroupIds: []uint64{1}})
+	assert.NotNil(t, err)
+}

--- a/modular/metadata/metadata_object_service_test.go
+++ b/modular/metadata/metadata_object_service_test.go
@@ -1,0 +1,1444 @@
+package metadata
+
+import (
+	"context"
+	"testing"
+
+	"github.com/forbole/juno/v4/common"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/bnb-chain/greenfield-storage-provider/modular/metadata/types"
+	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
+)
+
+func TestMetadataModular_GfSpListObjectsByBucketName_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListObjectsByBucketName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, string, string, int, bool) ([]*bsdb.ListObjectsResult, error) {
+			return []*bsdb.ListObjectsResult{&bsdb.ListObjectsResult{
+				PathName:   "/folder1",
+				ResultType: "Object",
+				Object: &bsdb.Object{
+					ID:                  1,
+					Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+					Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+					Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+					LocalVirtualGroupId: 0,
+					BucketName:          "barry",
+					ObjectName:          "",
+					ObjectID:            common.HexToHash("1"),
+					BucketID:            common.HexToHash("1"),
+					PayloadSize:         0,
+					Visibility:          "",
+					ContentType:         "",
+					CreateAt:            0,
+					CreateTime:          0,
+					ObjectStatus:        "",
+					RedundancyType:      "",
+					SourceType:          "",
+					Checksums:           nil,
+					LockedBalance:       common.HexToHash("1"),
+					Removed:             false,
+					UpdateTime:          0,
+					UpdateAt:            0,
+					DeleteAt:            0,
+					DeleteReason:        "",
+					CreateTxHash:        common.HexToHash("1"),
+					UpdateTxHash:        common.HexToHash("1"),
+					SealTxHash:          common.HexToHash("1"),
+				},
+			}}, nil
+		},
+	).Times(1)
+	objects, err := a.GfSpListObjectsByBucketName(context.Background(), &types.GfSpListObjectsByBucketNameRequest{
+		BucketName:        "barry",
+		AccountId:         "0xe978A9160BC061f602fa083e9C68539C549A421D",
+		MaxKeys:           0,
+		StartAfter:        "test",
+		ContinuationToken: "",
+		Delimiter:         "/",
+		Prefix:            "/folder1",
+		IncludeRemoved:    false,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "barry", objects.Objects[0].ObjectInfo.BucketName)
+}
+
+func TestMetadataModular_GfSpListObjectsByBucketName_Success2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListObjectsByBucketName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, string, string, int, bool) ([]*bsdb.ListObjectsResult, error) {
+			return []*bsdb.ListObjectsResult{&bsdb.ListObjectsResult{
+				PathName:   "/folder1",
+				ResultType: "Object",
+				Object: &bsdb.Object{
+					ID:                  1,
+					Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+					Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+					Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+					LocalVirtualGroupId: 0,
+					BucketName:          "barry",
+					ObjectName:          "",
+					ObjectID:            common.HexToHash("1"),
+					BucketID:            common.HexToHash("1"),
+					PayloadSize:         0,
+					Visibility:          "",
+					ContentType:         "",
+					CreateAt:            0,
+					CreateTime:          0,
+					ObjectStatus:        "",
+					RedundancyType:      "",
+					SourceType:          "",
+					Checksums:           nil,
+					LockedBalance:       common.HexToHash("1"),
+					Removed:             false,
+					UpdateTime:          0,
+					UpdateAt:            0,
+					DeleteAt:            0,
+					DeleteReason:        "",
+					CreateTxHash:        common.HexToHash("1"),
+					UpdateTxHash:        common.HexToHash("1"),
+					SealTxHash:          common.HexToHash("1"),
+				},
+			}}, nil
+		},
+	).Times(1)
+	objects, err := a.GfSpListObjectsByBucketName(context.Background(), &types.GfSpListObjectsByBucketNameRequest{
+		BucketName:        "barry",
+		AccountId:         "0xe978A9160BC061f602fa083e9C68539C549A421D",
+		MaxKeys:           11110,
+		StartAfter:        "test",
+		ContinuationToken: "",
+		Delimiter:         "/",
+		Prefix:            "/folder1",
+		IncludeRemoved:    false,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "barry", objects.Objects[0].ObjectInfo.BucketName)
+}
+
+func TestMetadataModular_GfSpListObjectsByBucketName_Success3(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListObjectsByBucketName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, string, string, int, bool) ([]*bsdb.ListObjectsResult, error) {
+			return []*bsdb.ListObjectsResult{
+				&bsdb.ListObjectsResult{
+					PathName:   "/folder1",
+					ResultType: "object",
+					Object: &bsdb.Object{
+						ID:                  1,
+						Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						LocalVirtualGroupId: 0,
+						BucketName:          "barry",
+						ObjectName:          "1111",
+						ObjectID:            common.HexToHash("1"),
+						BucketID:            common.HexToHash("1"),
+						PayloadSize:         0,
+						Visibility:          "",
+						ContentType:         "",
+						CreateAt:            0,
+						CreateTime:          0,
+						ObjectStatus:        "",
+						RedundancyType:      "",
+						SourceType:          "",
+						Checksums:           nil,
+						LockedBalance:       common.HexToHash("1"),
+						Removed:             false,
+						UpdateTime:          0,
+						UpdateAt:            0,
+						DeleteAt:            0,
+						DeleteReason:        "",
+						CreateTxHash:        common.HexToHash("1"),
+						UpdateTxHash:        common.HexToHash("1"),
+						SealTxHash:          common.HexToHash("1"),
+					}},
+				&bsdb.ListObjectsResult{
+					PathName:   "/folder1",
+					ResultType: "common_prefix",
+					Object: &bsdb.Object{
+						ID:                  1,
+						Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						LocalVirtualGroupId: 0,
+						BucketName:          "barry",
+						ObjectName:          "2222",
+						ObjectID:            common.HexToHash("2"),
+						BucketID:            common.HexToHash("2"),
+						PayloadSize:         0,
+						Visibility:          "",
+						ContentType:         "",
+						CreateAt:            0,
+						CreateTime:          0,
+						ObjectStatus:        "",
+						RedundancyType:      "",
+						SourceType:          "",
+						Checksums:           nil,
+						LockedBalance:       common.HexToHash("2"),
+						Removed:             false,
+						UpdateTime:          0,
+						UpdateAt:            0,
+						DeleteAt:            0,
+						DeleteReason:        "",
+						CreateTxHash:        common.HexToHash("2"),
+						UpdateTxHash:        common.HexToHash("2"),
+						SealTxHash:          common.HexToHash("2"),
+					}},
+				&bsdb.ListObjectsResult{
+					PathName:   "/folder1",
+					ResultType: "common_prefix",
+					Object: &bsdb.Object{
+						ID:                  1,
+						Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						LocalVirtualGroupId: 0,
+						BucketName:          "barry",
+						ObjectName:          "3333",
+						ObjectID:            common.HexToHash("3"),
+						BucketID:            common.HexToHash("3"),
+						PayloadSize:         0,
+						Visibility:          "",
+						ContentType:         "",
+						CreateAt:            0,
+						CreateTime:          0,
+						ObjectStatus:        "",
+						RedundancyType:      "",
+						SourceType:          "",
+						Checksums:           nil,
+						LockedBalance:       common.HexToHash("3"),
+						Removed:             false,
+						UpdateTime:          0,
+						UpdateAt:            0,
+						DeleteAt:            0,
+						DeleteReason:        "",
+						CreateTxHash:        common.HexToHash("3"),
+						UpdateTxHash:        common.HexToHash("3"),
+						SealTxHash:          common.HexToHash("3"),
+					}},
+			}, nil
+		},
+	).Times(1)
+	objects, err := a.GfSpListObjectsByBucketName(context.Background(), &types.GfSpListObjectsByBucketNameRequest{
+		BucketName:        "barry",
+		AccountId:         "0xe978A9160BC061f602fa083e9C68539C549A421D",
+		MaxKeys:           1,
+		StartAfter:        "test",
+		ContinuationToken: "",
+		Delimiter:         "",
+		Prefix:            "/folder1",
+		IncludeRemoved:    false,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "barry", objects.Objects[0].ObjectInfo.BucketName)
+}
+
+func TestMetadataModular_GfSpListObjectsByBucketName_Success4(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListObjectsByBucketName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, string, string, int, bool) ([]*bsdb.ListObjectsResult, error) {
+			return []*bsdb.ListObjectsResult{
+				&bsdb.ListObjectsResult{
+					PathName:   "/folder1",
+					ResultType: "object",
+					Object: &bsdb.Object{
+						ID:                  1,
+						Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						LocalVirtualGroupId: 0,
+						BucketName:          "barry",
+						ObjectName:          "1111",
+						ObjectID:            common.HexToHash("1"),
+						BucketID:            common.HexToHash("1"),
+						PayloadSize:         0,
+						Visibility:          "",
+						ContentType:         "",
+						CreateAt:            0,
+						CreateTime:          0,
+						ObjectStatus:        "",
+						RedundancyType:      "",
+						SourceType:          "",
+						Checksums:           nil,
+						LockedBalance:       common.HexToHash("1"),
+						Removed:             false,
+						UpdateTime:          0,
+						UpdateAt:            0,
+						DeleteAt:            0,
+						DeleteReason:        "",
+						CreateTxHash:        common.HexToHash("1"),
+						UpdateTxHash:        common.HexToHash("1"),
+						SealTxHash:          common.HexToHash("1"),
+					}},
+				&bsdb.ListObjectsResult{
+					PathName:   "/folder1",
+					ResultType: "common_prefix",
+					Object: &bsdb.Object{
+						ID:                  1,
+						Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						LocalVirtualGroupId: 0,
+						BucketName:          "barry",
+						ObjectName:          "2222",
+						ObjectID:            common.HexToHash("2"),
+						BucketID:            common.HexToHash("2"),
+						PayloadSize:         0,
+						Visibility:          "",
+						ContentType:         "",
+						CreateAt:            0,
+						CreateTime:          0,
+						ObjectStatus:        "",
+						RedundancyType:      "",
+						SourceType:          "",
+						Checksums:           nil,
+						LockedBalance:       common.HexToHash("2"),
+						Removed:             false,
+						UpdateTime:          0,
+						UpdateAt:            0,
+						DeleteAt:            0,
+						DeleteReason:        "",
+						CreateTxHash:        common.HexToHash("2"),
+						UpdateTxHash:        common.HexToHash("2"),
+						SealTxHash:          common.HexToHash("2"),
+					}},
+			}, nil
+		},
+	).Times(1)
+	objects, err := a.GfSpListObjectsByBucketName(context.Background(), &types.GfSpListObjectsByBucketNameRequest{
+		BucketName:        "barry",
+		AccountId:         "0xe978A9160BC061f602fa083e9C68539C549A421D",
+		MaxKeys:           1,
+		StartAfter:        "test",
+		ContinuationToken: "",
+		Delimiter:         "",
+		Prefix:            "/folder1",
+		IncludeRemoved:    false,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "barry", objects.Objects[0].ObjectInfo.BucketName)
+}
+
+func TestMetadataModular_GfSpListObjectsByBucketName_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListObjectsByBucketName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, string, string, int, bool) ([]*bsdb.ListObjectsResult, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpListObjectsByBucketName(context.Background(), &types.GfSpListObjectsByBucketNameRequest{
+		BucketName:        "barry",
+		AccountId:         "0xe978A9160BC061f602fa083e9C68539C549A421D",
+		MaxKeys:           11110,
+		StartAfter:        "test",
+		ContinuationToken: "",
+		Delimiter:         "/",
+		Prefix:            "/folder1",
+		IncludeRemoved:    false,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpListDeletedObjectsByBlockNumberRange_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetLatestBlockNumber().DoAndReturn(
+		func() (int64, error) {
+			return 10, nil
+		},
+	).Times(1)
+	m.EXPECT().ListDeletedObjectsByBlockNumberRange(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(int64, int64, bool) ([]*bsdb.Object, error) {
+			return []*bsdb.Object{
+				&bsdb.Object{
+					ID:                  1,
+					Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+					Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+					Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+					LocalVirtualGroupId: 0,
+					BucketName:          "barry",
+					ObjectName:          "2222",
+					ObjectID:            common.HexToHash("2"),
+					BucketID:            common.HexToHash("2"),
+					PayloadSize:         0,
+					Visibility:          "",
+					ContentType:         "",
+					CreateAt:            0,
+					CreateTime:          0,
+					ObjectStatus:        "",
+					RedundancyType:      "",
+					SourceType:          "",
+					Checksums:           nil,
+					LockedBalance:       common.HexToHash("2"),
+					Removed:             false,
+					UpdateTime:          0,
+					UpdateAt:            0,
+					DeleteAt:            0,
+					DeleteReason:        "",
+					CreateTxHash:        common.HexToHash("2"),
+					UpdateTxHash:        common.HexToHash("2"),
+					SealTxHash:          common.HexToHash("2"),
+				},
+			}, nil
+		},
+	).Times(1)
+	objects, err := a.GfSpListDeletedObjectsByBlockNumberRange(context.Background(), &types.GfSpListDeletedObjectsByBlockNumberRangeRequest{
+		StartBlockNumber: 0,
+		EndBlockNumber:   8,
+		IncludePrivate:   false,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "barry", objects.Objects[0].ObjectInfo.BucketName)
+}
+
+func TestMetadataModular_GfSpListDeletedObjectsByBlockNumberRange_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetLatestBlockNumber().DoAndReturn(
+		func() (int64, error) {
+			return 0, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpListDeletedObjectsByBlockNumberRange(context.Background(), &types.GfSpListDeletedObjectsByBlockNumberRangeRequest{
+		StartBlockNumber: 0,
+		EndBlockNumber:   8,
+		IncludePrivate:   false,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpListDeletedObjectsByBlockNumberRange_Failed2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetLatestBlockNumber().DoAndReturn(
+		func() (int64, error) {
+			return 10, nil
+		},
+	).Times(1)
+	m.EXPECT().ListDeletedObjectsByBlockNumberRange(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(int64, int64, bool) ([]*bsdb.Object, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpListDeletedObjectsByBlockNumberRange(context.Background(), &types.GfSpListDeletedObjectsByBlockNumberRangeRequest{
+		StartBlockNumber: 0,
+		EndBlockNumber:   8,
+		IncludePrivate:   false,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpGetObjectMeta_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetObjectByName(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, bool) (*bsdb.Object, error) {
+			return &bsdb.Object{
+				ID:                  1,
+				Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				LocalVirtualGroupId: 0,
+				BucketName:          "barry",
+				ObjectName:          "2222",
+				ObjectID:            common.HexToHash("2"),
+				BucketID:            common.HexToHash("2"),
+				PayloadSize:         0,
+				Visibility:          "",
+				ContentType:         "",
+				CreateAt:            0,
+				CreateTime:          0,
+				ObjectStatus:        "",
+				RedundancyType:      "",
+				SourceType:          "",
+				Checksums:           nil,
+				LockedBalance:       common.HexToHash("2"),
+				Removed:             false,
+				UpdateTime:          0,
+				UpdateAt:            0,
+				DeleteAt:            0,
+				DeleteReason:        "",
+				CreateTxHash:        common.HexToHash("2"),
+				UpdateTxHash:        common.HexToHash("2"),
+				SealTxHash:          common.HexToHash("2"),
+			}, nil
+		},
+	).Times(1)
+	object, err := a.GfSpGetObjectMeta(context.Background(), &types.GfSpGetObjectMetaRequest{
+		ObjectName:     "2222",
+		BucketName:     "barry",
+		IncludePrivate: false,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "2222", object.Object.ObjectInfo.ObjectName)
+}
+
+func TestMetadataModular_GfSpGetObjectMeta_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetObjectByName(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, bool) (*bsdb.Object, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpGetObjectMeta(context.Background(), &types.GfSpGetObjectMetaRequest{
+		ObjectName:     "2",
+		BucketName:     "barry",
+		IncludePrivate: false,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpGetObjectMeta_Failed2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	_, err := a.GfSpGetObjectMeta(context.Background(), &types.GfSpGetObjectMetaRequest{
+		ObjectName:     "",
+		BucketName:     "barry",
+		IncludePrivate: false,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpListObjectsByIDs_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListObjectsByIDs(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Object, error) {
+			return []*bsdb.Object{
+				&bsdb.Object{
+					ID:                  1,
+					Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+					Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+					Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+					LocalVirtualGroupId: 0,
+					BucketName:          "barry",
+					ObjectName:          "2222",
+					ObjectID:            common.HexToHash("2"),
+					BucketID:            common.HexToHash("2"),
+					PayloadSize:         0,
+					Visibility:          "",
+					ContentType:         "",
+					CreateAt:            0,
+					CreateTime:          0,
+					ObjectStatus:        "",
+					RedundancyType:      "",
+					SourceType:          "",
+					Checksums:           nil,
+					LockedBalance:       common.HexToHash("2"),
+					Removed:             false,
+					UpdateTime:          0,
+					UpdateAt:            0,
+					DeleteAt:            0,
+					DeleteReason:        "",
+					CreateTxHash:        common.HexToHash("2"),
+					UpdateTxHash:        common.HexToHash("2"),
+					SealTxHash:          common.HexToHash("2"),
+				},
+			}, nil
+		},
+	).Times(1)
+	objects, err := a.GfSpListObjectsByIDs(context.Background(), &types.GfSpListObjectsByIDsRequest{
+		ObjectIds:      []uint64{1},
+		IncludeRemoved: true,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "2222", objects.Objects[2].ObjectInfo.ObjectName)
+}
+
+func TestMetadataModular_GfSpListObjectsByIDs_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListObjectsByIDs(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Object, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpListObjectsByIDs(context.Background(), &types.GfSpListObjectsByIDsRequest{
+		ObjectIds:      []uint64{1},
+		IncludeRemoved: true,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpListObjectsInGVGAndBucket_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListObjectsInGVGAndBucket(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, uint32, common.Hash, int) ([]*bsdb.Object, *bsdb.Bucket, error) {
+			return []*bsdb.Object{
+					&bsdb.Object{
+						ID:                  1,
+						Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						LocalVirtualGroupId: 0,
+						BucketName:          "barry",
+						ObjectName:          "2222",
+						ObjectID:            common.HexToHash("2"),
+						BucketID:            common.HexToHash("2"),
+						PayloadSize:         0,
+						Visibility:          "",
+						ContentType:         "",
+						CreateAt:            0,
+						CreateTime:          0,
+						ObjectStatus:        "",
+						RedundancyType:      "",
+						SourceType:          "",
+						Checksums:           nil,
+						LockedBalance:       common.HexToHash("2"),
+						Removed:             false,
+						UpdateTime:          0,
+						UpdateAt:            0,
+						DeleteAt:            0,
+						DeleteReason:        "",
+						CreateTxHash:        common.HexToHash("2"),
+						UpdateTxHash:        common.HexToHash("2"),
+						SealTxHash:          common.HexToHash("2"),
+					},
+				},
+				&bsdb.Bucket{
+					ID:                         848,
+					Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					BucketName:                 "barry",
+					Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+					BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+					SourceType:                 "SOURCE_TYPE_ORIGIN",
+					CreateAt:                   0,
+					CreateTime:                 0,
+					CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+					PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					GlobalVirtualGroupFamilyID: 1,
+					ChargedReadQuota:           0,
+					PaymentPriceTime:           0,
+					Removed:                    false,
+					Status:                     "",
+					DeleteAt:                   0,
+					DeleteReason:               "",
+					UpdateAt:                   0,
+					UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+					UpdateTime:                 0,
+				}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetGvgByBucketAndLvgID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, uint32) (*bsdb.GlobalVirtualGroup, error) {
+			return &bsdb.GlobalVirtualGroup{
+				ID:                    1,
+				GlobalVirtualGroupId:  1,
+				FamilyId:              1,
+				PrimarySpId:           1,
+				SecondarySpIds:        []uint32{1},
+				StoredSize:            0,
+				VirtualPaymentAddress: common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				TotalDeposit:          nil,
+				CreateAt:              0,
+				CreateTxHash:          common.HexToHash("1"),
+				CreateTime:            0,
+				UpdateAt:              0,
+				UpdateTxHash:          common.HexToHash("1"),
+				UpdateTime:            0,
+				Removed:               false,
+			}, nil
+		},
+	).Times(1)
+	objects, err := a.GfSpListObjectsInGVGAndBucket(context.Background(), &types.GfSpListObjectsInGVGAndBucketRequest{
+		GvgId:      1,
+		BucketId:   1,
+		StartAfter: 0,
+		Limit:      0,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "2222", objects.Objects[0].Object.ObjectInfo.ObjectName)
+}
+
+func TestMetadataModular_GfSpListObjectsInGVGAndBucket_Success2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListObjectsInGVGAndBucket(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, uint32, common.Hash, int) ([]*bsdb.Object, *bsdb.Bucket, error) {
+			return []*bsdb.Object{
+					&bsdb.Object{
+						ID:                  1,
+						Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						LocalVirtualGroupId: 0,
+						BucketName:          "barry",
+						ObjectName:          "2222",
+						ObjectID:            common.HexToHash("2"),
+						BucketID:            common.HexToHash("2"),
+						PayloadSize:         0,
+						Visibility:          "",
+						ContentType:         "",
+						CreateAt:            0,
+						CreateTime:          0,
+						ObjectStatus:        "",
+						RedundancyType:      "",
+						SourceType:          "",
+						Checksums:           nil,
+						LockedBalance:       common.HexToHash("2"),
+						Removed:             false,
+						UpdateTime:          0,
+						UpdateAt:            0,
+						DeleteAt:            0,
+						DeleteReason:        "",
+						CreateTxHash:        common.HexToHash("2"),
+						UpdateTxHash:        common.HexToHash("2"),
+						SealTxHash:          common.HexToHash("2"),
+					},
+				},
+				&bsdb.Bucket{
+					ID:                         848,
+					Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					BucketName:                 "barry",
+					Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+					BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+					SourceType:                 "SOURCE_TYPE_ORIGIN",
+					CreateAt:                   0,
+					CreateTime:                 0,
+					CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+					PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					GlobalVirtualGroupFamilyID: 1,
+					ChargedReadQuota:           0,
+					PaymentPriceTime:           0,
+					Removed:                    false,
+					Status:                     "",
+					DeleteAt:                   0,
+					DeleteReason:               "",
+					UpdateAt:                   0,
+					UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+					UpdateTime:                 0,
+				}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetGvgByBucketAndLvgID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, uint32) (*bsdb.GlobalVirtualGroup, error) {
+			return &bsdb.GlobalVirtualGroup{
+				ID:                    1,
+				GlobalVirtualGroupId:  1,
+				FamilyId:              1,
+				PrimarySpId:           1,
+				SecondarySpIds:        []uint32{1},
+				StoredSize:            0,
+				VirtualPaymentAddress: common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				TotalDeposit:          nil,
+				CreateAt:              0,
+				CreateTxHash:          common.HexToHash("1"),
+				CreateTime:            0,
+				UpdateAt:              0,
+				UpdateTxHash:          common.HexToHash("1"),
+				UpdateTime:            0,
+				Removed:               false,
+			}, nil
+		},
+	).Times(1)
+	objects, err := a.GfSpListObjectsInGVGAndBucket(context.Background(), &types.GfSpListObjectsInGVGAndBucketRequest{
+		GvgId:      1,
+		BucketId:   1,
+		StartAfter: 0,
+		Limit:      11111,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "2222", objects.Objects[0].Object.ObjectInfo.ObjectName)
+}
+
+func TestMetadataModular_GfSpListObjectsInGVGAndBucket_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListObjectsInGVGAndBucket(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, uint32, common.Hash, int) ([]*bsdb.Object, *bsdb.Bucket, error) {
+			return []*bsdb.Object{
+					&bsdb.Object{
+						ID:                  1,
+						Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						LocalVirtualGroupId: 0,
+						BucketName:          "barry",
+						ObjectName:          "2222",
+						ObjectID:            common.HexToHash("2"),
+						BucketID:            common.HexToHash("2"),
+						PayloadSize:         0,
+						Visibility:          "",
+						ContentType:         "",
+						CreateAt:            0,
+						CreateTime:          0,
+						ObjectStatus:        "",
+						RedundancyType:      "",
+						SourceType:          "",
+						Checksums:           nil,
+						LockedBalance:       common.HexToHash("2"),
+						Removed:             false,
+						UpdateTime:          0,
+						UpdateAt:            0,
+						DeleteAt:            0,
+						DeleteReason:        "",
+						CreateTxHash:        common.HexToHash("2"),
+						UpdateTxHash:        common.HexToHash("2"),
+						SealTxHash:          common.HexToHash("2"),
+					},
+				},
+				&bsdb.Bucket{
+					ID:                         848,
+					Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					BucketName:                 "barry",
+					Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+					BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+					SourceType:                 "SOURCE_TYPE_ORIGIN",
+					CreateAt:                   0,
+					CreateTime:                 0,
+					CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+					PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					GlobalVirtualGroupFamilyID: 1,
+					ChargedReadQuota:           0,
+					PaymentPriceTime:           0,
+					Removed:                    false,
+					Status:                     "",
+					DeleteAt:                   0,
+					DeleteReason:               "",
+					UpdateAt:                   0,
+					UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+					UpdateTime:                 0,
+				}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetGvgByBucketAndLvgID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, uint32) (*bsdb.GlobalVirtualGroup, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpListObjectsInGVGAndBucket(context.Background(), &types.GfSpListObjectsInGVGAndBucketRequest{
+		GvgId:      1,
+		BucketId:   1,
+		StartAfter: 0,
+		Limit:      11111,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpListObjectsInGVGAndBucket_Failed2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListObjectsInGVGAndBucket(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, uint32, common.Hash, int) ([]*bsdb.Object, *bsdb.Bucket, error) {
+			return nil, nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpListObjectsInGVGAndBucket(context.Background(), &types.GfSpListObjectsInGVGAndBucketRequest{
+		GvgId:      1,
+		BucketId:   1,
+		StartAfter: 0,
+		Limit:      11111,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpListObjectsByGVGAndBucketForGC_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListObjectsByGVGAndBucketForGC(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, uint32, common.Hash, int) ([]*bsdb.Object, *bsdb.Bucket, error) {
+			return []*bsdb.Object{
+					&bsdb.Object{
+						ID:                  1,
+						Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						LocalVirtualGroupId: 0,
+						BucketName:          "barry",
+						ObjectName:          "2222",
+						ObjectID:            common.HexToHash("2"),
+						BucketID:            common.HexToHash("2"),
+						PayloadSize:         0,
+						Visibility:          "",
+						ContentType:         "",
+						CreateAt:            0,
+						CreateTime:          0,
+						ObjectStatus:        "",
+						RedundancyType:      "",
+						SourceType:          "",
+						Checksums:           nil,
+						LockedBalance:       common.HexToHash("2"),
+						Removed:             false,
+						UpdateTime:          0,
+						UpdateAt:            0,
+						DeleteAt:            0,
+						DeleteReason:        "",
+						CreateTxHash:        common.HexToHash("2"),
+						UpdateTxHash:        common.HexToHash("2"),
+						SealTxHash:          common.HexToHash("2"),
+					},
+				},
+				&bsdb.Bucket{
+					ID:                         848,
+					Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					BucketName:                 "barry",
+					Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+					BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+					SourceType:                 "SOURCE_TYPE_ORIGIN",
+					CreateAt:                   0,
+					CreateTime:                 0,
+					CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+					PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					GlobalVirtualGroupFamilyID: 1,
+					ChargedReadQuota:           0,
+					PaymentPriceTime:           0,
+					Removed:                    false,
+					Status:                     "",
+					DeleteAt:                   0,
+					DeleteReason:               "",
+					UpdateAt:                   0,
+					UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+					UpdateTime:                 0,
+				}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetGvgByBucketAndLvgID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, uint32) (*bsdb.GlobalVirtualGroup, error) {
+			return &bsdb.GlobalVirtualGroup{
+				ID:                    1,
+				GlobalVirtualGroupId:  1,
+				FamilyId:              1,
+				PrimarySpId:           1,
+				SecondarySpIds:        []uint32{1},
+				StoredSize:            0,
+				VirtualPaymentAddress: common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				TotalDeposit:          nil,
+				CreateAt:              0,
+				CreateTxHash:          common.HexToHash("1"),
+				CreateTime:            0,
+				UpdateAt:              0,
+				UpdateTxHash:          common.HexToHash("1"),
+				UpdateTime:            0,
+				Removed:               false,
+			}, nil
+		},
+	).Times(1)
+	objects, err := a.GfSpListObjectsByGVGAndBucketForGC(context.Background(), &types.GfSpListObjectsByGVGAndBucketForGCRequest{
+		GvgId:      1,
+		BucketId:   1,
+		StartAfter: 0,
+		Limit:      0,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "2222", objects.Objects[0].Object.ObjectInfo.ObjectName)
+}
+
+func TestMetadataModular_GfSpListObjectsByGVGAndBucketForGC_Success2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListObjectsByGVGAndBucketForGC(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, uint32, common.Hash, int) ([]*bsdb.Object, *bsdb.Bucket, error) {
+			return []*bsdb.Object{
+					&bsdb.Object{
+						ID:                  1,
+						Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						LocalVirtualGroupId: 0,
+						BucketName:          "barry",
+						ObjectName:          "2222",
+						ObjectID:            common.HexToHash("2"),
+						BucketID:            common.HexToHash("2"),
+						PayloadSize:         0,
+						Visibility:          "",
+						ContentType:         "",
+						CreateAt:            0,
+						CreateTime:          0,
+						ObjectStatus:        "",
+						RedundancyType:      "",
+						SourceType:          "",
+						Checksums:           nil,
+						LockedBalance:       common.HexToHash("2"),
+						Removed:             false,
+						UpdateTime:          0,
+						UpdateAt:            0,
+						DeleteAt:            0,
+						DeleteReason:        "",
+						CreateTxHash:        common.HexToHash("2"),
+						UpdateTxHash:        common.HexToHash("2"),
+						SealTxHash:          common.HexToHash("2"),
+					},
+				},
+				&bsdb.Bucket{
+					ID:                         848,
+					Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					BucketName:                 "barry",
+					Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+					BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+					SourceType:                 "SOURCE_TYPE_ORIGIN",
+					CreateAt:                   0,
+					CreateTime:                 0,
+					CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+					PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					GlobalVirtualGroupFamilyID: 1,
+					ChargedReadQuota:           0,
+					PaymentPriceTime:           0,
+					Removed:                    false,
+					Status:                     "",
+					DeleteAt:                   0,
+					DeleteReason:               "",
+					UpdateAt:                   0,
+					UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+					UpdateTime:                 0,
+				}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetGvgByBucketAndLvgID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, uint32) (*bsdb.GlobalVirtualGroup, error) {
+			return &bsdb.GlobalVirtualGroup{
+				ID:                    1,
+				GlobalVirtualGroupId:  1,
+				FamilyId:              1,
+				PrimarySpId:           1,
+				SecondarySpIds:        []uint32{1},
+				StoredSize:            0,
+				VirtualPaymentAddress: common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				TotalDeposit:          nil,
+				CreateAt:              0,
+				CreateTxHash:          common.HexToHash("1"),
+				CreateTime:            0,
+				UpdateAt:              0,
+				UpdateTxHash:          common.HexToHash("1"),
+				UpdateTime:            0,
+				Removed:               false,
+			}, nil
+		},
+	).Times(1)
+	objects, err := a.GfSpListObjectsByGVGAndBucketForGC(context.Background(), &types.GfSpListObjectsByGVGAndBucketForGCRequest{
+		GvgId:      1,
+		BucketId:   1,
+		StartAfter: 0,
+		Limit:      11111,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "2222", objects.Objects[0].Object.ObjectInfo.ObjectName)
+}
+
+func TestMetadataModular_GfSpListObjectsByGVGAndBucketForGC_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListObjectsByGVGAndBucketForGC(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, uint32, common.Hash, int) ([]*bsdb.Object, *bsdb.Bucket, error) {
+			return []*bsdb.Object{
+					&bsdb.Object{
+						ID:                  1,
+						Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						LocalVirtualGroupId: 0,
+						BucketName:          "barry",
+						ObjectName:          "2222",
+						ObjectID:            common.HexToHash("2"),
+						BucketID:            common.HexToHash("2"),
+						PayloadSize:         0,
+						Visibility:          "",
+						ContentType:         "",
+						CreateAt:            0,
+						CreateTime:          0,
+						ObjectStatus:        "",
+						RedundancyType:      "",
+						SourceType:          "",
+						Checksums:           nil,
+						LockedBalance:       common.HexToHash("2"),
+						Removed:             false,
+						UpdateTime:          0,
+						UpdateAt:            0,
+						DeleteAt:            0,
+						DeleteReason:        "",
+						CreateTxHash:        common.HexToHash("2"),
+						UpdateTxHash:        common.HexToHash("2"),
+						SealTxHash:          common.HexToHash("2"),
+					},
+				},
+				&bsdb.Bucket{
+					ID:                         848,
+					Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					BucketName:                 "barry",
+					Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+					BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+					SourceType:                 "SOURCE_TYPE_ORIGIN",
+					CreateAt:                   0,
+					CreateTime:                 0,
+					CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+					PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					GlobalVirtualGroupFamilyID: 1,
+					ChargedReadQuota:           0,
+					PaymentPriceTime:           0,
+					Removed:                    false,
+					Status:                     "",
+					DeleteAt:                   0,
+					DeleteReason:               "",
+					UpdateAt:                   0,
+					UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+					UpdateTime:                 0,
+				}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetGvgByBucketAndLvgID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, uint32) (*bsdb.GlobalVirtualGroup, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpListObjectsByGVGAndBucketForGC(context.Background(), &types.GfSpListObjectsByGVGAndBucketForGCRequest{
+		GvgId:      1,
+		BucketId:   1,
+		StartAfter: 0,
+		Limit:      11111,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpListObjectsByGVGAndBucketForGC_Failed2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListObjectsByGVGAndBucketForGC(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, uint32, common.Hash, int) ([]*bsdb.Object, *bsdb.Bucket, error) {
+			return nil, nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpListObjectsByGVGAndBucketForGC(context.Background(), &types.GfSpListObjectsByGVGAndBucketForGCRequest{
+		GvgId:      1,
+		BucketId:   1,
+		StartAfter: 0,
+		Limit:      11111,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpListObjectsInGVG_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListObjectsInGVG(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(uint32, common.Hash, int) ([]*bsdb.Object, *bsdb.Bucket, error) {
+			return []*bsdb.Object{
+					&bsdb.Object{
+						ID:                  1,
+						Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						LocalVirtualGroupId: 0,
+						BucketName:          "barry",
+						ObjectName:          "2222",
+						ObjectID:            common.HexToHash("2"),
+						BucketID:            common.HexToHash("2"),
+						PayloadSize:         0,
+						Visibility:          "",
+						ContentType:         "",
+						CreateAt:            0,
+						CreateTime:          0,
+						ObjectStatus:        "",
+						RedundancyType:      "",
+						SourceType:          "",
+						Checksums:           nil,
+						LockedBalance:       common.HexToHash("2"),
+						Removed:             false,
+						UpdateTime:          0,
+						UpdateAt:            0,
+						DeleteAt:            0,
+						DeleteReason:        "",
+						CreateTxHash:        common.HexToHash("2"),
+						UpdateTxHash:        common.HexToHash("2"),
+						SealTxHash:          common.HexToHash("2"),
+					},
+				},
+				&bsdb.Bucket{
+					ID:                         848,
+					Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					BucketName:                 "barry",
+					Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+					BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+					SourceType:                 "SOURCE_TYPE_ORIGIN",
+					CreateAt:                   0,
+					CreateTime:                 0,
+					CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+					PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					GlobalVirtualGroupFamilyID: 1,
+					ChargedReadQuota:           0,
+					PaymentPriceTime:           0,
+					Removed:                    false,
+					Status:                     "",
+					DeleteAt:                   0,
+					DeleteReason:               "",
+					UpdateAt:                   0,
+					UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+					UpdateTime:                 0,
+				}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetGvgByBucketAndLvgID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, uint32) (*bsdb.GlobalVirtualGroup, error) {
+			return &bsdb.GlobalVirtualGroup{
+				ID:                    1,
+				GlobalVirtualGroupId:  1,
+				FamilyId:              1,
+				PrimarySpId:           1,
+				SecondarySpIds:        []uint32{1},
+				StoredSize:            0,
+				VirtualPaymentAddress: common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				TotalDeposit:          nil,
+				CreateAt:              0,
+				CreateTxHash:          common.HexToHash("1"),
+				CreateTime:            0,
+				UpdateAt:              0,
+				UpdateTxHash:          common.HexToHash("1"),
+				UpdateTime:            0,
+				Removed:               false,
+			}, nil
+		},
+	).Times(1)
+	objects, err := a.GfSpListObjectsInGVG(context.Background(), &types.GfSpListObjectsInGVGRequest{
+		GvgId:      1,
+		StartAfter: 0,
+		Limit:      0,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "2222", objects.Objects[0].Object.ObjectInfo.ObjectName)
+}
+
+func TestMetadataModular_GfSpListObjectsInGVG_Success2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListObjectsInGVG(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(uint32, common.Hash, int) ([]*bsdb.Object, []*bsdb.Bucket, error) {
+			return []*bsdb.Object{
+					&bsdb.Object{
+						ID:                  1,
+						Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						LocalVirtualGroupId: 0,
+						BucketName:          "barry",
+						ObjectName:          "2222",
+						ObjectID:            common.HexToHash("2"),
+						BucketID:            common.HexToHash("1"),
+						PayloadSize:         0,
+						Visibility:          "",
+						ContentType:         "",
+						CreateAt:            0,
+						CreateTime:          0,
+						ObjectStatus:        "",
+						RedundancyType:      "",
+						SourceType:          "",
+						Checksums:           nil,
+						LockedBalance:       common.HexToHash("2"),
+						Removed:             false,
+						UpdateTime:          0,
+						UpdateAt:            0,
+						DeleteAt:            0,
+						DeleteReason:        "",
+						CreateTxHash:        common.HexToHash("2"),
+						UpdateTxHash:        common.HexToHash("2"),
+						SealTxHash:          common.HexToHash("2"),
+					},
+				}, []*bsdb.Bucket{
+					&bsdb.Bucket{
+						ID:                         848,
+						Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+						Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+						BucketName:                 "barry",
+						Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+						BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+						SourceType:                 "SOURCE_TYPE_ORIGIN",
+						CreateAt:                   0,
+						CreateTime:                 0,
+						CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+						PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+						GlobalVirtualGroupFamilyID: 1,
+						ChargedReadQuota:           0,
+						PaymentPriceTime:           0,
+						Removed:                    false,
+						Status:                     "",
+						DeleteAt:                   0,
+						DeleteReason:               "",
+						UpdateAt:                   0,
+						UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+						UpdateTime:                 0,
+					}}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetGvgByBucketAndLvgID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, uint32) (*bsdb.GlobalVirtualGroup, error) {
+			return &bsdb.GlobalVirtualGroup{
+				ID:                    1,
+				GlobalVirtualGroupId:  1,
+				FamilyId:              1,
+				PrimarySpId:           1,
+				SecondarySpIds:        []uint32{1},
+				StoredSize:            0,
+				VirtualPaymentAddress: common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				TotalDeposit:          nil,
+				CreateAt:              0,
+				CreateTxHash:          common.HexToHash("1"),
+				CreateTime:            0,
+				UpdateAt:              0,
+				UpdateTxHash:          common.HexToHash("1"),
+				UpdateTime:            0,
+				Removed:               false,
+			}, nil
+		},
+	).Times(1)
+	objects, err := a.GfSpListObjectsInGVG(context.Background(), &types.GfSpListObjectsInGVGRequest{
+		GvgId:      1,
+		StartAfter: 0,
+		Limit:      11111,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "2222", objects.Objects[0].Object.ObjectInfo.ObjectName)
+}
+
+func TestMetadataModular_GfSpListObjectsInGVG_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListObjectsInGVG(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(uint32, common.Hash, int) ([]*bsdb.Object, *bsdb.Bucket, error) {
+			return []*bsdb.Object{
+					&bsdb.Object{
+						ID:                  1,
+						Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+						LocalVirtualGroupId: 0,
+						BucketName:          "barry",
+						ObjectName:          "2222",
+						ObjectID:            common.HexToHash("2"),
+						BucketID:            common.HexToHash("2"),
+						PayloadSize:         0,
+						Visibility:          "",
+						ContentType:         "",
+						CreateAt:            0,
+						CreateTime:          0,
+						ObjectStatus:        "",
+						RedundancyType:      "",
+						SourceType:          "",
+						Checksums:           nil,
+						LockedBalance:       common.HexToHash("2"),
+						Removed:             false,
+						UpdateTime:          0,
+						UpdateAt:            0,
+						DeleteAt:            0,
+						DeleteReason:        "",
+						CreateTxHash:        common.HexToHash("2"),
+						UpdateTxHash:        common.HexToHash("2"),
+						SealTxHash:          common.HexToHash("2"),
+					},
+				},
+				&bsdb.Bucket{
+					ID:                         848,
+					Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					BucketName:                 "barry",
+					Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+					BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+					SourceType:                 "SOURCE_TYPE_ORIGIN",
+					CreateAt:                   0,
+					CreateTime:                 0,
+					CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+					PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					GlobalVirtualGroupFamilyID: 1,
+					ChargedReadQuota:           0,
+					PaymentPriceTime:           0,
+					Removed:                    false,
+					Status:                     "",
+					DeleteAt:                   0,
+					DeleteReason:               "",
+					UpdateAt:                   0,
+					UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+					UpdateTime:                 0,
+				}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetGvgByBucketAndLvgID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, uint32) (*bsdb.GlobalVirtualGroup, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpListObjectsInGVG(context.Background(), &types.GfSpListObjectsInGVGRequest{
+		GvgId:      1,
+		StartAfter: 0,
+		Limit:      11111,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpListObjectsInGVG_Failed2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListObjectsInGVG(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(uint32, common.Hash, int) ([]*bsdb.Object, *bsdb.Bucket, error) {
+			return nil, nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpListObjectsInGVG(context.Background(), &types.GfSpListObjectsInGVGRequest{
+		GvgId:      1,
+		StartAfter: 0,
+		Limit:      11111,
+	})
+	assert.NotNil(t, err)
+}

--- a/modular/metadata/metadata_options_test.go
+++ b/modular/metadata/metadata_options_test.go
@@ -1,0 +1,29 @@
+package metadata
+
+import (
+	"testing"
+
+	"github.com/bnb-chain/greenfield-storage-provider/base/gfspapp"
+	"github.com/bnb-chain/greenfield-storage-provider/base/gfspconfig"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultMetadataOptions(t *testing.T) {
+	app := &gfspapp.GfSpBaseApp{}
+	cfg := &gfspconfig.GfSpConfig{
+		Parallel:    gfspconfig.ParallelConfig{},
+		BlockSyncer: gfspconfig.BlockSyncerConfig{},
+		Chain:       gfspconfig.ChainConfig{},
+		SpAccount:   gfspconfig.SpAccountConfig{},
+		Gateway:     gfspconfig.GatewayConfig{},
+	}
+
+	metadata := &MetadataModular{
+		baseApp: app,
+	}
+
+	err := DefaultMetadataOptions(metadata, cfg)
+	assert.Nil(t, err)
+
+	assert.Equal(t, DefaultQuerySPParallelPerNode, metadata.maxMetadataRequest)
+}

--- a/modular/metadata/metadata_payment_service_test.go
+++ b/modular/metadata/metadata_payment_service_test.go
@@ -1,0 +1,221 @@
+package metadata
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/forbole/juno/v4/common"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/bnb-chain/greenfield-storage-provider/modular/metadata/types"
+	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
+)
+
+func TestMetadataModular_GfSpGetPaymentByBucketName_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	big, _ := new(big.Int).SetString("123456789012345678901234567890", 10)
+	m.EXPECT().GetPaymentByBucketName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, bool) (*bsdb.StreamRecord, error) {
+			return &bsdb.StreamRecord{
+				ID:                0,
+				Account:           common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				CrudTimestamp:     1000,
+				NetflowRate:       (*common.Big)(big),
+				StaticBalance:     (*common.Big)(big),
+				BufferBalance:     (*common.Big)(big),
+				LockBalance:       (*common.Big)(big),
+				Status:            "STREAM_ACCOUNT_STATUS_ACTIVE",
+				SettleTimestamp:   0,
+				OutFlowCount:      0,
+				FrozenNetflowRate: (*common.Big)(big),
+			}, nil
+		},
+	).Times(1)
+	record, err := a.GfSpGetPaymentByBucketName(context.Background(), &types.GfSpGetPaymentByBucketNameRequest{
+		BucketName:     "barry",
+		IncludePrivate: false,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1000), record.StreamRecord.CrudTimestamp)
+}
+
+func TestMetadataModular_GfSpGetPaymentByBucketName_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetPaymentByBucketName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, bool) (*bsdb.StreamRecord, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpGetPaymentByBucketName(context.Background(), &types.GfSpGetPaymentByBucketNameRequest{
+		BucketName:     "barry",
+		IncludePrivate: false,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpGetPaymentByBucketID_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	big, _ := new(big.Int).SetString("123456789012345678901234567890", 10)
+	m.EXPECT().GetPaymentByBucketID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(int64, bool) (*bsdb.StreamRecord, error) {
+			return &bsdb.StreamRecord{
+				ID:                0,
+				Account:           common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				CrudTimestamp:     1000,
+				NetflowRate:       (*common.Big)(big),
+				StaticBalance:     (*common.Big)(big),
+				BufferBalance:     (*common.Big)(big),
+				LockBalance:       (*common.Big)(big),
+				Status:            "STREAM_ACCOUNT_STATUS_ACTIVE",
+				SettleTimestamp:   0,
+				OutFlowCount:      0,
+				FrozenNetflowRate: (*common.Big)(big),
+			}, nil
+		},
+	).Times(1)
+	record, err := a.GfSpGetPaymentByBucketID(context.Background(), &types.GfSpGetPaymentByBucketIDRequest{
+		BucketId:       1,
+		IncludePrivate: false,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1000), record.StreamRecord.CrudTimestamp)
+}
+
+func TestMetadataModular_GfSpGetPaymentByBucketID_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetPaymentByBucketID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(int64, bool) (*bsdb.StreamRecord, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpGetPaymentByBucketID(context.Background(), &types.GfSpGetPaymentByBucketIDRequest{
+		BucketId:       1,
+		IncludePrivate: false,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpListPaymentAccountStreams_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListPaymentAccountStreams(gomock.Any()).DoAndReturn(
+		func(common.Address) ([]*bsdb.Bucket, error) {
+			return []*bsdb.Bucket{
+				&bsdb.Bucket{
+					ID:                         848,
+					Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					BucketName:                 "44yei",
+					Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+					BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000529"),
+					SourceType:                 "SOURCE_TYPE_ORIGIN",
+					CreateAt:                   0,
+					CreateTime:                 0,
+					CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+					PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					GlobalVirtualGroupFamilyID: 4,
+					ChargedReadQuota:           0,
+					PaymentPriceTime:           0,
+					Removed:                    false,
+					Status:                     "",
+					DeleteAt:                   0,
+					DeleteReason:               "",
+					UpdateAt:                   0,
+					UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+					UpdateTime:                 0,
+				},
+			}, nil
+		},
+	).Times(1)
+	buckets, err := a.GfSpListPaymentAccountStreams(context.Background(), &types.GfSpListPaymentAccountStreamsRequest{PaymentAccount: "0x11E0A11A7A01E2E757447B52FBD7152004AC699D"})
+	assert.Nil(t, err)
+	assert.Equal(t, "44yei", buckets.Buckets[0].BucketInfo.BucketName)
+}
+
+func TestMetadataModular_GfSpListPaymentAccountStreams_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListPaymentAccountStreams(gomock.Any()).DoAndReturn(
+		func(common.Address) ([]*bsdb.Bucket, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpListPaymentAccountStreams(context.Background(), &types.GfSpListPaymentAccountStreamsRequest{PaymentAccount: "0x11E0A11A7A01E2E757447B52FBD7152004AC699D"})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpListUserPaymentAccounts_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	big, _ := new(big.Int).SetString("123456789012345678901234567890", 10)
+	m.EXPECT().ListUserPaymentAccounts(gomock.Any()).DoAndReturn(
+		func(common.Address) ([]*bsdb.StreamRecordPaymentAccount, error) {
+			return []*bsdb.StreamRecordPaymentAccount{
+				&bsdb.StreamRecordPaymentAccount{
+					PaymentAccount: bsdb.PaymentAccount{
+						ID:         0,
+						Addr:       common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+						Owner:      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+						Refundable: false,
+						UpdateAt:   0,
+						UpdateTime: 0,
+					},
+					StreamRecord: bsdb.StreamRecord{
+						ID:                0,
+						Account:           common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+						CrudTimestamp:     1000,
+						NetflowRate:       (*common.Big)(big),
+						StaticBalance:     (*common.Big)(big),
+						BufferBalance:     (*common.Big)(big),
+						LockBalance:       (*common.Big)(big),
+						Status:            "STREAM_ACCOUNT_STATUS_ACTIVE",
+						SettleTimestamp:   0,
+						OutFlowCount:      0,
+						FrozenNetflowRate: (*common.Big)(big),
+					},
+				},
+			}, nil
+		},
+	).Times(1)
+	records, err := a.GfSpListUserPaymentAccounts(context.Background(), &types.GfSpListUserPaymentAccountsRequest{
+		AccountId: "0x11E0A11A7A01E2E757447B52FBD7152004AC699D",
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1000), records.PaymentAccounts[0].StreamRecord.CrudTimestamp)
+}
+
+func TestMetadataModular_GfSpListUserPaymentAccounts_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListUserPaymentAccounts(gomock.Any()).DoAndReturn(
+		func(common.Address) ([]*bsdb.StreamRecord, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpListUserPaymentAccounts(context.Background(), &types.GfSpListUserPaymentAccountsRequest{
+		AccountId: "0x11E0A11A7A01E2E757447B52FBD7152004AC699D",
+	})
+	assert.NotNil(t, err)
+}

--- a/modular/metadata/metadata_permission_service_test.go
+++ b/modular/metadata/metadata_permission_service_test.go
@@ -1,0 +1,1922 @@
+package metadata
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	permission_types "github.com/bnb-chain/greenfield/x/permission/types"
+	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
+	"github.com/forbole/juno/v4/common"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	"gorm.io/gorm"
+
+	"github.com/bnb-chain/greenfield-storage-provider/modular/metadata/types"
+	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
+)
+
+func TestMetadataModular_GfSpVerifyPermission_VerifyBucketPermission_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetBucketByName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, bool) (*bsdb.Bucket, error) {
+			return &bsdb.Bucket{
+				ID:                         848,
+				Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				BucketName:                 "barry",
+				Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+				BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				SourceType:                 "SOURCE_TYPE_ORIGIN",
+				CreateAt:                   0,
+				CreateTime:                 0,
+				CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				GlobalVirtualGroupFamilyID: 4,
+				ChargedReadQuota:           0,
+				PaymentPriceTime:           0,
+				Removed:                    false,
+				Status:                     "",
+				DeleteAt:                   0,
+				DeleteReason:               "",
+				UpdateAt:                   0,
+				UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				UpdateTime:                 0,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionByResourceAndPrincipal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, string, common.Hash) (*bsdb.Permission, error) {
+			return &bsdb.Permission{
+				ID:              2,
+				PrincipalType:   2,
+				PrincipalValue:  "3",
+				ResourceType:    "RESOURCE_TYPE_BUCKET",
+				ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+				CreateTimestamp: time.Now().Unix(),
+				UpdateTimestamp: time.Now().Unix(),
+				ExpirationTime:  time.Now().Unix() + 100000,
+				Removed:         false,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetStatementsByPolicyID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Statement, error) {
+			return []*bsdb.Statement{
+				&bsdb.Statement{
+					ID:             1,
+					PolicyID:       common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+					Effect:         "EFFECT_ALLOW",
+					ActionValue:    64,
+					Resources:      nil,
+					ExpirationTime: 0,
+					LimitSize:      0,
+					Removed:        false,
+				},
+			}, nil
+		},
+	).Times(1)
+	effect, err := a.GfSpVerifyPermission(context.Background(), &storagetypes.QueryVerifyPermissionRequest{
+		Operator:   "0x11E0A11A7A01E2E757447B52FBD7152004AC699e",
+		BucketName: "barry",
+		ObjectName: "",
+		ActionType: 6,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "EFFECT_ALLOW", effect.Effect.String())
+}
+
+func TestMetadataModular_GfSpVerifyPermission_VerifyBucketPermission_Success2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetBucketByName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, bool) (*bsdb.Bucket, error) {
+			return &bsdb.Bucket{
+				ID:                         848,
+				Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				BucketName:                 "barry",
+				Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+				BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				SourceType:                 "SOURCE_TYPE_ORIGIN",
+				CreateAt:                   0,
+				CreateTime:                 0,
+				CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				GlobalVirtualGroupFamilyID: 4,
+				ChargedReadQuota:           0,
+				PaymentPriceTime:           0,
+				Removed:                    false,
+				Status:                     "",
+				DeleteAt:                   0,
+				DeleteReason:               "",
+				UpdateAt:                   0,
+				UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				UpdateTime:                 0,
+			}, nil
+		},
+	).Times(1)
+	effect, err := a.GfSpVerifyPermission(context.Background(), &storagetypes.QueryVerifyPermissionRequest{
+		Operator:   "0x11E0A11A7A01E2E757447B52FBD7152004AC699D",
+		BucketName: "barry",
+		ObjectName: "",
+		ActionType: 6,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "EFFECT_ALLOW", effect.Effect.String())
+}
+
+func TestMetadataModular_GfSpVerifyPermission_VerifyBucketPermission_Success3(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetBucketByName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, bool) (*bsdb.Bucket, error) {
+			return &bsdb.Bucket{
+				ID:                         848,
+				Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				BucketName:                 "barry",
+				Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+				BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				SourceType:                 "SOURCE_TYPE_ORIGIN",
+				CreateAt:                   0,
+				CreateTime:                 0,
+				CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				GlobalVirtualGroupFamilyID: 4,
+				ChargedReadQuota:           0,
+				PaymentPriceTime:           0,
+				Removed:                    false,
+				Status:                     "",
+				DeleteAt:                   0,
+				DeleteReason:               "",
+				UpdateAt:                   0,
+				UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				UpdateTime:                 0,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionByResourceAndPrincipal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, string, common.Hash) (*bsdb.Permission, error) {
+			return &bsdb.Permission{
+				ID:              2,
+				PrincipalType:   2,
+				PrincipalValue:  "3",
+				ResourceType:    "RESOURCE_TYPE_BUCKET",
+				ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+				CreateTimestamp: time.Now().Unix(),
+				UpdateTimestamp: time.Now().Unix(),
+				ExpirationTime:  time.Now().Unix() + 100000,
+				Removed:         false,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetStatementsByPolicyID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Statement, error) {
+			return nil, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionsByResourceAndPrincipleType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, common.Hash, bool) ([]*bsdb.Permission, error) {
+			return []*bsdb.Permission{
+				&bsdb.Permission{
+					ID:              2,
+					PrincipalType:   3,
+					PrincipalValue:  "3",
+					ResourceType:    "RESOURCE_TYPE_BUCKET",
+					ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+					PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+					CreateTimestamp: time.Now().Unix(),
+					UpdateTimestamp: time.Now().Unix(),
+					ExpirationTime:  time.Now().Unix() + 100000,
+					Removed:         false,
+				},
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetGroupsByGroupIDAndAccount(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, common.Address, bool) ([]*bsdb.Group, error) {
+			return []*bsdb.Group{
+				&bsdb.Group{
+					ID:             1,
+					Owner:          common.HexToAddress("0x84A0D38D64498414B14CD979159D57557345CD8B"),
+					GroupID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000003"),
+					GroupName:      "test",
+					SourceType:     "SOURCE_TYPE_ORIGIN",
+					Extra:          "",
+					AccountID:      common.HexToAddress("0x00000000000000000000000000000000000000000x0000000000000000000000000000000000000000"),
+					Operator:       common.HexToAddress("0x0000000000000000000000000000000000000000"),
+					ExpirationTime: 0,
+					CreateAt:       0,
+					CreateTime:     0,
+					UpdateAt:       0,
+					UpdateTime:     0,
+					Removed:        false,
+				},
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetStatementsByPolicyID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Statement, error) {
+			return []*bsdb.Statement{
+				&bsdb.Statement{
+					ID:             1,
+					PolicyID:       common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+					Effect:         "EFFECT_ALLOW",
+					ActionValue:    64,
+					Resources:      nil,
+					ExpirationTime: 0,
+					LimitSize:      0,
+					Removed:        false,
+				},
+			}, nil
+		},
+	).Times(1)
+	effect, err := a.GfSpVerifyPermission(context.Background(), &storagetypes.QueryVerifyPermissionRequest{
+		Operator:   "0x11E0A11A7A01E2E757447B52FBD7152004AC699e",
+		BucketName: "barry",
+		ObjectName: "",
+		ActionType: 6,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "EFFECT_ALLOW", effect.Effect.String())
+}
+
+func TestMetadataModular_GfSpVerifyPermission_VerifyBucketPermission_Success4(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetBucketByName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, bool) (*bsdb.Bucket, error) {
+			return &bsdb.Bucket{
+				ID:                         848,
+				Owner:                      common.HexToAddress("ABC"),
+				Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				BucketName:                 "barry",
+				Visibility:                 "VISIBILITY_TYPE_PUBLIC_READ",
+				BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				SourceType:                 "SOURCE_TYPE_ORIGIN",
+				CreateAt:                   0,
+				CreateTime:                 0,
+				CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				GlobalVirtualGroupFamilyID: 4,
+				ChargedReadQuota:           0,
+				PaymentPriceTime:           0,
+				Removed:                    false,
+				Status:                     "",
+				DeleteAt:                   0,
+				DeleteReason:               "",
+				UpdateAt:                   0,
+				UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				UpdateTime:                 0,
+			}, nil
+		},
+	).Times(1)
+	effect, err := a.GfSpVerifyPermission(context.Background(), &storagetypes.QueryVerifyPermissionRequest{
+		Operator:   "0x11E0A11A7A01E2E757447B52FBD7152004AC699e",
+		BucketName: "barry",
+		ObjectName: "",
+		ActionType: 6,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "EFFECT_ALLOW", effect.Effect.String())
+}
+
+func TestMetadataModular_GfSpVerifyPermission_VerifyObjectPermission_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetBucketByName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, bool) (*bsdb.Bucket, error) {
+			return &bsdb.Bucket{
+				ID:                         848,
+				Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				BucketName:                 "barry",
+				Visibility:                 "VISIBILITY_TYPE_PUBLIC_READ",
+				BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				SourceType:                 "SOURCE_TYPE_ORIGIN",
+				CreateAt:                   0,
+				CreateTime:                 0,
+				CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				GlobalVirtualGroupFamilyID: 4,
+				ChargedReadQuota:           0,
+				PaymentPriceTime:           0,
+				Removed:                    false,
+				Status:                     "",
+				DeleteAt:                   0,
+				DeleteReason:               "",
+				UpdateAt:                   0,
+				UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				UpdateTime:                 0,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetObjectByName(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, bool) (*bsdb.Object, error) {
+			return &bsdb.Object{
+				ID:                  1,
+				Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				LocalVirtualGroupId: 0,
+				BucketName:          "barry",
+				ObjectName:          "test",
+				ObjectID:            common.HexToHash("1"),
+				BucketID:            common.HexToHash("1"),
+				PayloadSize:         0,
+				Visibility:          "VISIBILITY_TYPE_INHERIT",
+				ContentType:         "",
+				CreateAt:            0,
+				CreateTime:          0,
+				ObjectStatus:        "",
+				RedundancyType:      "",
+				SourceType:          "",
+				Checksums:           nil,
+				LockedBalance:       common.HexToHash("1"),
+				Removed:             false,
+				UpdateTime:          0,
+				UpdateAt:            0,
+				DeleteAt:            0,
+				DeleteReason:        "",
+				CreateTxHash:        common.HexToHash("1"),
+				UpdateTxHash:        common.HexToHash("1"),
+				SealTxHash:          common.HexToHash("1"),
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionByResourceAndPrincipal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, string, common.Hash) (*bsdb.Permission, error) {
+			return &bsdb.Permission{
+				ID:              2,
+				PrincipalType:   2,
+				PrincipalValue:  "3",
+				ResourceType:    "RESOURCE_TYPE_BUCKET",
+				ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+				CreateTimestamp: time.Now().Unix(),
+				UpdateTimestamp: time.Now().Unix(),
+				ExpirationTime:  time.Now().Unix() + 100000,
+				Removed:         false,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetStatementsByPolicyID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Statement, error) {
+			return nil, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionsByResourceAndPrincipleType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, common.Hash, bool) ([]*bsdb.Permission, error) {
+			return []*bsdb.Permission{
+				&bsdb.Permission{
+					ID:              2,
+					PrincipalType:   3,
+					PrincipalValue:  "3",
+					ResourceType:    "RESOURCE_TYPE_BUCKET",
+					ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+					PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+					CreateTimestamp: time.Now().Unix(),
+					UpdateTimestamp: time.Now().Unix(),
+					ExpirationTime:  time.Now().Unix() + 100000,
+					Removed:         false,
+				},
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetGroupsByGroupIDAndAccount(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, common.Address, bool) ([]*bsdb.Group, error) {
+			return []*bsdb.Group{
+				&bsdb.Group{
+					ID:             1,
+					Owner:          common.HexToAddress("0x84A0D38D64498414B14CD979159D57557345CD8B"),
+					GroupID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000003"),
+					GroupName:      "test",
+					SourceType:     "SOURCE_TYPE_ORIGIN",
+					Extra:          "",
+					AccountID:      common.HexToAddress("0x00000000000000000000000000000000000000000x0000000000000000000000000000000000000000"),
+					Operator:       common.HexToAddress("0x0000000000000000000000000000000000000000"),
+					ExpirationTime: 0,
+					CreateAt:       0,
+					CreateTime:     0,
+					UpdateAt:       0,
+					UpdateTime:     0,
+					Removed:        false,
+				},
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetStatementsByPolicyID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Statement, error) {
+			return []*bsdb.Statement{
+				&bsdb.Statement{
+					ID:             1,
+					PolicyID:       common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+					Effect:         "EFFECT_ALLOW",
+					ActionValue:    512,
+					Resources:      []string{"grn"},
+					ExpirationTime: 0,
+					LimitSize:      0,
+					Removed:        false,
+				},
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionByResourceAndPrincipal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, string, common.Hash) (*bsdb.Permission, error) {
+			return &bsdb.Permission{
+				ID:              2,
+				PrincipalType:   2,
+				PrincipalValue:  "3",
+				ResourceType:    "RESOURCE_TYPE_BUCKET",
+				ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+				CreateTimestamp: time.Now().Unix(),
+				UpdateTimestamp: time.Now().Unix(),
+				ExpirationTime:  time.Now().Unix() + 100000,
+				Removed:         false,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetStatementsByPolicyID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Statement, error) {
+			return nil, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionsByResourceAndPrincipleType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, common.Hash, bool) ([]*bsdb.Permission, error) {
+			return []*bsdb.Permission{
+				&bsdb.Permission{
+					ID:              2,
+					PrincipalType:   3,
+					PrincipalValue:  "3",
+					ResourceType:    "RESOURCE_TYPE_BUCKET",
+					ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+					PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+					CreateTimestamp: time.Now().Unix(),
+					UpdateTimestamp: time.Now().Unix(),
+					ExpirationTime:  time.Now().Unix() + 100000,
+					Removed:         false,
+				},
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetGroupsByGroupIDAndAccount(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, common.Address, bool) ([]*bsdb.Group, error) {
+			return []*bsdb.Group{
+				&bsdb.Group{
+					ID:             1,
+					Owner:          common.HexToAddress("0x84A0D38D64498414B14CD979159D57557345CD8B"),
+					GroupID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000003"),
+					GroupName:      "test",
+					SourceType:     "SOURCE_TYPE_ORIGIN",
+					Extra:          "",
+					AccountID:      common.HexToAddress("0x00000000000000000000000000000000000000000x0000000000000000000000000000000000000000"),
+					Operator:       common.HexToAddress("0x0000000000000000000000000000000000000000"),
+					ExpirationTime: 0,
+					CreateAt:       0,
+					CreateTime:     0,
+					UpdateAt:       0,
+					UpdateTime:     0,
+					Removed:        false,
+				},
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetStatementsByPolicyID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Statement, error) {
+			return []*bsdb.Statement{
+				&bsdb.Statement{
+					ID:             1,
+					PolicyID:       common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+					Effect:         "EFFECT_ALLOW",
+					ActionValue:    512,
+					Resources:      []string{"grn"},
+					ExpirationTime: 0,
+					LimitSize:      0,
+					Removed:        false,
+				},
+			}, nil
+		},
+	).Times(1)
+	effect, err := a.GfSpVerifyPermission(context.Background(), &storagetypes.QueryVerifyPermissionRequest{
+		Operator:   "0x11E0A11A7A01E2E757447B52FBD7152004AC699e",
+		BucketName: "barry",
+		ObjectName: "test",
+		ActionType: 9,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "EFFECT_ALLOW", effect.Effect.String())
+}
+
+func TestMetadataModular_GfSpVerifyPermission_VerifyBucketPermission_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetBucketByName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, bool) (*bsdb.Bucket, error) {
+			return &bsdb.Bucket{
+				ID:                         848,
+				Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				BucketName:                 "barry",
+				Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+				BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				SourceType:                 "SOURCE_TYPE_ORIGIN",
+				CreateAt:                   0,
+				CreateTime:                 0,
+				CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				GlobalVirtualGroupFamilyID: 4,
+				ChargedReadQuota:           0,
+				PaymentPriceTime:           0,
+				Removed:                    false,
+				Status:                     "",
+				DeleteAt:                   0,
+				DeleteReason:               "",
+				UpdateAt:                   0,
+				UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				UpdateTime:                 0,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionByResourceAndPrincipal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, string, common.Hash) (*bsdb.Permission, error) {
+			return &bsdb.Permission{
+				ID:              2,
+				PrincipalType:   2,
+				PrincipalValue:  "3",
+				ResourceType:    "RESOURCE_TYPE_BUCKET",
+				ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+				CreateTimestamp: time.Now().Unix(),
+				UpdateTimestamp: time.Now().Unix(),
+				ExpirationTime:  time.Now().Unix() + 100000,
+				Removed:         false,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetStatementsByPolicyID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Statement, error) {
+			return nil, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionsByResourceAndPrincipleType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, common.Hash, bool) ([]*bsdb.Permission, error) {
+			return []*bsdb.Permission{
+				&bsdb.Permission{
+					ID:              2,
+					PrincipalType:   3,
+					PrincipalValue:  "3",
+					ResourceType:    "RESOURCE_TYPE_BUCKET",
+					ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+					PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+					CreateTimestamp: time.Now().Unix(),
+					UpdateTimestamp: time.Now().Unix(),
+					ExpirationTime:  time.Now().Unix() + 100000,
+					Removed:         false,
+				},
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetGroupsByGroupIDAndAccount(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, common.Address, bool) ([]*bsdb.Group, error) {
+			return []*bsdb.Group{
+				&bsdb.Group{
+					ID:             1,
+					Owner:          common.HexToAddress("0x84A0D38D64498414B14CD979159D57557345CD8B"),
+					GroupID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000003"),
+					GroupName:      "test",
+					SourceType:     "SOURCE_TYPE_ORIGIN",
+					Extra:          "",
+					AccountID:      common.HexToAddress("0x00000000000000000000000000000000000000000x0000000000000000000000000000000000000000"),
+					Operator:       common.HexToAddress("0x0000000000000000000000000000000000000000"),
+					ExpirationTime: 0,
+					CreateAt:       0,
+					CreateTime:     0,
+					UpdateAt:       0,
+					UpdateTime:     0,
+					Removed:        false,
+				},
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetStatementsByPolicyID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Statement, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpVerifyPermission(context.Background(), &storagetypes.QueryVerifyPermissionRequest{
+		Operator:   "0x11E0A11A7A01E2E757447B52FBD7152004AC699e",
+		BucketName: "barry",
+		ObjectName: "",
+		ActionType: 6,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpVerifyPermission_VerifyBucketPermission_Failed2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetBucketByName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, bool) (*bsdb.Bucket, error) {
+			return &bsdb.Bucket{
+				ID:                         848,
+				Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				BucketName:                 "barry",
+				Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+				BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				SourceType:                 "SOURCE_TYPE_ORIGIN",
+				CreateAt:                   0,
+				CreateTime:                 0,
+				CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				GlobalVirtualGroupFamilyID: 4,
+				ChargedReadQuota:           0,
+				PaymentPriceTime:           0,
+				Removed:                    false,
+				Status:                     "",
+				DeleteAt:                   0,
+				DeleteReason:               "",
+				UpdateAt:                   0,
+				UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				UpdateTime:                 0,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionByResourceAndPrincipal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, string, common.Hash) (*bsdb.Permission, error) {
+			return &bsdb.Permission{
+				ID:              2,
+				PrincipalType:   2,
+				PrincipalValue:  "3",
+				ResourceType:    "RESOURCE_TYPE_BUCKET",
+				ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+				CreateTimestamp: time.Now().Unix(),
+				UpdateTimestamp: time.Now().Unix(),
+				ExpirationTime:  time.Now().Unix() + 100000,
+				Removed:         false,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetStatementsByPolicyID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Statement, error) {
+			return nil, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionsByResourceAndPrincipleType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, common.Hash, bool) ([]*bsdb.Permission, error) {
+			return []*bsdb.Permission{
+				&bsdb.Permission{
+					ID:              2,
+					PrincipalType:   3,
+					PrincipalValue:  "3",
+					ResourceType:    "RESOURCE_TYPE_BUCKET",
+					ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+					PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+					CreateTimestamp: time.Now().Unix(),
+					UpdateTimestamp: time.Now().Unix(),
+					ExpirationTime:  time.Now().Unix() + 100000,
+					Removed:         false,
+				},
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetGroupsByGroupIDAndAccount(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, common.Address, bool) ([]*bsdb.Group, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpVerifyPermission(context.Background(), &storagetypes.QueryVerifyPermissionRequest{
+		Operator:   "0x11E0A11A7A01E2E757447B52FBD7152004AC699e",
+		BucketName: "barry",
+		ObjectName: "",
+		ActionType: 6,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpVerifyPermission_VerifyBucketPermission_Failed3(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetBucketByName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, bool) (*bsdb.Bucket, error) {
+			return &bsdb.Bucket{
+				ID:                         848,
+				Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				BucketName:                 "barry",
+				Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+				BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				SourceType:                 "SOURCE_TYPE_ORIGIN",
+				CreateAt:                   0,
+				CreateTime:                 0,
+				CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				GlobalVirtualGroupFamilyID: 4,
+				ChargedReadQuota:           0,
+				PaymentPriceTime:           0,
+				Removed:                    false,
+				Status:                     "",
+				DeleteAt:                   0,
+				DeleteReason:               "",
+				UpdateAt:                   0,
+				UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				UpdateTime:                 0,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionByResourceAndPrincipal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, string, common.Hash) (*bsdb.Permission, error) {
+			return &bsdb.Permission{
+				ID:              2,
+				PrincipalType:   2,
+				PrincipalValue:  "3",
+				ResourceType:    "RESOURCE_TYPE_BUCKET",
+				ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+				CreateTimestamp: time.Now().Unix(),
+				UpdateTimestamp: time.Now().Unix(),
+				ExpirationTime:  time.Now().Unix() + 100000,
+				Removed:         false,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetStatementsByPolicyID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Statement, error) {
+			return nil, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionsByResourceAndPrincipleType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, common.Hash, bool) ([]*bsdb.Permission, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpVerifyPermission(context.Background(), &storagetypes.QueryVerifyPermissionRequest{
+		Operator:   "0x11E0A11A7A01E2E757447B52FBD7152004AC699e",
+		BucketName: "barry",
+		ObjectName: "",
+		ActionType: 6,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpVerifyPermission_VerifyBucketPermission_Failed4(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetBucketByName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, bool) (*bsdb.Bucket, error) {
+			return &bsdb.Bucket{
+				ID:                         848,
+				Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				BucketName:                 "barry",
+				Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+				BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				SourceType:                 "SOURCE_TYPE_ORIGIN",
+				CreateAt:                   0,
+				CreateTime:                 0,
+				CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				GlobalVirtualGroupFamilyID: 4,
+				ChargedReadQuota:           0,
+				PaymentPriceTime:           0,
+				Removed:                    false,
+				Status:                     "",
+				DeleteAt:                   0,
+				DeleteReason:               "",
+				UpdateAt:                   0,
+				UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				UpdateTime:                 0,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionByResourceAndPrincipal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, string, common.Hash) (*bsdb.Permission, error) {
+			return &bsdb.Permission{
+				ID:              2,
+				PrincipalType:   2,
+				PrincipalValue:  "3",
+				ResourceType:    "RESOURCE_TYPE_BUCKET",
+				ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+				CreateTimestamp: time.Now().Unix(),
+				UpdateTimestamp: time.Now().Unix(),
+				ExpirationTime:  time.Now().Unix() + 100000,
+				Removed:         false,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetStatementsByPolicyID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Statement, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpVerifyPermission(context.Background(), &storagetypes.QueryVerifyPermissionRequest{
+		Operator:   "0x11E0A11A7A01E2E757447B52FBD7152004AC699e",
+		BucketName: "barry",
+		ObjectName: "",
+		ActionType: 6,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpVerifyPermission_VerifyBucketPermission_Failed5(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetBucketByName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, bool) (*bsdb.Bucket, error) {
+			return &bsdb.Bucket{
+				ID:                         848,
+				Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				BucketName:                 "barry",
+				Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+				BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				SourceType:                 "SOURCE_TYPE_ORIGIN",
+				CreateAt:                   0,
+				CreateTime:                 0,
+				CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				GlobalVirtualGroupFamilyID: 4,
+				ChargedReadQuota:           0,
+				PaymentPriceTime:           0,
+				Removed:                    false,
+				Status:                     "",
+				DeleteAt:                   0,
+				DeleteReason:               "",
+				UpdateAt:                   0,
+				UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				UpdateTime:                 0,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionByResourceAndPrincipal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, string, common.Hash) (*bsdb.Permission, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpVerifyPermission(context.Background(), &storagetypes.QueryVerifyPermissionRequest{
+		Operator:   "0x11E0A11A7A01E2E757447B52FBD7152004AC699e",
+		BucketName: "barry",
+		ObjectName: "",
+		ActionType: 6,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpVerifyPermission_VerifyBucketPermission_Failed6(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetBucketByName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, bool) (*bsdb.Bucket, error) {
+			return &bsdb.Bucket{
+				ID:                         848,
+				Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				BucketName:                 "barry",
+				Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+				BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				SourceType:                 "SOURCE_TYPE_ORIGIN",
+				CreateAt:                   0,
+				CreateTime:                 0,
+				CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				GlobalVirtualGroupFamilyID: 4,
+				ChargedReadQuota:           0,
+				PaymentPriceTime:           0,
+				Removed:                    false,
+				Status:                     "",
+				DeleteAt:                   0,
+				DeleteReason:               "",
+				UpdateAt:                   0,
+				UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				UpdateTime:                 0,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionByResourceAndPrincipal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, string, common.Hash) (*bsdb.Permission, error) {
+			return nil, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionsByResourceAndPrincipleType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, common.Hash, bool) ([]*bsdb.Permission, error) {
+			return nil, nil
+		},
+	).Times(1)
+	m.EXPECT().GetStatementsByPolicyID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Statement, error) {
+			return nil, nil
+		},
+	).Times(1)
+	effect, err := a.GfSpVerifyPermission(context.Background(), &storagetypes.QueryVerifyPermissionRequest{
+		Operator:   "0x11E0A11A7A01E2E757447B52FBD7152004AC699e",
+		BucketName: "barry",
+		ObjectName: "",
+		ActionType: 6,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "EFFECT_DENY", effect.Effect.String())
+}
+
+func TestMetadataModular_GfSpVerifyPermission_VerifyObjectPermission_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetBucketByName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, bool) (*bsdb.Bucket, error) {
+			return &bsdb.Bucket{
+				ID:                         848,
+				Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				BucketName:                 "barry",
+				Visibility:                 "VISIBILITY_TYPE_PUBLIC_READ",
+				BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				SourceType:                 "SOURCE_TYPE_ORIGIN",
+				CreateAt:                   0,
+				CreateTime:                 0,
+				CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				GlobalVirtualGroupFamilyID: 4,
+				ChargedReadQuota:           0,
+				PaymentPriceTime:           0,
+				Removed:                    false,
+				Status:                     "",
+				DeleteAt:                   0,
+				DeleteReason:               "",
+				UpdateAt:                   0,
+				UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				UpdateTime:                 0,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetObjectByName(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, bool) (*bsdb.Object, error) {
+			return nil, gorm.ErrRecordNotFound
+		},
+	).Times(1)
+	_, err := a.GfSpVerifyPermission(context.Background(), &storagetypes.QueryVerifyPermissionRequest{
+		Operator:   "0x11E0A11A7A01E2E757447B52FBD7152004AC699e",
+		BucketName: "barry",
+		ObjectName: "test",
+		ActionType: 9,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpVerifyPermission_VerifyObjectPermission_Failed2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetBucketByName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, bool) (*bsdb.Bucket, error) {
+			return nil, nil
+		},
+	).Times(1)
+	_, err := a.GfSpVerifyPermission(context.Background(), &storagetypes.QueryVerifyPermissionRequest{
+		Operator:   "0x11E0A11A7A01E2E757447B52FBD7152004AC699e",
+		BucketName: "barry",
+		ObjectName: "test",
+		ActionType: 9,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpVerifyPermission_VerifyObjectPermission_Failed3(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetBucketByName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, bool) (*bsdb.Bucket, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpVerifyPermission(context.Background(), &storagetypes.QueryVerifyPermissionRequest{
+		Operator:   "0x11E0A11A7A01E2E757447B52FBD7152004AC699e",
+		BucketName: "barry",
+		ObjectName: "test",
+		ActionType: 9,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpVerifyPermission_VerifyObjectPermission_Failed4(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetBucketByName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, bool) (*bsdb.Bucket, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpVerifyPermission(context.Background(), &storagetypes.QueryVerifyPermissionRequest{
+		Operator:   "0x11E0A11A7A01E2E757447B52FBD7152004AC699e",
+		BucketName: "barry",
+		ObjectName: "test",
+		ActionType: 9,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpVerifyPermission_VerifyObjectPermission_Failed5(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	_, err := a.GfSpVerifyPermission(context.Background(), nil)
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpVerifyPermission_VerifyObjectPermission_Failed6(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	_, err := a.GfSpVerifyPermission(context.Background(), &storagetypes.QueryVerifyPermissionRequest{
+		Operator:   "111",
+		BucketName: "barry",
+		ObjectName: "test",
+		ActionType: 9,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpVerifyPermission_VerifyObjectPermission_Failed7(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	_, err := a.GfSpVerifyPermission(context.Background(), &storagetypes.QueryVerifyPermissionRequest{
+		Operator:   "0x11E0A11A7A01E2E757447B52FBD7152004AC699e",
+		BucketName: "",
+		ObjectName: "test",
+		ActionType: 9,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModularGfSpGfSpVerifyPermissionByID_VerifyObjectPermission_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetObjectByID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(int64, bool) (*bsdb.Object, error) {
+			return &bsdb.Object{
+				ID:                  1,
+				Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				LocalVirtualGroupId: 0,
+				BucketName:          "barry",
+				ObjectName:          "test",
+				ObjectID:            common.HexToHash("1"),
+				BucketID:            common.HexToHash("1"),
+				PayloadSize:         0,
+				Visibility:          "VISIBILITY_TYPE_INHERIT",
+				ContentType:         "",
+				CreateAt:            0,
+				CreateTime:          0,
+				ObjectStatus:        "",
+				RedundancyType:      "",
+				SourceType:          "",
+				Checksums:           nil,
+				LockedBalance:       common.HexToHash("1"),
+				Removed:             false,
+				UpdateTime:          0,
+				UpdateAt:            0,
+				DeleteAt:            0,
+				DeleteReason:        "",
+				CreateTxHash:        common.HexToHash("1"),
+				UpdateTxHash:        common.HexToHash("1"),
+				SealTxHash:          common.HexToHash("1"),
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetBucketByID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(int64, bool) (*bsdb.Bucket, error) {
+			return &bsdb.Bucket{
+				ID:                         848,
+				Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				BucketName:                 "barry",
+				Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+				BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				SourceType:                 "SOURCE_TYPE_ORIGIN",
+				CreateAt:                   0,
+				CreateTime:                 0,
+				CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				GlobalVirtualGroupFamilyID: 4,
+				ChargedReadQuota:           0,
+				PaymentPriceTime:           0,
+				Removed:                    false,
+				Status:                     "",
+				DeleteAt:                   0,
+				DeleteReason:               "",
+				UpdateAt:                   0,
+				UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				UpdateTime:                 0,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionByResourceAndPrincipal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, string, common.Hash) (*bsdb.Permission, error) {
+			return &bsdb.Permission{
+				ID:              2,
+				PrincipalType:   2,
+				PrincipalValue:  "3",
+				ResourceType:    "RESOURCE_TYPE_BUCKET",
+				ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+				CreateTimestamp: time.Now().Unix(),
+				UpdateTimestamp: time.Now().Unix(),
+				ExpirationTime:  time.Now().Unix() + 100000,
+				Removed:         false,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetStatementsByPolicyID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Statement, error) {
+			return nil, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionsByResourceAndPrincipleType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, common.Hash, bool) ([]*bsdb.Permission, error) {
+			return []*bsdb.Permission{
+				&bsdb.Permission{
+					ID:              2,
+					PrincipalType:   3,
+					PrincipalValue:  "3",
+					ResourceType:    "RESOURCE_TYPE_BUCKET",
+					ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+					PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+					CreateTimestamp: time.Now().Unix(),
+					UpdateTimestamp: time.Now().Unix(),
+					ExpirationTime:  time.Now().Unix() + 100000,
+					Removed:         false,
+				},
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetGroupsByGroupIDAndAccount(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, common.Address, bool) ([]*bsdb.Group, error) {
+			return []*bsdb.Group{
+				&bsdb.Group{
+					ID:             1,
+					Owner:          common.HexToAddress("0x84A0D38D64498414B14CD979159D57557345CD8B"),
+					GroupID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000003"),
+					GroupName:      "test",
+					SourceType:     "SOURCE_TYPE_ORIGIN",
+					Extra:          "",
+					AccountID:      common.HexToAddress("0x00000000000000000000000000000000000000000x0000000000000000000000000000000000000000"),
+					Operator:       common.HexToAddress("0x0000000000000000000000000000000000000000"),
+					ExpirationTime: 0,
+					CreateAt:       0,
+					CreateTime:     0,
+					UpdateAt:       0,
+					UpdateTime:     0,
+					Removed:        false,
+				},
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetStatementsByPolicyID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Statement, error) {
+			return []*bsdb.Statement{
+				&bsdb.Statement{
+					ID:             1,
+					PolicyID:       common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+					Effect:         "EFFECT_ALLOW",
+					ActionValue:    512,
+					Resources:      []string{"grn"},
+					ExpirationTime: 0,
+					LimitSize:      0,
+					Removed:        false,
+				},
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionByResourceAndPrincipal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, string, common.Hash) (*bsdb.Permission, error) {
+			return &bsdb.Permission{
+				ID:              2,
+				PrincipalType:   2,
+				PrincipalValue:  "3",
+				ResourceType:    "RESOURCE_TYPE_BUCKET",
+				ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+				CreateTimestamp: time.Now().Unix(),
+				UpdateTimestamp: time.Now().Unix(),
+				ExpirationTime:  time.Now().Unix() + 100000,
+				Removed:         false,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetStatementsByPolicyID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Statement, error) {
+			return nil, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionsByResourceAndPrincipleType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, common.Hash, bool) ([]*bsdb.Permission, error) {
+			return []*bsdb.Permission{
+				&bsdb.Permission{
+					ID:              2,
+					PrincipalType:   3,
+					PrincipalValue:  "3",
+					ResourceType:    "RESOURCE_TYPE_BUCKET",
+					ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+					PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+					CreateTimestamp: time.Now().Unix(),
+					UpdateTimestamp: time.Now().Unix(),
+					ExpirationTime:  time.Now().Unix() + 100000,
+					Removed:         false,
+				},
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetGroupsByGroupIDAndAccount(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, common.Address, bool) ([]*bsdb.Group, error) {
+			return []*bsdb.Group{
+				&bsdb.Group{
+					ID:             1,
+					Owner:          common.HexToAddress("0x84A0D38D64498414B14CD979159D57557345CD8B"),
+					GroupID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000003"),
+					GroupName:      "test",
+					SourceType:     "SOURCE_TYPE_ORIGIN",
+					Extra:          "",
+					AccountID:      common.HexToAddress("0x00000000000000000000000000000000000000000x0000000000000000000000000000000000000000"),
+					Operator:       common.HexToAddress("0x0000000000000000000000000000000000000000"),
+					ExpirationTime: 0,
+					CreateAt:       0,
+					CreateTime:     0,
+					UpdateAt:       0,
+					UpdateTime:     0,
+					Removed:        false,
+				},
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetStatementsByPolicyID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Statement, error) {
+			return []*bsdb.Statement{
+				&bsdb.Statement{
+					ID:             1,
+					PolicyID:       common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+					Effect:         "EFFECT_ALLOW",
+					ActionValue:    512,
+					Resources:      []string{"grn"},
+					ExpirationTime: 0,
+					LimitSize:      0,
+					Removed:        false,
+				},
+			}, nil
+		},
+	).Times(1)
+	effect, err := a.GfSpVerifyPermissionByID(context.Background(), &types.GfSpVerifyPermissionByIDRequest{
+		Operator:     "0x11E0A11A7A01E2E757447B52FBD7152004AC699e",
+		ResourceType: 2,
+		ResourceId:   1,
+		ActionType:   9,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "EFFECT_ALLOW", effect.Effect.String())
+}
+
+func TestMetadataModularGfSpGfSpVerifyPermissionByID_VerifyBucket_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetBucketByID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(int64, bool) (*bsdb.Bucket, error) {
+			return &bsdb.Bucket{
+				ID:                         848,
+				Owner:                      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				BucketName:                 "barry",
+				Visibility:                 "VISIBILITY_TYPE_PRIVATE",
+				BucketID:                   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				SourceType:                 "SOURCE_TYPE_ORIGIN",
+				CreateAt:                   0,
+				CreateTime:                 0,
+				CreateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				PaymentAddress:             common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				GlobalVirtualGroupFamilyID: 4,
+				ChargedReadQuota:           0,
+				PaymentPriceTime:           0,
+				Removed:                    false,
+				Status:                     "",
+				DeleteAt:                   0,
+				DeleteReason:               "",
+				UpdateAt:                   0,
+				UpdateTxHash:               common.HexToHash("0x0F508E101FF83B79DF357212029B05D1FCC585B50D479FB7E68D6E1A68E8BDD4"),
+				UpdateTime:                 0,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionByResourceAndPrincipal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, string, common.Hash) (*bsdb.Permission, error) {
+			return &bsdb.Permission{
+				ID:              2,
+				PrincipalType:   2,
+				PrincipalValue:  "3",
+				ResourceType:    "RESOURCE_TYPE_BUCKET",
+				ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+				CreateTimestamp: time.Now().Unix(),
+				UpdateTimestamp: time.Now().Unix(),
+				ExpirationTime:  time.Now().Unix() + 100000,
+				Removed:         false,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetStatementsByPolicyID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Statement, error) {
+			return nil, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionsByResourceAndPrincipleType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, common.Hash, bool) ([]*bsdb.Permission, error) {
+			return []*bsdb.Permission{
+				&bsdb.Permission{
+					ID:              2,
+					PrincipalType:   3,
+					PrincipalValue:  "3",
+					ResourceType:    "RESOURCE_TYPE_BUCKET",
+					ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+					PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+					CreateTimestamp: time.Now().Unix(),
+					UpdateTimestamp: time.Now().Unix(),
+					ExpirationTime:  time.Now().Unix() + 100000,
+					Removed:         false,
+				},
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetGroupsByGroupIDAndAccount(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, common.Address, bool) ([]*bsdb.Group, error) {
+			return []*bsdb.Group{
+				&bsdb.Group{
+					ID:             1,
+					Owner:          common.HexToAddress("0x84A0D38D64498414B14CD979159D57557345CD8B"),
+					GroupID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000003"),
+					GroupName:      "test",
+					SourceType:     "SOURCE_TYPE_ORIGIN",
+					Extra:          "",
+					AccountID:      common.HexToAddress("0x00000000000000000000000000000000000000000x0000000000000000000000000000000000000000"),
+					Operator:       common.HexToAddress("0x0000000000000000000000000000000000000000"),
+					ExpirationTime: 0,
+					CreateAt:       0,
+					CreateTime:     0,
+					UpdateAt:       0,
+					UpdateTime:     0,
+					Removed:        false,
+				},
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetStatementsByPolicyID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Statement, error) {
+			return []*bsdb.Statement{
+				&bsdb.Statement{
+					ID:             1,
+					PolicyID:       common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+					Effect:         "EFFECT_ALLOW",
+					ActionValue:    512,
+					Resources:      []string{"grn"},
+					ExpirationTime: 0,
+					LimitSize:      0,
+					Removed:        false,
+				},
+			}, nil
+		},
+	).Times(1)
+	effect, err := a.GfSpVerifyPermissionByID(context.Background(), &types.GfSpVerifyPermissionByIDRequest{
+		Operator:     "0x11E0A11A7A01E2E757447B52FBD7152004AC699e",
+		ResourceType: 1,
+		ResourceId:   1,
+		ActionType:   9,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "EFFECT_ALLOW", effect.Effect.String())
+}
+
+func TestMetadataModularGfSpGfSpVerifyPermissionByID_VerifyGroup_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetGroupByID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(int64, bool) (*bsdb.Group, error) {
+			return &bsdb.Group{
+				ID:             1,
+				Owner:          common.HexToAddress("0x84A0D38D64498414B14CD979159D57557345CD8B"),
+				GroupID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				GroupName:      "test",
+				SourceType:     "SOURCE_TYPE_ORIGIN",
+				Extra:          "",
+				AccountID:      common.HexToAddress("0x00000000000000000000000000000000000000000x0000000000000000000000000000000000000000"),
+				Operator:       common.HexToAddress("0x0000000000000000000000000000000000000000"),
+				ExpirationTime: 0,
+				CreateAt:       0,
+				CreateTime:     0,
+				UpdateAt:       0,
+				UpdateTime:     0,
+				Removed:        false,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionByResourceAndPrincipal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, string, common.Hash) (*bsdb.Permission, error) {
+			return &bsdb.Permission{
+				ID:              2,
+				PrincipalType:   2,
+				PrincipalValue:  "3",
+				ResourceType:    "RESOURCE_TYPE_BUCKET",
+				ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+				CreateTimestamp: time.Now().Unix(),
+				UpdateTimestamp: time.Now().Unix(),
+				ExpirationTime:  time.Now().Unix() + 100000,
+				Removed:         false,
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetStatementsByPolicyID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Statement, error) {
+			return nil, nil
+		},
+	).Times(1)
+	m.EXPECT().GetPermissionsByResourceAndPrincipleType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, common.Hash, bool) ([]*bsdb.Permission, error) {
+			return []*bsdb.Permission{
+				&bsdb.Permission{
+					ID:              2,
+					PrincipalType:   3,
+					PrincipalValue:  "3",
+					ResourceType:    "RESOURCE_TYPE_BUCKET",
+					ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+					PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+					CreateTimestamp: time.Now().Unix(),
+					UpdateTimestamp: time.Now().Unix(),
+					ExpirationTime:  time.Now().Unix() + 100000,
+					Removed:         false,
+				},
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetGroupsByGroupIDAndAccount(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, common.Address, bool) ([]*bsdb.Group, error) {
+			return []*bsdb.Group{
+				&bsdb.Group{
+					ID:             1,
+					Owner:          common.HexToAddress("0x84A0D38D64498414B14CD979159D57557345CD8B"),
+					GroupID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000003"),
+					GroupName:      "test",
+					SourceType:     "SOURCE_TYPE_ORIGIN",
+					Extra:          "",
+					AccountID:      common.HexToAddress("0x00000000000000000000000000000000000000000x0000000000000000000000000000000000000000"),
+					Operator:       common.HexToAddress("0x0000000000000000000000000000000000000000"),
+					ExpirationTime: 0,
+					CreateAt:       0,
+					CreateTime:     0,
+					UpdateAt:       0,
+					UpdateTime:     0,
+					Removed:        false,
+				},
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().GetStatementsByPolicyID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func([]common.Hash, bool) ([]*bsdb.Statement, error) {
+			return []*bsdb.Statement{
+				&bsdb.Statement{
+					ID:             1,
+					PolicyID:       common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+					Effect:         "EFFECT_ALLOW",
+					ActionValue:    512,
+					Resources:      []string{"grn"},
+					ExpirationTime: 0,
+					LimitSize:      0,
+					Removed:        false,
+				},
+			}, nil
+		},
+	).Times(1)
+	effect, err := a.GfSpVerifyPermissionByID(context.Background(), &types.GfSpVerifyPermissionByIDRequest{
+		Operator:     "0x11E0A11A7A01E2E757447B52FBD7152004AC699e",
+		ResourceType: 3,
+		ResourceId:   1,
+		ActionType:   9,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "EFFECT_ALLOW", effect.Effect.String())
+}
+
+func TestMetadataModularGfSpListObjectPolicies_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetObjectByName(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, bool) (*bsdb.Object, error) {
+			return &bsdb.Object{
+				ID:                  1,
+				Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				LocalVirtualGroupId: 0,
+				BucketName:          "barry",
+				ObjectName:          "1111",
+				ObjectID:            common.HexToHash("1"),
+				BucketID:            common.HexToHash("1"),
+				PayloadSize:         0,
+				Visibility:          "",
+				ContentType:         "",
+				CreateAt:            0,
+				CreateTime:          0,
+				ObjectStatus:        "",
+				RedundancyType:      "",
+				SourceType:          "",
+				Checksums:           nil,
+				LockedBalance:       common.HexToHash("1"),
+				Removed:             false,
+				UpdateTime:          0,
+				UpdateAt:            0,
+				DeleteAt:            0,
+				DeleteReason:        "",
+				CreateTxHash:        common.HexToHash("1"),
+				UpdateTxHash:        common.HexToHash("1"),
+				SealTxHash:          common.HexToHash("1"),
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().ListObjectPolicies(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, permission_types.ActionType, common.Hash, int) ([]*bsdb.Permission, error) {
+			return []*bsdb.Permission{
+				&bsdb.Permission{
+					ID:              2,
+					PrincipalType:   2,
+					PrincipalValue:  "3",
+					ResourceType:    "RESOURCE_TYPE_OBJECT",
+					ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+					PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+					CreateTimestamp: time.Now().Unix(),
+					UpdateTimestamp: time.Now().Unix(),
+					ExpirationTime:  time.Now().Unix() + 100000,
+					Removed:         false,
+				},
+			}, nil
+		},
+	).Times(1)
+	policies, err := a.GfSpListObjectPolicies(context.Background(), &types.GfSpListObjectPoliciesRequest{
+		ObjectName: "1111",
+		BucketName: "barry",
+		ActionType: 6,
+		Limit:      1111,
+		StartAfter: 0,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "RESOURCE_TYPE_OBJECT", policies.Policies[0].ResourceType.String())
+}
+
+func TestMetadataModularGfSpListObjectPolicies_Success2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetObjectByName(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, bool) (*bsdb.Object, error) {
+			return &bsdb.Object{
+				ID:                  1,
+				Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				LocalVirtualGroupId: 0,
+				BucketName:          "barry",
+				ObjectName:          "1111",
+				ObjectID:            common.HexToHash("1"),
+				BucketID:            common.HexToHash("1"),
+				PayloadSize:         0,
+				Visibility:          "",
+				ContentType:         "",
+				CreateAt:            0,
+				CreateTime:          0,
+				ObjectStatus:        "",
+				RedundancyType:      "",
+				SourceType:          "",
+				Checksums:           nil,
+				LockedBalance:       common.HexToHash("1"),
+				Removed:             false,
+				UpdateTime:          0,
+				UpdateAt:            0,
+				DeleteAt:            0,
+				DeleteReason:        "",
+				CreateTxHash:        common.HexToHash("1"),
+				UpdateTxHash:        common.HexToHash("1"),
+				SealTxHash:          common.HexToHash("1"),
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().ListObjectPolicies(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, permission_types.ActionType, common.Hash, int) ([]*bsdb.Permission, error) {
+			return []*bsdb.Permission{
+				&bsdb.Permission{
+					ID:              2,
+					PrincipalType:   2,
+					PrincipalValue:  "3",
+					ResourceType:    "RESOURCE_TYPE_OBJECT",
+					ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+					PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+					CreateTimestamp: time.Now().Unix(),
+					UpdateTimestamp: time.Now().Unix(),
+					ExpirationTime:  time.Now().Unix() + 100000,
+					Removed:         false,
+				},
+			}, nil
+		},
+	).Times(1)
+	policies, err := a.GfSpListObjectPolicies(context.Background(), &types.GfSpListObjectPoliciesRequest{
+		ObjectName: "1111",
+		BucketName: "barry",
+		ActionType: 6,
+		Limit:      0,
+		StartAfter: 0,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "RESOURCE_TYPE_OBJECT", policies.Policies[0].ResourceType.String())
+}
+
+func TestMetadataModular_GfSpListObjectPolicies_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetObjectByName(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, bool) (*bsdb.Object, error) {
+			return &bsdb.Object{
+				ID:                  1,
+				Creator:             common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				Operator:            common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				Owner:               common.HexToAddress("0xe978A9160BC061f602fa083e9C68539C549A421D"),
+				LocalVirtualGroupId: 0,
+				BucketName:          "barry",
+				ObjectName:          "1111",
+				ObjectID:            common.HexToHash("1"),
+				BucketID:            common.HexToHash("1"),
+				PayloadSize:         0,
+				Visibility:          "",
+				ContentType:         "",
+				CreateAt:            0,
+				CreateTime:          0,
+				ObjectStatus:        "",
+				RedundancyType:      "",
+				SourceType:          "",
+				Checksums:           nil,
+				LockedBalance:       common.HexToHash("1"),
+				Removed:             false,
+				UpdateTime:          0,
+				UpdateAt:            0,
+				DeleteAt:            0,
+				DeleteReason:        "",
+				CreateTxHash:        common.HexToHash("1"),
+				UpdateTxHash:        common.HexToHash("1"),
+				SealTxHash:          common.HexToHash("1"),
+			}, nil
+		},
+	).Times(1)
+	m.EXPECT().ListObjectPolicies(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, permission_types.ActionType, common.Hash, int) ([]*bsdb.Permission, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpListObjectPolicies(context.Background(), &types.GfSpListObjectPoliciesRequest{
+		ObjectName: "1111",
+		BucketName: "barry",
+		ActionType: 6,
+		Limit:      0,
+		StartAfter: 0,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpListObjectPolicies_Failed2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetObjectByName(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, bool) (*bsdb.Object, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpListObjectPolicies(context.Background(), &types.GfSpListObjectPoliciesRequest{
+		ObjectName: "1111",
+		BucketName: "barry",
+		ActionType: 6,
+		Limit:      0,
+		StartAfter: 0,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpListObjectPolicies_Failed3(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetObjectByName(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, bool) (*bsdb.Object, error) {
+			return nil, gorm.ErrRecordNotFound
+		},
+	).Times(1)
+	_, err := a.GfSpListObjectPolicies(context.Background(), &types.GfSpListObjectPoliciesRequest{
+		ObjectName: "1111",
+		BucketName: "barry",
+		ActionType: 6,
+		Limit:      0,
+		StartAfter: 0,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModularGfSpVerifyMigrateGVGPermission_verifyBucketMigration_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetEventMigrationBucketByBucketID(gomock.Any()).DoAndReturn(
+		func(common.Hash) (*bsdb.EventMigrationBucket, error) {
+			return &bsdb.EventMigrationBucket{
+				ID:             1,
+				BucketID:       common.HexToHash("1"),
+				Operator:       common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				BucketName:     "barry",
+				DstPrimarySpId: 0,
+				CreateAt:       0,
+				CreateTxHash:   common.HexToHash("1"),
+				CreateTime:     0,
+			}, nil
+		},
+	).Times(1)
+	effect, err := a.GfSpVerifyMigrateGVGPermission(context.Background(), &types.GfSpVerifyMigrateGVGPermissionRequest{
+		BucketId: 1,
+		GvgId:    0,
+		DstSpId:  0,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "EFFECT_ALLOW", effect.Effect.String())
+}
+
+func TestMetadataModularGfSpVerifyMigrateGVGPermission_verifySwapOut_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetEventSwapOutByGvgID(gomock.Any()).DoAndReturn(
+		func(uint32) (*bsdb.EventSwapOut, error) {
+			return &bsdb.EventSwapOut{
+				ID:                         1,
+				StorageProviderId:          1,
+				GlobalVirtualGroupFamilyId: 1,
+				GlobalVirtualGroupIds:      []uint32{1},
+				SuccessorSpId:              1,
+				CreateAt:                   0,
+				CreateTxHash:               common.HexToHash("1"),
+				CreateTime:                 0,
+			}, nil
+		},
+	).Times(1)
+	effect, err := a.GfSpVerifyMigrateGVGPermission(context.Background(), &types.GfSpVerifyMigrateGVGPermissionRequest{
+		BucketId: 0,
+		GvgId:    1,
+		DstSpId:  1,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "EFFECT_ALLOW", effect.Effect.String())
+}
+
+func TestMetadataModularGfSpVerifyMigrateGVGPermission_verifyBucketMigration_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetEventMigrationBucketByBucketID(gomock.Any()).DoAndReturn(
+		func(common.Hash) (*bsdb.EventMigrationBucket, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpVerifyMigrateGVGPermission(context.Background(), &types.GfSpVerifyMigrateGVGPermissionRequest{
+		BucketId: 1,
+		GvgId:    0,
+		DstSpId:  0,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModularGfSpVerifyMigrateGVGPermission_verifySwapOut_Failed(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetEventSwapOutByGvgID(gomock.Any()).DoAndReturn(
+		func(uint32) (*bsdb.EventSwapOut, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpVerifyMigrateGVGPermission(context.Background(), &types.GfSpVerifyMigrateGVGPermissionRequest{
+		BucketId: 0,
+		GvgId:    1,
+		DstSpId:  1,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModularGfSpVerifyMigrateGVGPermission_verifyBucketMigration_DENY(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetEventMigrationBucketByBucketID(gomock.Any()).DoAndReturn(
+		func(common.Hash) (*bsdb.EventMigrationBucket, error) {
+			return &bsdb.EventMigrationBucket{
+				ID:             1,
+				BucketID:       common.HexToHash("1"),
+				Operator:       common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				BucketName:     "barry",
+				DstPrimarySpId: 0,
+				CreateAt:       0,
+				CreateTxHash:   common.HexToHash("1"),
+				CreateTime:     0,
+			}, nil
+		},
+	).Times(1)
+	effect, err := a.GfSpVerifyMigrateGVGPermission(context.Background(), &types.GfSpVerifyMigrateGVGPermissionRequest{
+		BucketId: 1,
+		GvgId:    0,
+		DstSpId:  1,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "EFFECT_DENY", effect.Effect.String())
+}
+
+func TestMetadataModularGfSpVerifyMigrateGVGPermission_verifySwapOut_DENY(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetEventSwapOutByGvgID(gomock.Any()).DoAndReturn(
+		func(uint32) (*bsdb.EventSwapOut, error) {
+			return &bsdb.EventSwapOut{
+				ID:                         1,
+				StorageProviderId:          1,
+				GlobalVirtualGroupFamilyId: 1,
+				GlobalVirtualGroupIds:      []uint32{1},
+				SuccessorSpId:              1,
+				CreateAt:                   0,
+				CreateTxHash:               common.HexToHash("1"),
+				CreateTime:                 0,
+			}, nil
+		},
+	).Times(1)
+	effect, err := a.GfSpVerifyMigrateGVGPermission(context.Background(), &types.GfSpVerifyMigrateGVGPermissionRequest{
+		BucketId: 0,
+		GvgId:    1,
+		DstSpId:  11,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "EFFECT_DENY", effect.Effect.String())
+}

--- a/modular/metadata/metadata_query_service_test.go
+++ b/modular/metadata/metadata_query_service_test.go
@@ -17,7 +17,6 @@ import (
 func TestMetadataModular_GfSpQueryUploadProgress_Success(t *testing.T) {
 	a := setup(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockSPDB := spdb.NewMockSPDB(ctrl)
 	a.baseApp.SetGfSpDB(mockSPDB)
 	mockSPDB.EXPECT().GetUploadState(gomock.Any()).DoAndReturn(
@@ -33,7 +32,6 @@ func TestMetadataModular_GfSpQueryUploadProgress_Success(t *testing.T) {
 func TestMetadataModular_GfSpQueryUploadProgress_ErrRecordNotFound(t *testing.T) {
 	a := setup(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockSPDB := spdb.NewMockSPDB(ctrl)
 	a.baseApp.SetGfSpDB(mockSPDB)
 	mockSPDB.EXPECT().GetUploadState(gomock.Any()).DoAndReturn(
@@ -49,7 +47,6 @@ func TestMetadataModular_GfSpQueryUploadProgress_ErrRecordNotFound(t *testing.T)
 func TestMetadataModular_GfSpQueryUploadProgress_Err(t *testing.T) {
 	a := setup(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockSPDB := spdb.NewMockSPDB(ctrl)
 	a.baseApp.SetGfSpDB(mockSPDB)
 	mockSPDB.EXPECT().GetUploadState(gomock.Any()).DoAndReturn(
@@ -65,7 +62,6 @@ func TestMetadataModular_GfSpQueryUploadProgress_Err(t *testing.T) {
 func TestMetadataModular_GfSpQueryResumableUploadSegment_Success(t *testing.T) {
 	a := setup(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockSPDB := spdb.NewMockSPDB(ctrl)
 	a.baseApp.SetGfSpDB(mockSPDB)
 	mockSPDB.EXPECT().GetObjectIntegrity(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -90,7 +86,6 @@ func TestMetadataModular_GfSpQueryResumableUploadSegment_Success(t *testing.T) {
 func TestMetadataModular_GfSpQueryResumableUploadSegment_ErrRecordNotFound(t *testing.T) {
 	a := setup(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockSPDB := spdb.NewMockSPDB(ctrl)
 	a.baseApp.SetGfSpDB(mockSPDB)
 	mockSPDB.EXPECT().GetObjectIntegrity(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -106,7 +101,6 @@ func TestMetadataModular_GfSpQueryResumableUploadSegment_ErrRecordNotFound(t *te
 func TestMetadataModular_GfSpQueryResumableUploadSegment_Err(t *testing.T) {
 	a := setup(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockSPDB := spdb.NewMockSPDB(ctrl)
 	a.baseApp.SetGfSpDB(mockSPDB)
 	mockSPDB.EXPECT().GetObjectIntegrity(gomock.Any(), gomock.Any()).DoAndReturn(

--- a/modular/metadata/metadata_query_service_test.go
+++ b/modular/metadata/metadata_query_service_test.go
@@ -1,0 +1,120 @@
+package metadata
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/bnb-chain/greenfield-storage-provider/core/spdb"
+	storetypes "github.com/bnb-chain/greenfield-storage-provider/store/types"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	"gorm.io/gorm"
+
+	"github.com/bnb-chain/greenfield-storage-provider/modular/metadata/types"
+)
+
+func TestMetadataModular_GfSpQueryUploadProgress_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSPDB := spdb.NewMockSPDB(ctrl)
+	a.baseApp.SetGfSpDB(mockSPDB)
+	mockSPDB.EXPECT().GetUploadState(gomock.Any()).DoAndReturn(
+		func(uint642 uint64) (storetypes.TaskState, string, error) {
+			return storetypes.TaskState_TASK_STATE_UPLOAD_OBJECT_DOING, "", nil
+		},
+	).Times(1)
+	state, err := a.GfSpQueryUploadProgress(context.Background(), &types.GfSpQueryUploadProgressRequest{ObjectId: 1})
+	assert.Nil(t, err)
+	assert.Equal(t, "TASK_STATE_UPLOAD_OBJECT_DOING", state.State.String())
+}
+
+func TestMetadataModular_GfSpQueryUploadProgress_ErrRecordNotFound(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSPDB := spdb.NewMockSPDB(ctrl)
+	a.baseApp.SetGfSpDB(mockSPDB)
+	mockSPDB.EXPECT().GetUploadState(gomock.Any()).DoAndReturn(
+		func(uint642 uint64) (storetypes.TaskState, string, error) {
+			return 0, gorm.ErrRecordNotFound.Error(), gorm.ErrRecordNotFound
+		},
+	).Times(1)
+	state, err := a.GfSpQueryUploadProgress(context.Background(), &types.GfSpQueryUploadProgressRequest{ObjectId: 1})
+	assert.Nil(t, err)
+	assert.Equal(t, "no uploading record", state.Err.Description)
+}
+
+func TestMetadataModular_GfSpQueryUploadProgress_Err(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSPDB := spdb.NewMockSPDB(ctrl)
+	a.baseApp.SetGfSpDB(mockSPDB)
+	mockSPDB.EXPECT().GetUploadState(gomock.Any()).DoAndReturn(
+		func(uint642 uint64) (storetypes.TaskState, string, error) {
+			return 0, "", errors.New("test error")
+		},
+	).Times(1)
+	state, err := a.GfSpQueryUploadProgress(context.Background(), &types.GfSpQueryUploadProgressRequest{ObjectId: 1})
+	assert.Nil(t, err)
+	assert.Equal(t, "GfSpQueryUploadProgress error:"+"test error", state.Err.Description)
+}
+
+func TestMetadataModular_GfSpQueryResumableUploadSegment_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSPDB := spdb.NewMockSPDB(ctrl)
+	a.baseApp.SetGfSpDB(mockSPDB)
+	mockSPDB.EXPECT().GetObjectIntegrity(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(uint64, int32) (*spdb.IntegrityMeta, error) {
+			return &spdb.IntegrityMeta{
+				ObjectID:          1,
+				RedundancyIndex:   1,
+				IntegrityChecksum: []byte{'a'},
+				PieceChecksumList: [][]byte{
+					[]byte("hello"),
+					[]byte("world"),
+					[]byte("golang"),
+				},
+			}, nil
+		},
+	).Times(1)
+	state, err := a.GfSpQueryResumableUploadSegment(context.Background(), &types.GfSpQueryResumableUploadSegmentRequest{ObjectId: 1})
+	assert.Nil(t, err)
+	assert.Equal(t, uint32(3), state.SegmentCount)
+}
+
+func TestMetadataModular_GfSpQueryResumableUploadSegment_ErrRecordNotFound(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSPDB := spdb.NewMockSPDB(ctrl)
+	a.baseApp.SetGfSpDB(mockSPDB)
+	mockSPDB.EXPECT().GetObjectIntegrity(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(uint64, int32) (*spdb.IntegrityMeta, error) {
+			return nil, gorm.ErrRecordNotFound
+		},
+	).Times(1)
+	state, err := a.GfSpQueryResumableUploadSegment(context.Background(), &types.GfSpQueryResumableUploadSegmentRequest{ObjectId: 1})
+	assert.Nil(t, err)
+	assert.Equal(t, "no uploading record", state.Err.Description)
+}
+
+func TestMetadataModular_GfSpQueryResumableUploadSegment_Err(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSPDB := spdb.NewMockSPDB(ctrl)
+	a.baseApp.SetGfSpDB(mockSPDB)
+	mockSPDB.EXPECT().GetObjectIntegrity(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(uint64, int32) (*spdb.IntegrityMeta, error) {
+			return nil, errors.New("test error")
+		},
+	).Times(1)
+	state, err := a.GfSpQueryResumableUploadSegment(context.Background(), &types.GfSpQueryResumableUploadSegmentRequest{ObjectId: 1})
+	assert.Nil(t, err)
+	assert.Equal(t, "GfSpQueryResumableUploadSegment error: "+"test error", state.Err.Description)
+}

--- a/modular/metadata/metadata_sp_exit_service.go
+++ b/modular/metadata/metadata_sp_exit_service.go
@@ -59,10 +59,6 @@ func (r *MetadataModular) GfSpGetGlobalVirtualGroupByGvgID(ctx context.Context, 
 	}
 
 	if gvg != nil {
-		if err != nil {
-			log.CtxErrorw(ctx, "failed to parse global virtual group ids", "error", err)
-			return nil, err
-		}
 		res = &virtual_types.GlobalVirtualGroup{
 			Id:                    gvg.GlobalVirtualGroupId,
 			FamilyId:              gvg.FamilyId,

--- a/modular/metadata/metadata_sp_exit_service_test.go
+++ b/modular/metadata/metadata_sp_exit_service_test.go
@@ -1,0 +1,790 @@
+package metadata
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/forbole/juno/v4/common"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	"gorm.io/gorm"
+
+	"github.com/bnb-chain/greenfield-storage-provider/modular/metadata/types"
+	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
+)
+
+func TestMetadataModularGfSpListVirtualGroupFamiliesBySpID_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListVirtualGroupFamiliesBySpID(gomock.Any()).DoAndReturn(
+		func(uint32) ([]*bsdb.GlobalVirtualGroupFamily, error) {
+			return []*bsdb.GlobalVirtualGroupFamily{
+				&bsdb.GlobalVirtualGroupFamily{
+					ID:                         1,
+					GlobalVirtualGroupFamilyId: 1,
+					PrimarySpId:                1,
+					GlobalVirtualGroupIds:      []uint32{1},
+					VirtualPaymentAddress:      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					CreateAt:                   0,
+					CreateTxHash:               common.HexToHash("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					CreateTime:                 0,
+					UpdateAt:                   0,
+					UpdateTxHash:               common.HexToHash("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					UpdateTime:                 0,
+					Removed:                    false,
+				},
+			}, nil
+		},
+	).Times(1)
+	vgf, err := a.GfSpListVirtualGroupFamiliesBySpID(context.Background(), &types.GfSpListVirtualGroupFamiliesBySpIDRequest{
+		SpId: 1,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, []uint32{1}, vgf.GlobalVirtualGroupFamilies[0].GlobalVirtualGroupIds)
+}
+
+func TestMetadataModularGfSpListVirtualGroupFamiliesBySpID_Fail(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListVirtualGroupFamiliesBySpID(gomock.Any()).DoAndReturn(
+		func(uint32) ([]*bsdb.GlobalVirtualGroupFamily, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpListVirtualGroupFamiliesBySpID(context.Background(), &types.GfSpListVirtualGroupFamiliesBySpIDRequest{
+		SpId: 1,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModularGfSpGetGlobalVirtualGroupByGvgID_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetGlobalVirtualGroupByGvgID(gomock.Any()).DoAndReturn(
+		func(uint32) (*bsdb.GlobalVirtualGroup, error) {
+			return &bsdb.GlobalVirtualGroup{
+				ID:                    1,
+				GlobalVirtualGroupId:  1,
+				FamilyId:              1,
+				PrimarySpId:           1,
+				SecondarySpIds:        []uint32{1},
+				StoredSize:            1,
+				VirtualPaymentAddress: common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				TotalDeposit:          nil,
+				CreateAt:              0,
+				CreateTxHash:          common.HexToHash("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				CreateTime:            0,
+				UpdateAt:              0,
+				UpdateTxHash:          common.HexToHash("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				UpdateTime:            0,
+				Removed:               false,
+			}, nil
+		},
+	).Times(1)
+	gvg, err := a.GfSpGetGlobalVirtualGroupByGvgID(context.Background(), &types.GfSpGetGlobalVirtualGroupByGvgIDRequest{
+		GvgId: 1,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, uint32(1), gvg.GlobalVirtualGroup.FamilyId)
+}
+
+func TestMetadataModularGfSpGetGlobalVirtualGroupByGvgID_Fail(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetGlobalVirtualGroupByGvgID(gomock.Any()).DoAndReturn(
+		func(uint32) (*bsdb.GlobalVirtualGroup, error) {
+			return nil, ErrDanglingPointer
+		},
+	).Times(1)
+	_, err := a.GfSpGetGlobalVirtualGroupByGvgID(context.Background(), &types.GfSpGetGlobalVirtualGroupByGvgIDRequest{
+		GvgId: 1,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModularGfSpGetVirtualGroupFamily_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetVirtualGroupFamiliesByVgfID(gomock.Any()).DoAndReturn(
+		func(uint32) (*bsdb.GlobalVirtualGroupFamily, error) {
+			return &bsdb.GlobalVirtualGroupFamily{
+				ID:                         1,
+				GlobalVirtualGroupFamilyId: 1,
+				PrimarySpId:                1,
+				GlobalVirtualGroupIds:      []uint32{1},
+				VirtualPaymentAddress:      common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				CreateAt:                   0,
+				CreateTxHash:               common.HexToHash("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				CreateTime:                 0,
+				UpdateAt:                   0,
+				UpdateTxHash:               common.HexToHash("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				UpdateTime:                 0,
+				Removed:                    false,
+			}, nil
+		},
+	).Times(1)
+	vgf, err := a.GfSpGetVirtualGroupFamily(context.Background(), &types.GfSpGetVirtualGroupFamilyRequest{
+		VgfId: 1,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, uint32(1), vgf.Vgf.Id)
+}
+
+func TestMetadataModularGfSpGetVirtualGroupFamily_Fail(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetVirtualGroupFamiliesByVgfID(gomock.Any()).DoAndReturn(
+		func(uint32) (*bsdb.GlobalVirtualGroupFamily, error) {
+			return nil, ErrDanglingPointer
+		},
+	).Times(1)
+	_, err := a.GfSpGetVirtualGroupFamily(context.Background(), &types.GfSpGetVirtualGroupFamilyRequest{
+		VgfId: 1,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModularGfSpGetGlobalVirtualGroup_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetGvgByBucketAndLvgID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, uint32) (*bsdb.GlobalVirtualGroup, error) {
+			return &bsdb.GlobalVirtualGroup{
+				ID:                    1,
+				GlobalVirtualGroupId:  1,
+				FamilyId:              1,
+				PrimarySpId:           1,
+				SecondarySpIds:        []uint32{1},
+				StoredSize:            1,
+				VirtualPaymentAddress: common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				TotalDeposit:          nil,
+				CreateAt:              0,
+				CreateTxHash:          common.HexToHash("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				CreateTime:            0,
+				UpdateAt:              0,
+				UpdateTxHash:          common.HexToHash("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				UpdateTime:            0,
+				Removed:               false,
+			}, nil
+		},
+	).Times(1)
+	gvg, err := a.GfSpGetGlobalVirtualGroup(context.Background(), &types.GfSpGetGlobalVirtualGroupRequest{
+		BucketId: 1,
+		LvgId:    1,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, uint32(1), gvg.Gvg.Id)
+}
+
+func TestMetadataModularGfSpGetGlobalVirtualGroup_Fail(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetGvgByBucketAndLvgID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, uint32) (*bsdb.GlobalVirtualGroup, error) {
+			return nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpGetGlobalVirtualGroup(context.Background(), &types.GfSpGetGlobalVirtualGroupRequest{
+		BucketId: 1,
+		LvgId:    1,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModularGfSpListMigrateBucketEvents_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetLatestBlockNumber().DoAndReturn(
+		func() (int64, error) {
+			return 100000, nil
+		},
+	).Times(1)
+	m.EXPECT().ListMigrateBucketEvents(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(spID uint32, filters ...func(*gorm.DB) *gorm.DB) ([]*bsdb.EventMigrationBucket, []*bsdb.EventCompleteMigrationBucket, []*bsdb.EventCancelMigrationBucket, error) {
+			return []*bsdb.EventMigrationBucket{
+					&bsdb.EventMigrationBucket{
+						ID:             1,
+						BucketID:       common.HexToHash("1"),
+						Operator:       common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+						BucketName:     "",
+						DstPrimarySpId: 1,
+						CreateAt:       0,
+						CreateTxHash:   common.HexToHash("1"),
+						CreateTime:     0,
+					},
+				},
+				[]*bsdb.EventCompleteMigrationBucket{
+					&bsdb.EventCompleteMigrationBucket{
+						ID:                         0,
+						BucketID:                   common.HexToHash("1"),
+						Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+						BucketName:                 "",
+						GlobalVirtualGroupFamilyId: 0,
+						SrcPrimarySpId:             1,
+						CreateAt:                   2,
+						CreateTxHash:               common.HexToHash("1"),
+						CreateTime:                 2,
+					},
+				},
+				[]*bsdb.EventCancelMigrationBucket{
+					&bsdb.EventCancelMigrationBucket{
+						ID:           0,
+						BucketID:     common.HexToHash("1"),
+						Operator:     common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+						BucketName:   "",
+						CreateAt:     1,
+						CreateTxHash: common.HexToHash("1"),
+						CreateTime:   1,
+					},
+				}, nil
+		},
+	).Times(1)
+	res, err := a.GfSpListMigrateBucketEvents(context.Background(), &types.GfSpListMigrateBucketEventsRequest{
+		BlockId: 999,
+		SpId:    1,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(res.Events))
+}
+
+func TestMetadataModularGfSpListMigrateBucketEvents_Success2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetLatestBlockNumber().DoAndReturn(
+		func() (int64, error) {
+			return 100000, nil
+		},
+	).Times(1)
+	m.EXPECT().ListMigrateBucketEvents(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(spID uint32, filters ...func(*gorm.DB) *gorm.DB) ([]*bsdb.EventMigrationBucket, []*bsdb.EventCompleteMigrationBucket, []*bsdb.EventCancelMigrationBucket, error) {
+			return []*bsdb.EventMigrationBucket{
+					&bsdb.EventMigrationBucket{
+						ID:             1,
+						BucketID:       common.HexToHash("1"),
+						Operator:       common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+						BucketName:     "",
+						DstPrimarySpId: 1,
+						CreateAt:       0,
+						CreateTxHash:   common.HexToHash("1"),
+						CreateTime:     0,
+					},
+				}, nil,
+				[]*bsdb.EventCancelMigrationBucket{
+					&bsdb.EventCancelMigrationBucket{
+						ID:           0,
+						BucketID:     common.HexToHash("1"),
+						Operator:     common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+						BucketName:   "",
+						CreateAt:     1,
+						CreateTxHash: common.HexToHash("1"),
+						CreateTime:   1,
+					},
+				}, nil
+		},
+	).Times(1)
+	res, err := a.GfSpListMigrateBucketEvents(context.Background(), &types.GfSpListMigrateBucketEventsRequest{
+		BlockId: 999,
+		SpId:    1,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(res.Events))
+}
+
+func TestMetadataModularGfSpListMigrateBucketEvents_Fail(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetLatestBlockNumber().DoAndReturn(
+		func() (int64, error) {
+			return 100000, nil
+		},
+	).Times(1)
+	m.EXPECT().ListMigrateBucketEvents(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(spID uint32, filters ...func(*gorm.DB) *gorm.DB) ([]*bsdb.EventMigrationBucket, []*bsdb.EventCompleteMigrationBucket, []*bsdb.EventCancelMigrationBucket, error) {
+			return nil, nil, nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpListMigrateBucketEvents(context.Background(), &types.GfSpListMigrateBucketEventsRequest{
+		BlockId: 999,
+		SpId:    1,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModularGfSpListMigrateBucketEvents_Fail2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetLatestBlockNumber().DoAndReturn(
+		func() (int64, error) {
+			return 100000, nil
+		},
+	).Times(1)
+	_, err := a.GfSpListMigrateBucketEvents(context.Background(), &types.GfSpListMigrateBucketEventsRequest{
+		BlockId: 1000001,
+		SpId:    1,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModularGfSpListMigrateBucketEvents_Fail3(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetLatestBlockNumber().DoAndReturn(
+		func() (int64, error) {
+			return 0, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpListMigrateBucketEvents(context.Background(), &types.GfSpListMigrateBucketEventsRequest{
+		BlockId: 1000001,
+		SpId:    1,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModularGfSpGetSPMigratingBucketNumber_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListMigrateBucketEvents(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(spID uint32, filters ...func(*gorm.DB) *gorm.DB) ([]*bsdb.EventMigrationBucket, []*bsdb.EventCompleteMigrationBucket, []*bsdb.EventCancelMigrationBucket, error) {
+			return []*bsdb.EventMigrationBucket{
+					&bsdb.EventMigrationBucket{
+						ID:             1,
+						BucketID:       common.HexToHash("1"),
+						Operator:       common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+						BucketName:     "",
+						DstPrimarySpId: 1,
+						CreateAt:       0,
+						CreateTxHash:   common.HexToHash("1"),
+						CreateTime:     0,
+					},
+				},
+				[]*bsdb.EventCompleteMigrationBucket{
+					&bsdb.EventCompleteMigrationBucket{
+						ID:                         0,
+						BucketID:                   common.HexToHash("1"),
+						Operator:                   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+						BucketName:                 "",
+						GlobalVirtualGroupFamilyId: 0,
+						SrcPrimarySpId:             1,
+						CreateAt:                   2,
+						CreateTxHash:               common.HexToHash("1"),
+						CreateTime:                 2,
+					},
+				},
+				[]*bsdb.EventCancelMigrationBucket{
+					&bsdb.EventCancelMigrationBucket{
+						ID:           0,
+						BucketID:     common.HexToHash("1"),
+						Operator:     common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+						BucketName:   "",
+						CreateAt:     1,
+						CreateTxHash: common.HexToHash("1"),
+						CreateTime:   1,
+					},
+				}, nil
+		},
+	).Times(1)
+	count, err := a.GfSpGetSPMigratingBucketNumber(context.Background(), &types.GfSpGetSPMigratingBucketNumberRequest{
+		SpId: 1,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(0), count.Count)
+}
+
+func TestMetadataModularGfSpGetSPMigratingBucketNumber_Success2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListMigrateBucketEvents(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(spID uint32, filters ...func(*gorm.DB) *gorm.DB) ([]*bsdb.EventMigrationBucket, []*bsdb.EventCompleteMigrationBucket, []*bsdb.EventCancelMigrationBucket, error) {
+			return []*bsdb.EventMigrationBucket{
+					&bsdb.EventMigrationBucket{
+						ID:             1,
+						BucketID:       common.HexToHash("1"),
+						Operator:       common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+						BucketName:     "",
+						DstPrimarySpId: 1,
+						CreateAt:       0,
+						CreateTxHash:   common.HexToHash("1"),
+						CreateTime:     0,
+					},
+				}, nil,
+				[]*bsdb.EventCancelMigrationBucket{
+					&bsdb.EventCancelMigrationBucket{
+						ID:           0,
+						BucketID:     common.HexToHash("1"),
+						Operator:     common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+						BucketName:   "",
+						CreateAt:     1,
+						CreateTxHash: common.HexToHash("1"),
+						CreateTime:   1,
+					},
+				}, nil
+		},
+	).Times(1)
+	count, err := a.GfSpGetSPMigratingBucketNumber(context.Background(), &types.GfSpGetSPMigratingBucketNumberRequest{
+		SpId: 1,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(0), count.Count)
+}
+
+func TestMetadataModularGfSpGetSPMigratingBucketNumber_Success3(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListMigrateBucketEvents(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(spID uint32, filters ...func(*gorm.DB) *gorm.DB) ([]*bsdb.EventMigrationBucket, []*bsdb.EventCompleteMigrationBucket, []*bsdb.EventCancelMigrationBucket, error) {
+			return []*bsdb.EventMigrationBucket{
+				&bsdb.EventMigrationBucket{
+					ID:             1,
+					BucketID:       common.HexToHash("1"),
+					Operator:       common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					BucketName:     "",
+					DstPrimarySpId: 1,
+					CreateAt:       0,
+					CreateTxHash:   common.HexToHash("1"),
+					CreateTime:     0,
+				},
+			}, nil, nil, nil
+		},
+	).Times(1)
+	count, err := a.GfSpGetSPMigratingBucketNumber(context.Background(), &types.GfSpGetSPMigratingBucketNumberRequest{
+		SpId: 1,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(1), count.Count)
+}
+
+func TestMetadataModularGfSpGetSPMigratingBucketNumber_Fail(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListMigrateBucketEvents(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(spID uint32, filters ...func(*gorm.DB) *gorm.DB) ([]*bsdb.EventMigrationBucket, []*bsdb.EventCompleteMigrationBucket, []*bsdb.EventCancelMigrationBucket, error) {
+			return nil, nil, nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpGetSPMigratingBucketNumber(context.Background(), &types.GfSpGetSPMigratingBucketNumberRequest{
+		SpId: 1,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModularGfSpListSwapOutEvents_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetLatestBlockNumber().DoAndReturn(
+		func() (int64, error) {
+			return 100000, nil
+		},
+	).Times(1)
+	m.EXPECT().ListSwapOutEvents(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(blockID uint64, spID uint32) ([]*bsdb.EventSwapOut, []*bsdb.EventCompleteSwapOut, []*bsdb.EventCancelSwapOut, error) {
+			return []*bsdb.EventSwapOut{
+					&bsdb.EventSwapOut{
+						ID:                         1,
+						StorageProviderId:          1,
+						GlobalVirtualGroupFamilyId: 1,
+						GlobalVirtualGroupIds:      []uint32{1},
+						SuccessorSpId:              1,
+						CreateAt:                   1,
+						CreateTxHash:               common.HexToHash("1"),
+						CreateTime:                 0,
+					},
+				},
+				[]*bsdb.EventCompleteSwapOut{
+					&bsdb.EventCompleteSwapOut{
+						ID:                         1,
+						StorageProviderId:          1,
+						SrcStorageProviderId:       1,
+						GlobalVirtualGroupFamilyId: 1,
+						GlobalVirtualGroupIds:      []uint32{1},
+						CreateAt:                   3,
+						CreateTxHash:               common.HexToHash("1"),
+						CreateTime:                 3,
+					},
+				},
+				[]*bsdb.EventCancelSwapOut{
+					&bsdb.EventCancelSwapOut{
+						ID:                         1,
+						StorageProviderId:          1,
+						SuccessorSpId:              1,
+						GlobalVirtualGroupFamilyId: 1,
+						GlobalVirtualGroupIds:      []uint32{1},
+						CreateAt:                   2,
+						CreateTxHash:               common.HexToHash("1"),
+						CreateTime:                 2,
+					},
+				}, nil
+		},
+	).Times(1)
+	res, err := a.GfSpListSwapOutEvents(context.Background(), &types.GfSpListSwapOutEventsRequest{
+		BlockId: 999,
+		SpId:    1,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(res.Events))
+}
+
+func TestMetadataModularGfSpGfSpListSwapOutEvents_Success2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetLatestBlockNumber().DoAndReturn(
+		func() (int64, error) {
+			return 100000, nil
+		},
+	).Times(1)
+	m.EXPECT().ListSwapOutEvents(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(blockID uint64, spID uint32) ([]*bsdb.EventSwapOut, []*bsdb.EventCompleteSwapOut, []*bsdb.EventCancelSwapOut, error) {
+			return []*bsdb.EventSwapOut{
+					&bsdb.EventSwapOut{
+						ID:                         1,
+						StorageProviderId:          1,
+						GlobalVirtualGroupFamilyId: 1,
+						GlobalVirtualGroupIds:      []uint32{1},
+						SuccessorSpId:              1,
+						CreateAt:                   1,
+						CreateTxHash:               common.HexToHash("1"),
+						CreateTime:                 0,
+					},
+				}, nil,
+				[]*bsdb.EventCancelSwapOut{
+					&bsdb.EventCancelSwapOut{
+						ID:                         1,
+						StorageProviderId:          1,
+						SuccessorSpId:              1,
+						GlobalVirtualGroupFamilyId: 1,
+						GlobalVirtualGroupIds:      []uint32{1},
+						CreateAt:                   2,
+						CreateTxHash:               common.HexToHash("1"),
+						CreateTime:                 2,
+					},
+				}, nil
+		},
+	).Times(1)
+	res, err := a.GfSpListSwapOutEvents(context.Background(), &types.GfSpListSwapOutEventsRequest{
+		BlockId: 999,
+		SpId:    1,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(res.Events))
+}
+
+func TestMetadataModularGfSpGfSpListSwapOutEvents_Fail(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetLatestBlockNumber().DoAndReturn(
+		func() (int64, error) {
+			return 100000, nil
+		},
+	).Times(1)
+	m.EXPECT().ListSwapOutEvents(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(blockID uint64, spID uint32) ([]*bsdb.EventSwapOut, []*bsdb.EventCompleteSwapOut, []*bsdb.EventCancelSwapOut, error) {
+			return nil, nil, nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpListSwapOutEvents(context.Background(), &types.GfSpListSwapOutEventsRequest{
+		BlockId: 999,
+		SpId:    1,
+	})
+
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModularGfSpGfSpListSwapOutEvents_Fail2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetLatestBlockNumber().DoAndReturn(
+		func() (int64, error) {
+			return 100000, nil
+		},
+	).Times(1)
+	_, err := a.GfSpListSwapOutEvents(context.Background(), &types.GfSpListSwapOutEventsRequest{
+		BlockId: 1000001,
+		SpId:    1,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModularGfSpListSwapOutEvents_Fail3(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetLatestBlockNumber().DoAndReturn(
+		func() (int64, error) {
+			return 0, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpListSwapOutEvents(context.Background(), &types.GfSpListSwapOutEventsRequest{
+		BlockId: 1000001,
+		SpId:    1,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModularGfSpListSpExitEvents_Success(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetLatestBlockNumber().DoAndReturn(
+		func() (int64, error) {
+			return 100000, nil
+		},
+	).Times(1)
+	big, _ := new(big.Int).SetString("123456789012345678901234567890", 10)
+	m.EXPECT().ListSpExitEvents(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(blockID uint64, spID uint32) (*bsdb.EventStorageProviderExit, *bsdb.EventCompleteStorageProviderExit, error) {
+			return &bsdb.EventStorageProviderExit{
+					ID:                1,
+					StorageProviderId: 1,
+					OperatorAddress:   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					CreateAt:          0,
+					CreateTxHash:      common.HexToHash("1"),
+					CreateTime:        0,
+				}, &bsdb.EventCompleteStorageProviderExit{
+					ID:                1,
+					StorageProviderId: 1,
+					TotalDeposit:      (*common.Big)(big),
+					OperatorAddress:   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+					CreateAt:          1,
+					CreateTxHash:      common.HexToHash("1"),
+					CreateTime:        1,
+				}, nil
+		},
+	).Times(1)
+	res, err := a.GfSpListSpExitEvents(context.Background(), &types.GfSpListSpExitEventsRequest{
+		BlockId: 999,
+		SpId:    1,
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, res.Events.Event)
+}
+
+func TestMetadataModularGfSpGfSpGfSpListSpExitEvents_Success2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetLatestBlockNumber().DoAndReturn(
+		func() (int64, error) {
+			return 100000, nil
+		},
+	).Times(1)
+	m.EXPECT().ListSpExitEvents(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(blockID uint64, spID uint32) (*bsdb.EventStorageProviderExit, *bsdb.EventCompleteStorageProviderExit, error) {
+			return &bsdb.EventStorageProviderExit{
+				ID:                1,
+				StorageProviderId: 1,
+				OperatorAddress:   common.HexToAddress("0x11E0A11A7A01E2E757447B52FBD7152004AC699D"),
+				CreateAt:          0,
+				CreateTxHash:      common.HexToHash("1"),
+				CreateTime:        0,
+			}, nil, nil
+		},
+	).Times(1)
+	res, err := a.GfSpListSpExitEvents(context.Background(), &types.GfSpListSpExitEventsRequest{
+		BlockId: 999,
+		SpId:    1,
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, res.Events.Event)
+}
+
+func TestMetadataModularGfSpListSpExitEvents_Fail(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetLatestBlockNumber().DoAndReturn(
+		func() (int64, error) {
+			return 100000, nil
+		},
+	).Times(1)
+	m.EXPECT().ListSpExitEvents(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(blockID uint64, spID uint32) (*bsdb.EventStorageProviderExit, *bsdb.EventCompleteStorageProviderExit, error) {
+			return nil, nil, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpListSpExitEvents(context.Background(), &types.GfSpListSpExitEventsRequest{
+		BlockId: 999,
+		SpId:    1,
+	})
+
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModularGfSpListSpExitEvents_Fail2(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetLatestBlockNumber().DoAndReturn(
+		func() (int64, error) {
+			return 100000, nil
+		},
+	).Times(1)
+	_, err := a.GfSpListSpExitEvents(context.Background(), &types.GfSpListSpExitEventsRequest{
+		BlockId: 1000001,
+		SpId:    1,
+	})
+	assert.NotNil(t, err)
+}
+
+func TestMetadataModularGfSpGfSpListSpExitEvents_Fail3(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetLatestBlockNumber().DoAndReturn(
+		func() (int64, error) {
+			return 0, ErrExceedRequest
+		},
+	).Times(1)
+	_, err := a.GfSpListSpExitEvents(context.Background(), &types.GfSpListSpExitEventsRequest{
+		BlockId: 1000001,
+		SpId:    1,
+	})
+	assert.NotNil(t, err)
+}

--- a/modular/metadata/metadata_test.go
+++ b/modular/metadata/metadata_test.go
@@ -1,0 +1,83 @@
+package metadata
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/bnb-chain/greenfield-storage-provider/base/gfspapp"
+	"github.com/bnb-chain/greenfield-storage-provider/core/module"
+	"github.com/bnb-chain/greenfield-storage-provider/core/rcmgr"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+var mockErr = errors.New("mock error")
+
+func setup(t *testing.T) *MetadataModular {
+	return &MetadataModular{baseApp: &gfspapp.GfSpBaseApp{}}
+}
+
+func TestMetadataModular_Name(t *testing.T) {
+	r := setup(t)
+	result := r.Name()
+	assert.Equal(t, module.MetadataModularName, result)
+}
+
+func TestMetadataModular_StartSuccess(t *testing.T) {
+	r := setup(t)
+	ctrl := gomock.NewController(t)
+	m1 := rcmgr.NewMockResourceManager(ctrl)
+	r.baseApp.SetResourceManager(m1)
+	m2 := rcmgr.NewMockResourceScope(ctrl)
+	m1.EXPECT().OpenService(gomock.Any()).DoAndReturn(func(svc string) (rcmgr.ResourceScope, error) {
+		return m2, nil
+	})
+	err := r.Start(context.TODO())
+	assert.Nil(t, err)
+}
+
+func TestMetadataModular_StartFailure(t *testing.T) {
+	r := setup(t)
+	ctrl := gomock.NewController(t)
+	m1 := rcmgr.NewMockResourceManager(ctrl)
+	r.baseApp.SetResourceManager(m1)
+	m1.EXPECT().OpenService(gomock.Any()).DoAndReturn(func(svc string) (rcmgr.ResourceScope, error) {
+		return nil, mockErr
+	})
+	err := r.Start(context.TODO())
+	assert.Equal(t, mockErr, err)
+}
+
+func TestMetadataModular_Stop(t *testing.T) {
+	r := setup(t)
+	ctrl := gomock.NewController(t)
+	m := rcmgr.NewMockResourceScope(ctrl)
+	r.scope = m
+	m.EXPECT().Release().AnyTimes()
+	err := r.Stop(context.TODO())
+	assert.Nil(t, err)
+}
+
+func TestMetadataModular_ReserveResourceSuccess(t *testing.T) {
+	r := setup(t)
+	ctrl := gomock.NewController(t)
+	m := rcmgr.NewMockResourceScope(ctrl)
+	r.scope = m
+	m1 := rcmgr.NewMockResourceScopeSpan(ctrl)
+	m.EXPECT().BeginSpan().DoAndReturn(func() (rcmgr.ResourceScopeSpan, error) {
+		return m1, nil
+	}).AnyTimes()
+	m1.EXPECT().ReserveResources(gomock.Any()).DoAndReturn(func(st *rcmgr.ScopeStat) error { return nil }).AnyTimes()
+	result, err := r.ReserveResource(context.TODO(), &rcmgr.ScopeStat{Memory: 1})
+	assert.Nil(t, err)
+	assert.NotNil(t, result)
+}
+
+func TestMetadataModular_ReleaseResource(t *testing.T) {
+	r := setup(t)
+	ctrl := gomock.NewController(t)
+	m := rcmgr.NewMockResourceScopeSpan(ctrl)
+	m.EXPECT().Done().AnyTimes()
+	r.ReleaseResource(context.TODO(), m)
+}

--- a/store/bsdb/database_mock.go
+++ b/store/bsdb/database_mock.go
@@ -126,6 +126,36 @@ func (mr *MockMetadataMockRecorder) GetEpoch() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEpoch", reflect.TypeOf((*MockMetadata)(nil).GetEpoch))
 }
 
+// GetEventMigrationBucketByBucketID mocks base method.
+func (m *MockMetadata) GetEventMigrationBucketByBucketID(bucketID common.Hash) (*EventMigrationBucket, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEventMigrationBucketByBucketID", bucketID)
+	ret0, _ := ret[0].(*EventMigrationBucket)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEventMigrationBucketByBucketID indicates an expected call of GetEventMigrationBucketByBucketID.
+func (mr *MockMetadataMockRecorder) GetEventMigrationBucketByBucketID(bucketID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEventMigrationBucketByBucketID", reflect.TypeOf((*MockMetadata)(nil).GetEventMigrationBucketByBucketID), bucketID)
+}
+
+// GetEventSwapOutByGvgID mocks base method.
+func (m *MockMetadata) GetEventSwapOutByGvgID(gvgID uint32) (*EventSwapOut, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEventSwapOutByGvgID", gvgID)
+	ret0, _ := ret[0].(*EventSwapOut)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEventSwapOutByGvgID indicates an expected call of GetEventSwapOutByGvgID.
+func (mr *MockMetadataMockRecorder) GetEventSwapOutByGvgID(gvgID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEventSwapOutByGvgID", reflect.TypeOf((*MockMetadata)(nil).GetEventSwapOutByGvgID), gvgID)
+}
+
 // GetGlobalVirtualGroupByGvgID mocks base method.
 func (m *MockMetadata) GetGlobalVirtualGroupByGvgID(gvgID uint32) (*GlobalVirtualGroup, error) {
 	m.ctrl.T.Helper()
@@ -575,6 +605,21 @@ func (mr *MockMetadataMockRecorder) ListExpiredBucketsBySp(createAt, primarySpID
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExpiredBucketsBySp", reflect.TypeOf((*MockMetadata)(nil).ListExpiredBucketsBySp), createAt, primarySpID, limit)
 }
 
+// ListGroupsByIDs mocks base method.
+func (m *MockMetadata) ListGroupsByIDs(ids []common.Hash) ([]*Group, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListGroupsByIDs", ids)
+	ret0, _ := ret[0].([]*Group)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListGroupsByIDs indicates an expected call of ListGroupsByIDs.
+func (mr *MockMetadataMockRecorder) ListGroupsByIDs(ids interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroupsByIDs", reflect.TypeOf((*MockMetadata)(nil).ListGroupsByIDs), ids)
+}
+
 // ListGroupsByNameAndSourceType mocks base method.
 func (m *MockMetadata) ListGroupsByNameAndSourceType(name, prefix, sourceType string, limit, offset int, includeRemoved bool) ([]*Group, int64, error) {
 	m.ctrl.T.Helper()
@@ -667,9 +712,13 @@ func (mr *MockMetadataMockRecorder) ListLvgByGvgID(gvgIDs interface{}) *gomock.C
 }
 
 // ListMigrateBucketEvents mocks base method.
-func (m *MockMetadata) ListMigrateBucketEvents(blockID uint64, spID uint32) ([]*EventMigrationBucket, []*EventCompleteMigrationBucket, []*EventCancelMigrationBucket, error) {
+func (m *MockMetadata) ListMigrateBucketEvents(spID uint32, filters ...func(*gorm.DB) *gorm.DB) ([]*EventMigrationBucket, []*EventCompleteMigrationBucket, []*EventCancelMigrationBucket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListMigrateBucketEvents", blockID, spID)
+	varargs := []interface{}{spID}
+	for _, a := range filters {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListMigrateBucketEvents", varargs...)
 	ret0, _ := ret[0].([]*EventMigrationBucket)
 	ret1, _ := ret[1].([]*EventCompleteMigrationBucket)
 	ret2, _ := ret[2].([]*EventCancelMigrationBucket)
@@ -678,9 +727,10 @@ func (m *MockMetadata) ListMigrateBucketEvents(blockID uint64, spID uint32) ([]*
 }
 
 // ListMigrateBucketEvents indicates an expected call of ListMigrateBucketEvents.
-func (mr *MockMetadataMockRecorder) ListMigrateBucketEvents(blockID, spID interface{}) *gomock.Call {
+func (mr *MockMetadataMockRecorder) ListMigrateBucketEvents(spID interface{}, filters ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMigrateBucketEvents", reflect.TypeOf((*MockMetadata)(nil).ListMigrateBucketEvents), blockID, spID)
+	varargs := append([]interface{}{spID}, filters...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMigrateBucketEvents", reflect.TypeOf((*MockMetadata)(nil).ListMigrateBucketEvents), varargs...)
 }
 
 // ListObjectPolicies mocks base method.
@@ -797,6 +847,21 @@ func (mr *MockMetadataMockRecorder) ListObjectsInGVGAndBucket(bucketID, gvgID, s
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListObjectsInGVGAndBucket", reflect.TypeOf((*MockMetadata)(nil).ListObjectsInGVGAndBucket), bucketID, gvgID, startAfter, limit)
 }
 
+// ListPaymentAccountStreams mocks base method.
+func (m *MockMetadata) ListPaymentAccountStreams(paymentAccount common.Address) ([]*Bucket, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPaymentAccountStreams", paymentAccount)
+	ret0, _ := ret[0].([]*Bucket)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPaymentAccountStreams indicates an expected call of ListPaymentAccountStreams.
+func (mr *MockMetadataMockRecorder) ListPaymentAccountStreams(paymentAccount interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPaymentAccountStreams", reflect.TypeOf((*MockMetadata)(nil).ListPaymentAccountStreams), paymentAccount)
+}
+
 // ListSpExitEvents mocks base method.
 func (m *MockMetadata) ListSpExitEvents(blockID uint64, spID uint32) (*EventStorageProviderExit, *EventCompleteStorageProviderExit, error) {
 	m.ctrl.T.Helper()
@@ -830,6 +895,21 @@ func (mr *MockMetadataMockRecorder) ListSwapOutEvents(blockID, spID interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSwapOutEvents", reflect.TypeOf((*MockMetadata)(nil).ListSwapOutEvents), blockID, spID)
 }
 
+// ListUserPaymentAccounts mocks base method.
+func (m *MockMetadata) ListUserPaymentAccounts(accountID common.Address) ([]*StreamRecordPaymentAccount, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListUserPaymentAccounts", accountID)
+	ret0, _ := ret[0].([]*StreamRecordPaymentAccount)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListUserPaymentAccounts indicates an expected call of ListUserPaymentAccounts.
+func (mr *MockMetadataMockRecorder) ListUserPaymentAccounts(accountID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserPaymentAccounts", reflect.TypeOf((*MockMetadata)(nil).ListUserPaymentAccounts), accountID)
+}
+
 // ListVgfByGvgID mocks base method.
 func (m *MockMetadata) ListVgfByGvgID(gvgIDs []uint32) ([]*GlobalVirtualGroupFamily, error) {
 	m.ctrl.T.Helper()
@@ -858,6 +938,21 @@ func (m *MockMetadata) ListVirtualGroupFamiliesBySpID(spID uint32) ([]*GlobalVir
 func (mr *MockMetadataMockRecorder) ListVirtualGroupFamiliesBySpID(spID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListVirtualGroupFamiliesBySpID", reflect.TypeOf((*MockMetadata)(nil).ListVirtualGroupFamiliesBySpID), spID)
+}
+
+// ListVirtualGroupFamiliesByVgfIDs mocks base method.
+func (m *MockMetadata) ListVirtualGroupFamiliesByVgfIDs(vgfIDs []uint32) ([]*GlobalVirtualGroupFamily, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListVirtualGroupFamiliesByVgfIDs", vgfIDs)
+	ret0, _ := ret[0].([]*GlobalVirtualGroupFamily)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListVirtualGroupFamiliesByVgfIDs indicates an expected call of ListVirtualGroupFamiliesByVgfIDs.
+func (mr *MockMetadataMockRecorder) ListVirtualGroupFamiliesByVgfIDs(vgfIDs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListVirtualGroupFamiliesByVgfIDs", reflect.TypeOf((*MockMetadata)(nil).ListVirtualGroupFamiliesByVgfIDs), vgfIDs)
 }
 
 // MockBSDB is a mock of BSDB interface.
@@ -971,6 +1066,36 @@ func (m *MockBSDB) GetEpoch() (*Epoch, error) {
 func (mr *MockBSDBMockRecorder) GetEpoch() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEpoch", reflect.TypeOf((*MockBSDB)(nil).GetEpoch))
+}
+
+// GetEventMigrationBucketByBucketID mocks base method.
+func (m *MockBSDB) GetEventMigrationBucketByBucketID(bucketID common.Hash) (*EventMigrationBucket, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEventMigrationBucketByBucketID", bucketID)
+	ret0, _ := ret[0].(*EventMigrationBucket)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEventMigrationBucketByBucketID indicates an expected call of GetEventMigrationBucketByBucketID.
+func (mr *MockBSDBMockRecorder) GetEventMigrationBucketByBucketID(bucketID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEventMigrationBucketByBucketID", reflect.TypeOf((*MockBSDB)(nil).GetEventMigrationBucketByBucketID), bucketID)
+}
+
+// GetEventSwapOutByGvgID mocks base method.
+func (m *MockBSDB) GetEventSwapOutByGvgID(gvgID uint32) (*EventSwapOut, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEventSwapOutByGvgID", gvgID)
+	ret0, _ := ret[0].(*EventSwapOut)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEventSwapOutByGvgID indicates an expected call of GetEventSwapOutByGvgID.
+func (mr *MockBSDBMockRecorder) GetEventSwapOutByGvgID(gvgID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEventSwapOutByGvgID", reflect.TypeOf((*MockBSDB)(nil).GetEventSwapOutByGvgID), gvgID)
 }
 
 // GetGlobalVirtualGroupByGvgID mocks base method.
@@ -1422,6 +1547,21 @@ func (mr *MockBSDBMockRecorder) ListExpiredBucketsBySp(createAt, primarySpID, li
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExpiredBucketsBySp", reflect.TypeOf((*MockBSDB)(nil).ListExpiredBucketsBySp), createAt, primarySpID, limit)
 }
 
+// ListGroupsByIDs mocks base method.
+func (m *MockBSDB) ListGroupsByIDs(ids []common.Hash) ([]*Group, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListGroupsByIDs", ids)
+	ret0, _ := ret[0].([]*Group)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListGroupsByIDs indicates an expected call of ListGroupsByIDs.
+func (mr *MockBSDBMockRecorder) ListGroupsByIDs(ids interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroupsByIDs", reflect.TypeOf((*MockBSDB)(nil).ListGroupsByIDs), ids)
+}
+
 // ListGroupsByNameAndSourceType mocks base method.
 func (m *MockBSDB) ListGroupsByNameAndSourceType(name, prefix, sourceType string, limit, offset int, includeRemoved bool) ([]*Group, int64, error) {
 	m.ctrl.T.Helper()
@@ -1514,9 +1654,13 @@ func (mr *MockBSDBMockRecorder) ListLvgByGvgID(gvgIDs interface{}) *gomock.Call 
 }
 
 // ListMigrateBucketEvents mocks base method.
-func (m *MockBSDB) ListMigrateBucketEvents(blockID uint64, spID uint32) ([]*EventMigrationBucket, []*EventCompleteMigrationBucket, []*EventCancelMigrationBucket, error) {
+func (m *MockBSDB) ListMigrateBucketEvents(spID uint32, filters ...func(*gorm.DB) *gorm.DB) ([]*EventMigrationBucket, []*EventCompleteMigrationBucket, []*EventCancelMigrationBucket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListMigrateBucketEvents", blockID, spID)
+	varargs := []interface{}{spID}
+	for _, a := range filters {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListMigrateBucketEvents", varargs...)
 	ret0, _ := ret[0].([]*EventMigrationBucket)
 	ret1, _ := ret[1].([]*EventCompleteMigrationBucket)
 	ret2, _ := ret[2].([]*EventCancelMigrationBucket)
@@ -1525,9 +1669,10 @@ func (m *MockBSDB) ListMigrateBucketEvents(blockID uint64, spID uint32) ([]*Even
 }
 
 // ListMigrateBucketEvents indicates an expected call of ListMigrateBucketEvents.
-func (mr *MockBSDBMockRecorder) ListMigrateBucketEvents(blockID, spID interface{}) *gomock.Call {
+func (mr *MockBSDBMockRecorder) ListMigrateBucketEvents(spID interface{}, filters ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMigrateBucketEvents", reflect.TypeOf((*MockBSDB)(nil).ListMigrateBucketEvents), blockID, spID)
+	varargs := append([]interface{}{spID}, filters...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMigrateBucketEvents", reflect.TypeOf((*MockBSDB)(nil).ListMigrateBucketEvents), varargs...)
 }
 
 // ListObjectPolicies mocks base method.
@@ -1644,6 +1789,21 @@ func (mr *MockBSDBMockRecorder) ListObjectsInGVGAndBucket(bucketID, gvgID, start
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListObjectsInGVGAndBucket", reflect.TypeOf((*MockBSDB)(nil).ListObjectsInGVGAndBucket), bucketID, gvgID, startAfter, limit)
 }
 
+// ListPaymentAccountStreams mocks base method.
+func (m *MockBSDB) ListPaymentAccountStreams(paymentAccount common.Address) ([]*Bucket, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPaymentAccountStreams", paymentAccount)
+	ret0, _ := ret[0].([]*Bucket)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPaymentAccountStreams indicates an expected call of ListPaymentAccountStreams.
+func (mr *MockBSDBMockRecorder) ListPaymentAccountStreams(paymentAccount interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPaymentAccountStreams", reflect.TypeOf((*MockBSDB)(nil).ListPaymentAccountStreams), paymentAccount)
+}
+
 // ListSpExitEvents mocks base method.
 func (m *MockBSDB) ListSpExitEvents(blockID uint64, spID uint32) (*EventStorageProviderExit, *EventCompleteStorageProviderExit, error) {
 	m.ctrl.T.Helper()
@@ -1677,6 +1837,21 @@ func (mr *MockBSDBMockRecorder) ListSwapOutEvents(blockID, spID interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSwapOutEvents", reflect.TypeOf((*MockBSDB)(nil).ListSwapOutEvents), blockID, spID)
 }
 
+// ListUserPaymentAccounts mocks base method.
+func (m *MockBSDB) ListUserPaymentAccounts(accountID common.Address) ([]*StreamRecordPaymentAccount, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListUserPaymentAccounts", accountID)
+	ret0, _ := ret[0].([]*StreamRecordPaymentAccount)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListUserPaymentAccounts indicates an expected call of ListUserPaymentAccounts.
+func (mr *MockBSDBMockRecorder) ListUserPaymentAccounts(accountID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserPaymentAccounts", reflect.TypeOf((*MockBSDB)(nil).ListUserPaymentAccounts), accountID)
+}
+
 // ListVgfByGvgID mocks base method.
 func (m *MockBSDB) ListVgfByGvgID(gvgIDs []uint32) ([]*GlobalVirtualGroupFamily, error) {
 	m.ctrl.T.Helper()
@@ -1705,4 +1880,19 @@ func (m *MockBSDB) ListVirtualGroupFamiliesBySpID(spID uint32) ([]*GlobalVirtual
 func (mr *MockBSDBMockRecorder) ListVirtualGroupFamiliesBySpID(spID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListVirtualGroupFamiliesBySpID", reflect.TypeOf((*MockBSDB)(nil).ListVirtualGroupFamiliesBySpID), spID)
+}
+
+// ListVirtualGroupFamiliesByVgfIDs mocks base method.
+func (m *MockBSDB) ListVirtualGroupFamiliesByVgfIDs(vgfIDs []uint32) ([]*GlobalVirtualGroupFamily, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListVirtualGroupFamiliesByVgfIDs", vgfIDs)
+	ret0, _ := ret[0].([]*GlobalVirtualGroupFamily)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListVirtualGroupFamiliesByVgfIDs indicates an expected call of ListVirtualGroupFamiliesByVgfIDs.
+func (mr *MockBSDBMockRecorder) ListVirtualGroupFamiliesByVgfIDs(vgfIDs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListVirtualGroupFamiliesByVgfIDs", reflect.TypeOf((*MockBSDB)(nil).ListVirtualGroupFamiliesByVgfIDs), vgfIDs)
 }


### PR DESCRIPTION
### Description

add metadata api UT to 83.2% 
```
go test ./modular/metadata -coverprofile=coverage.out
ok      github.com/bnb-chain/greenfield-storage-provider/modular/metadata       1.175s  coverage: 83.2% of statements
```

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 
* add metadata api UT