### PR TITLE
fix: verify permission 500 code and update UT

### DIFF
--- a/modular/gater/helper_test.go
+++ b/modular/gater/helper_test.go
@@ -8,10 +8,12 @@ import (
 )
 
 const (
-	testDomain     = "www.route-test.com"
-	scheme         = "https://"
-	mockBucketName = "mock-bucket-name"
-	mockObjectName = "mock-object-name"
+	testDomain        = "www.route-test.com"
+	scheme            = "https://"
+	mockBucketName    = "mock-bucket-name"
+	mockObjectName    = "mock-object-name"
+	invalidBucketName = "1"
+	invalidObjectName = ".."
 )
 
 var mockErr = errors.New("mock error")

--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -405,6 +405,17 @@ func (g *GateModular) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 	// GNFD1-ECDSA or GNFD1-EDDSA authentication, by checking the headers.
 	reqCtx, reqCtxErr = NewRequestContext(r, g)
 
+	if err = s3util.CheckValidBucketName(reqCtx.bucketName); err != nil {
+		log.Errorw("failed to check bucket name", "bucket_name", reqCtx.bucketName, "error", err)
+		err = ErrInvalidQuery
+		return
+	}
+	if err = s3util.CheckValidObjectName(reqCtx.objectName); err != nil {
+		log.Errorw("failed to check object name", "object_name", reqCtx.objectName, "error", err)
+		err = ErrInvalidQuery
+		return
+	}
+
 	// check the object permission whether allow public read.
 	verifyObjectPermissionTime := time.Now()
 	var permission *permissiontypes.Effect
@@ -775,10 +786,12 @@ func (g *GateModular) getObjectByUniversalEndpointHandler(w http.ResponseWriter,
 
 	if err = s3util.CheckValidBucketName(reqCtx.bucketName); err != nil {
 		log.Errorw("failed to check bucket name", "bucket_name", reqCtx.bucketName, "error", err)
+		err = ErrInvalidQuery
 		return
 	}
 	if err = s3util.CheckValidObjectName(reqCtx.objectName); err != nil {
 		log.Errorw("failed to check object name", "object_name", reqCtx.objectName, "error", err)
+		err = ErrInvalidQuery
 		return
 	}
 

--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -422,7 +422,6 @@ func (g *GateModular) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 	if permission, err = g.baseApp.GfSpClient().VerifyPermission(reqCtx.Context(), sdk.AccAddress{}.String(),
 		reqCtx.bucketName, reqCtx.objectName, permissiontypes.ACTION_GET_OBJECT); err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to verify authentication for getting public object", "error", err)
-		err = ErrConsensusWithDetail("failed to verify authentication for getting public object, error: " + err.Error())
 		return
 	}
 	if *permission == permissiontypes.EFFECT_ALLOW {

--- a/modular/gater/object_handler_test.go
+++ b/modular/gater/object_handler_test.go
@@ -1117,7 +1117,7 @@ func TestGateModular_getObjectHandler(t *testing.T) {
 				req.Header.Set(GnfdAuthorizationHeader, "GNFD1-EDDSA,Signature=48656c6c6f20476f7068657221")
 				return req
 			},
-			wantedResult: "failed to verify authentication for getting public object",
+			wantedResult: "<Error><Code>999999</Code><Message>mock error</Message></Error>",
 		},
 		{
 			name: "new request returns error and unsupported sign type",

--- a/modular/gater/object_handler_test.go
+++ b/modular/gater/object_handler_test.go
@@ -1441,6 +1441,48 @@ func TestGateModular_getObjectHandler(t *testing.T) {
 			},
 			wantedResult: "",
 		},
