### PR TITLE
fix: add xml response for rate limit error

### DIFF
--- a/base/errors.md
+++ b/base/errors.md
@@ -20,6 +20,8 @@ modular reports an error, and in the `10` modular it is the `01` error.
 It sorts in reverse order starting from 99...
 * `99`: is used for GfSp Bass App code.
 * `98`: is used for GfSp Client code.
+* `97`: is used for TaskQueue code.
+* `96`: is used for Middleware code.
 
 ### System External Dependencies Code
 It sorts from 50...

--- a/base/errors.md
+++ b/base/errors.md
@@ -18,7 +18,7 @@ modular reports an error, and in the `10` modular it is the `01` error.
 
 ### Infrastructure Code
 It sorts in reverse order starting from 99...
-* `99`: is used for GfSp Bass App code.
+* `99`: is used for GfSp Base App code.
 * `98`: is used for GfSp Client code.
 * `97`: is used for TaskQueue code.
 * `96`: is used for Middleware code.

--- a/go.mod
+++ b/go.mod
@@ -123,7 +123,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.3.0 // indirect
 	github.com/golang/glog v1.1.0 // indirect
-	github.com/golang/mock v1.6.0 // indirect
+	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.1.2 // indirect

--- a/pkg/middleware/http/ratelimiter.go
+++ b/pkg/middleware/http/ratelimiter.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
-	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsperrors"
 	"net/http"
 	"regexp"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsperrors"
 
 	slimiter "github.com/ulule/limiter/v3"
 	smemory "github.com/ulule/limiter/v3/drivers/store/memory"
@@ -214,12 +215,12 @@ func MakeLimitErrorResponse(w http.ResponseWriter, err error) {
 	}
 	xmlBody, err := xml.Marshal(&xmlInfo)
 	if err != nil {
-		log.Errorw("failed to marshal error response", "error", gfspErr.String())
+		log.Errorw("failed to marshal error response", "gfsp_error", gfspErr.String(), "error", err)
 	}
 	w.Header().Set("Content-Type", "application/xml")
 	w.WriteHeader(int(gfspErr.GetHttpStatusCode()))
 	if _, err = w.Write(xmlBody); err != nil {
-		log.Errorw("failed to write error response", "error", gfspErr.String())
+		log.Errorw("failed to write error response", "gfsp_error", gfspErr.String(), "error", err)
 	}
 }
 


### PR DESCRIPTION
### Description

fix: add xml response for rate limit error
### Rationale

Make rate limit error response format look consistent with other errors
### Example

```
curl -v 127.0.0.1:9133/auth/request_nonce
*   Trying 127.0.0.1:9133...
* Connected to 127.0.0.1 (127.0.0.1) port 9133 (#0)
> GET /auth/request_nonce HTTP/1.1
> Host: 127.0.0.1:9133
> User-Agent: curl/7.84.0
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 429 Too Many Requests
< Content-Type: application/xml
< Date: Wed, 20 Sep 2023 02:41:13 GMT
< Content-Length: 97
<
* Connection #0 to host 127.0.0.1 left intact
<Error><Code>960001</Code><Message>too many requests, please try it again later</Message></Error>%
```
### Changes

Notable changes: 
* add a new error code
* update error code's readme doc
