### PR TITLE
fix: list objects by gvg sql bug

### DIFF
--- a/modular/gater/metadata_handler.go
+++ b/modular/gater/metadata_handler.go
@@ -1713,7 +1713,7 @@ func (g *GateModular) listObjectsInGVGAndBucketHandler(w http.ResponseWriter, r 
 		return
 	}
 
-	grpcResponse := &types.GfSpListObjectsInGVGResponse{Objects: objects}
+	grpcResponse := &types.GfSpListObjectsInGVGAndBucketResponse{Objects: objects}
 
 	respBytes, err = xml.Marshal(grpcResponse)
 	if err != nil {


### PR DESCRIPTION
### Description

fix list objects by gvg sql bug
To avoid SQL query length exceeding the server's max_allowed_packet size, we can add a simple check mechanism. One way is to keep track of the query string's length and break out of the loop if it gets too close to the limit.


### Rationale

```
client failed to list objects by gvg id, 
error: rpc error: code = Unknown desc = Error 1436 (HY000): 
Thread stack overrun: 242207 bytes used of a 262144 byte stack, and 20000 bytes needed.  Use &#39;mysqld --thread_stack=#&#39; to specify a bigger stack.
```

### Example

N/A

### Changes

Notable changes: 
* fix list objects by gvg sql bug