+		{
+			name: "failed to check bucket name",
+			fn: func() *GateModular {
+				g := setup(t)
+				ctrl := gomock.NewController(t)
+				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
+				clientMock.EXPECT().VerifyGNFD1EddsaSignature(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any()).Return(false, mockErr).Times(1)
+				g.baseApp.SetGfSpClient(clientMock)
+				return g
+			},
+			request: func() *http.Request {
+				path := fmt.Sprintf("%s%s.%s/%s", scheme, invalidBucketName, testDomain, mockObjectName)
+				req := httptest.NewRequest(http.MethodGet, path, strings.NewReader(""))
+				validExpiryDateStr := time.Now().Add(time.Hour * 60).Format(ExpiryDateFormat)
+				req.Header.Set(commonhttp.HTTPHeaderExpiryTimestamp, validExpiryDateStr)
+				req.Header.Set(GnfdAuthorizationHeader, "GNFD1-EDDSA,Signature=48656c6c6f20476f7068657221")
+				return req
+			},
+			wantedResult: "<Error><Code>50010</Code><Message>invalid request params for query</Message></Error>",
+		},
+		{
+			name: "failed to check object name",
+			fn: func() *GateModular {
+				g := setup(t)
+				ctrl := gomock.NewController(t)
+				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
+				clientMock.EXPECT().VerifyGNFD1EddsaSignature(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any()).Return(false, mockErr).Times(1)
+				g.baseApp.SetGfSpClient(clientMock)
+				return g
+			},
+			request: func() *http.Request {
+				path := fmt.Sprintf("%s%s.%s/%s", scheme, mockBucketName, testDomain, invalidObjectName)
+				req := httptest.NewRequest(http.MethodGet, path, strings.NewReader(""))
+				validExpiryDateStr := time.Now().Add(time.Hour * 60).Format(ExpiryDateFormat)
+				req.Header.Set(commonhttp.HTTPHeaderExpiryTimestamp, validExpiryDateStr)
+				req.Header.Set(GnfdAuthorizationHeader, "GNFD1-EDDSA,Signature=48656c6c6f20476f7068657221")
+				return req
+			},
+			wantedResult: "<Error><Code>50010</Code><Message>invalid request params for query</Message></Error>",
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1738,7 +1780,7 @@ func TestGateModular_getObjectByUniversalEndpointHandler(t *testing.T) {
 				return g
 			},
 			request: func() *http.Request {
-				path := fmt.Sprintf("%s%s/download/%s/%s", scheme, testDomain, mockBucketName, "")
+				path := fmt.Sprintf("%s%s/download/%s/%s", scheme, testDomain, mockBucketName, invalidObjectName)
 				req := httptest.NewRequest(http.MethodGet, path, strings.NewReader(""))
 				validExpiryDateStr := time.Now().Add(time.Hour * 60).Format(ExpiryDateFormat)
 				req.Header.Set("User-Agent", "Chrome")

--- a/modular/metadata/metadata_bucket_service.go
+++ b/modular/metadata/metadata_bucket_service.go
@@ -120,7 +120,7 @@ func (r *MetadataModular) GfSpGetBucketByBucketName(ctx context.Context, req *ty
 	ctx = log.Context(ctx, req)
 	if err = s3util.CheckValidBucketName(req.BucketName); err != nil {
 		log.Errorw("failed to check bucket name", "bucket_name", req.BucketName, "error", err)
-		return nil, err
+		return nil, ErrInvalidBucketName
 	}
 
 	bucket, err = r.baseApp.GfBsDB().GetBucketByName(req.BucketName, req.IncludePrivate)
@@ -266,6 +266,9 @@ func (r *MetadataModular) GfSpGetBucketMeta(
 	bucketFullMeta, err := r.baseApp.GfBsDB().GetBucketMetaByName(req.GetBucketName(), req.GetIncludePrivate())
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get bucket meta by name", "error", err)
+		if systemerrors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNoSuchBucket
+		}
 		return
 	}
 	bucket = &bucketFullMeta.Bucket

--- a/modular/metadata/metadata_bucket_service.go
+++ b/modular/metadata/metadata_bucket_service.go
@@ -28,6 +28,16 @@ var (
 	ErrNoRecord          = gfsperrors.Register(coremodule.MetadataModularName, http.StatusNotFound, 90003, "no uploading record")
 	ErrNoSuchSP          = gfsperrors.Register(coremodule.MetadataModularName, http.StatusNotFound, 90004, "no such sp")
 	ErrExceedBlockHeight = gfsperrors.Register(coremodule.MetadataModularName, http.StatusBadRequest, 90005, "request block height exceed latest height")
+	// ErrInvalidParams defines invalid params
+	ErrInvalidParams = gfsperrors.Register(coremodule.MetadataModularName, http.StatusBadRequest, 90006, "invalid params")
+	// ErrInvalidBucketName defines invalid bucket name
+	ErrInvalidBucketName = gfsperrors.Register(coremodule.MetadataModularName, http.StatusBadRequest, 90007, "invalid bucket name")
+	// ErrNoSuchBucket defines not existed bucket error
+	ErrNoSuchBucket = gfsperrors.Register(coremodule.MetadataModularName, http.StatusNotFound, 90008, "the specified bucket does not exist")
+	// ErrNoSuchGroup defines not existed group error
+	ErrNoSuchGroup = gfsperrors.Register(coremodule.MetadataModularName, http.StatusNotFound, 90009, "the specified group does not exist")
+	// ErrNoSuchObject defines not existed object error
+	ErrNoSuchObject = gfsperrors.Register(coremodule.MetadataModularName, http.StatusNotFound, 90010, "the specified object does not exist")
 )
 
 var _ types.GfSpMetadataServiceServer = &MetadataModular{}

--- a/modular/metadata/metadata_permission_service.go
+++ b/modular/metadata/metadata_permission_service.go
@@ -23,19 +23,6 @@ import (
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 )
 
-var (
-	// ErrInvalidParams defines invalid params
-	ErrInvalidParams = errors.New("invalid params")
-	// ErrInvalidBucketName defines invalid bucket name
-	ErrInvalidBucketName = errors.New("invalid bucket name")
-	// ErrNoSuchBucket defines not existed bucket error
-	ErrNoSuchBucket = errors.New("the specified bucket does not exist")
-	// ErrNoSuchGroup defines not existed group error
-	ErrNoSuchGroup = errors.New("the specified group does not exist")
-	// ErrNoSuchObject defines not existed object error
-	ErrNoSuchObject = errors.New("the specified key does not exist")
-)
-
 // GfSpVerifyPermission Verify the input account’s permission to input items
 func (r *MetadataModular) GfSpVerifyPermission(ctx context.Context, req *storagetypes.QueryVerifyPermissionRequest) (resp *storagetypes.QueryVerifyPermissionResponse, err error) {
 	var (
@@ -55,7 +42,7 @@ func (r *MetadataModular) GfSpVerifyPermission(ctx context.Context, req *storage
 	operator, err = sdk.AccAddressFromHexUnsafe(req.Operator)
 	if err != nil && err != sdk.ErrEmptyHexAddress {
 		log.CtxErrorw(ctx, "failed to creates an AccAddress from a HEX-encoded string", "req.Operator", operator.String(), "error", err)
-		return nil, err
+		return nil, ErrInvalidParams
 	}
 
 	if err = s3util.CheckValidBucketName(req.BucketName); err != nil {
@@ -249,7 +236,7 @@ func (r *MetadataModular) VerifyBucketPermission(ctx context.Context, bucketInfo
 	owner, err = sdk.AccAddressFromHexUnsafe(bucketInfo.Owner.String())
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to creates an AccAddress from a HEX-encoded string", "bucketInfo.Owner.String()", bucketInfo.Owner.String(), "error", err)
-		return permtypes.EFFECT_DENY, err
+		return permtypes.EFFECT_DENY, ErrInvalidParams
 	}
 
 	// the owner has full permissions


### PR DESCRIPTION
### Description

verify permission 500 code and update UT
includes these Verify Permission senarios:
1. bucket not found -> 404
2. object not found -> 404
3. invalid bucket name -> 400
4. AccAddressFromHexUnsafe(operator) -> 400

### Rationale

```
failed to send verify permission rpc, error: rpc error: code = Unknown desc = the specified bucket does not exist

```

### Example

N/A

### Changes

Notable changes: 
* verify permission 500 code and update UT
