### PR TITLE
release: release for v0.2.6-hf.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+
+## v0.2.6-hf.1
+
+BUGFIX
+* [#1166](https://github.com/bnb-chain/greenfield-storage-provider/pull/1166) fix: delete group fix job
+* [#1160](https://github.com/bnb-chain/greenfield-storage-provider/pull/1160) fix: fix replication failed SP err recording issue
+* [#1159](https://github.com/bnb-chain/greenfield-storage-provider/pull/1159) fix: list objects by gvg sql bug
+* [#1165](https://github.com/bnb-chain/greenfield-storage-provider/pull/1165) fix: verify permission 500 code and update UT
+* [#1155](https://github.com/bnb-chain/greenfield-storage-provider/pull/1155) fix: fix manager duplicate entry when inserting upload progress
+* [#1158](https://github.com/bnb-chain/greenfield-storage-provider/pull/1158) fix: add xml response for rate limit error
+* [#1156](https://github.com/bnb-chain/greenfield-storage-provider/pull/1156) fix: recovery object status should be sealed
+* [#1154](https://github.com/bnb-chain/greenfield-storage-provider/pull/1154) fix: add ut for universal endpoint
+
+
 ## v0.2.6
 
 TEST

--- a/base/errors.md
+++ b/base/errors.md
@@ -18,8 +18,10 @@ modular reports an error, and in the `10` modular it is the `01` error.
 
 ### Infrastructure Code
 It sorts in reverse order starting from 99...
-* `99`: is used for GfSp Bass App code.
+* `99`: is used for GfSp Base App code.
 * `98`: is used for GfSp Client code.
+* `97`: is used for TaskQueue code.
+* `96`: is used for Middleware code.
 
 ### System External Dependencies Code
 It sorts from 50...

--- a/base/gfspapp/approval_server.go
+++ b/base/gfspapp/approval_server.go
@@ -21,7 +21,7 @@ var _ gfspserver.GfSpApprovalServiceServer = &GfSpBaseApp{}
 
 func (g *GfSpBaseApp) GfSpAskApproval(ctx context.Context, req *gfspserver.GfSpAskApprovalRequest) (
 	*gfspserver.GfSpAskApprovalResponse, error) {
-	if req.GetRequest() == nil {
+	if req == nil || req.GetRequest() == nil {
 		log.Error("failed to ask approval due to pointer dangling")
 		return &gfspserver.GfSpAskApprovalResponse{Err: ErrApprovalTaskDangling}, nil
 	}

--- a/base/gfspapp/authenticator_server.go
+++ b/base/gfspapp/authenticator_server.go
@@ -2,6 +2,7 @@ package gfspapp
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsperrors"
@@ -11,10 +12,20 @@ import (
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/metrics"
 )
 
+var (
+	ErrAuthenticatorTaskDangling = gfsperrors.Register(BaseCodeSpace, http.StatusBadRequest, 990101, "OoooH... request lost")
+)
+
 var _ gfspserver.GfSpAuthenticationServiceServer = &GfSpBaseApp{}
 
 func (g *GfSpBaseApp) GfSpVerifyAuthentication(ctx context.Context, req *gfspserver.GfSpAuthenticationRequest) (
 	*gfspserver.GfSpAuthenticationResponse, error) {
+	if req == nil {
+		log.Error("failed to verify authentication due to pointer dangling")
+		return &gfspserver.GfSpAuthenticationResponse{
+			Err: ErrAuthenticatorTaskDangling,
+		}, nil
+	}
 	ctx = log.WithValue(ctx, log.CtxKeyBucketName, req.GetBucketName())
 	ctx = log.WithValue(ctx, log.CtxKeyObjectName, req.GetObjectName())
 	log.CtxDebugw(ctx, "begin to authenticate", "user", req.GetUserAccount(), "auth_type", req.GetAuthType())
@@ -38,6 +49,12 @@ func (g *GfSpBaseApp) GfSpVerifyAuthentication(ctx context.Context, req *gfspser
 
 // GetAuthNonce get the auth nonce for which the Dapp or client can generate EDDSA key pairs.
 func (g *GfSpBaseApp) GetAuthNonce(ctx context.Context, req *gfspserver.GetAuthNonceRequest) (*gfspserver.GetAuthNonceResponse, error) {
+	if req == nil {
+		log.Error("failed to get auth nonce due to pointer dangling")
+		return &gfspserver.GetAuthNonceResponse{
+			Err: ErrAuthenticatorTaskDangling,
+		}, nil
+	}
 	log.CtxDebugw(ctx, "begin to get auth nonce", "user", req.GetAccountId(), "domain", req.GetDomain())
 	resp, err := g.authenticator.GetAuthNonce(ctx, req.AccountId, req.Domain)
 	log.CtxDebugw(ctx, "finish to get auth nonce", "user", req.GetAccountId(), "domain", req.GetDomain(), "error", err)
@@ -58,6 +75,12 @@ func (g *GfSpBaseApp) GetAuthNonce(ctx context.Context, req *gfspserver.GetAuthN
 
 // UpdateUserPublicKey updates the user public key once the Dapp or client generates the EDDSA key pairs.
 func (g *GfSpBaseApp) UpdateUserPublicKey(ctx context.Context, req *gfspserver.UpdateUserPublicKeyRequest) (*gfspserver.UpdateUserPublicKeyResponse, error) {
+	if req == nil {
+		log.Error("failed to update user publicKey due to pointer dangling")
+		return &gfspserver.UpdateUserPublicKeyResponse{
+			Err: ErrAuthenticatorTaskDangling,
+		}, nil
+	}
 	log.CtxDebugw(ctx, "begin to update user public key", "user", req.GetAccountId(), "domain", req.GetDomain(),
 		"public_key", req.UserPublicKey)
 	resp, err := g.authenticator.UpdateUserPublicKey(ctx, req.AccountId, req.Domain, req.CurrentNonce, req.Nonce, req.UserPublicKey, req.ExpiryDate)
@@ -71,6 +94,12 @@ func (g *GfSpBaseApp) UpdateUserPublicKey(ctx context.Context, req *gfspserver.U
 
 // VerifyGNFD1EddsaSignature verifies the signature signed by user's EDDSA private key.
 func (g *GfSpBaseApp) VerifyGNFD1EddsaSignature(ctx context.Context, req *gfspserver.VerifyGNFD1EddsaSignatureRequest) (*gfspserver.VerifyGNFD1EddsaSignatureResponse, error) {
+	if req == nil {
+		log.Error("failed to verify gnfd1EddsaSignature due to pointer dangling")
+		return &gfspserver.VerifyGNFD1EddsaSignatureResponse{
+			Err: ErrAuthenticatorTaskDangling,
+		}, nil
+	}
 	log.CtxDebugw(ctx, "begin to verify off-chain signature", "user", req.GetAccountId(), "domain", req.GetDomain(),
 		"off_chain_sig", req.OffChainSig, "real_msg_to_sign", req.RealMsgToSign)
 	resp, err := g.authenticator.VerifyGNFD1EddsaSignature(ctx, req.AccountId, req.Domain, req.OffChainSig, req.RealMsgToSign)

--- a/base/gfspapp/download_server.go
+++ b/base/gfspapp/download_server.go
@@ -177,6 +177,10 @@ func (g *GfSpBaseApp) OnChallengePieceTask(ctx context.Context, challengePieceTa
 }
 
 func (g *GfSpBaseApp) GfSpReimburseQuota(ctx context.Context, fixRequest *gfspserver.GfSpReimburseQuotaRequest) (*gfspserver.GfSpReimburseQuotaResponse, error) {
+	if fixRequest == nil {
+		log.CtxError(ctx, "failed to reimburse quota due to task pointer dangling")
+		return &gfspserver.GfSpReimburseQuotaResponse{Err: ErrDownloadTaskDangling}, nil
+	}
 	err := g.GfSpDB().UpdateExtraQuota(fixRequest.GetBucketId(), fixRequest.GetExtraQuota(), fixRequest.YearMonth)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to reimburse extra quota", "error", err, "bucketID:", fixRequest.GetBucketId())

--- a/base/gfspapp/manage_server.go
+++ b/base/gfspapp/manage_server.go
@@ -25,7 +25,7 @@ var (
 var _ gfspserver.GfSpManageServiceServer = &GfSpBaseApp{}
 
 func (g *GfSpBaseApp) GfSpBeginTask(ctx context.Context, req *gfspserver.GfSpBeginTaskRequest) (*gfspserver.GfSpBeginTaskResponse, error) {
-	if req.GetRequest() == nil {
+	if req == nil || req.GetRequest() == nil {
 		log.Error("failed to begin task due to pointer dangling")
 		return &gfspserver.GfSpBeginTaskResponse{Err: ErrUploadTaskDangling}, nil
 	}

--- a/base/gfspapp/sign_server.go
+++ b/base/gfspapp/sign_server.go
@@ -19,7 +19,7 @@ var (
 var _ gfspserver.GfSpSignServiceServer = &GfSpBaseApp{}
 
 func (g *GfSpBaseApp) GfSpSign(ctx context.Context, req *gfspserver.GfSpSignRequest) (*gfspserver.GfSpSignResponse, error) {
-	if req.GetRequest() == nil {
+	if req == nil || req.GetRequest() == nil {
 		log.Error("failed to sign msg due to pointer dangling")
 		return &gfspserver.GfSpSignResponse{Err: ErrSingTaskDangling}, nil
 	}

--- a/base/types/gfsptask/upload.go
+++ b/base/types/gfsptask/upload.go
@@ -434,9 +434,7 @@ func (m *GfSpReplicatePieceTask) SetPriority(priority coretask.TPriority) {
 }
 
 func (m *GfSpReplicatePieceTask) SetNotAvailableSpIdx(idx int32) {
-	if atomic.LoadInt32(&m.NotAvailableSpIdx) != idx {
-		atomic.StoreInt32(&m.NotAvailableSpIdx, idx)
-	}
+	atomic.CompareAndSwapInt32(&m.NotAvailableSpIdx, -1, idx)
 }
 
 func (m *GfSpReplicatePieceTask) EstimateLimit() corercmgr.Limit {

--- a/go.mod
+++ b/go.mod
@@ -123,7 +123,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.3.0 // indirect
 	github.com/golang/glog v1.1.0 // indirect
-	github.com/golang/mock v1.6.0
+	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.1.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aliyun/credentials-go v1.3.0
 	github.com/avast/retry-go/v4 v4.3.1
 	github.com/aws/aws-sdk-go v1.44.159
-	github.com/bnb-chain/greenfield v0.2.6
+	github.com/bnb-chain/greenfield v0.2.6-hf.1
 	github.com/bnb-chain/greenfield-common/go v0.0.0-20230906132736-eb2f0efea228
 	github.com/bytedance/gopkg v0.0.0-20221122125632-68358b8ecec6
 	github.com/cometbft/cometbft v0.37.2
@@ -123,7 +123,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.3.0 // indirect
 	github.com/golang/glog v1.1.0 // indirect
-	github.com/golang/mock v1.6.0 // indirect
+	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.1.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -123,7 +123,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.3.0 // indirect
 	github.com/golang/glog v1.1.0 // indirect
-	github.com/golang/mock v1.6.0 // indirect
+	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816/go.mod h1:+zsy
 github.com/bits-and-blooms/bitset v1.2.0 h1:Kn4yilvwNtMACtf1eYDlG8H77R07mZSPbMjLyS07ChA=
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/bnb-chain/greenfield v0.2.6 h1:U40wmSBQR4Wd0HiVCu/J6zqoLS4YUrvNgyuX71kgK3U=
-github.com/bnb-chain/greenfield v0.2.6/go.mod h1:8kGVzKu3BEbpotk2Lmp/OzPh+nhbMsuUJueZtn0he4s=
+github.com/bnb-chain/greenfield v0.2.6-hf.1 h1:/kxz4RN0HVRb56tF6dvS0tmWcrTx5dDALKVbsv3qXq8=
+github.com/bnb-chain/greenfield v0.2.6-hf.1/go.mod h1:8kGVzKu3BEbpotk2Lmp/OzPh+nhbMsuUJueZtn0he4s=
 github.com/bnb-chain/greenfield-cometbft v0.0.3 h1:tv8NMy3bzX/1urqXGQIIAZSLy83loiI+dG0VKeyh1CY=
 github.com/bnb-chain/greenfield-cometbft v0.0.3/go.mod h1:f35mk/r5ab6yvzlqEWZt68LfUje68sYgMpVlt2CUYMk=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=

--- a/modular/blocksyncer/modules/group/module.go
+++ b/modular/blocksyncer/modules/group/module.go
@@ -2,14 +2,12 @@ package group
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/forbole/juno/v4/models"
 	"github.com/forbole/juno/v4/modules"
 	"gorm.io/gorm/schema"
 
 	"github.com/bnb-chain/greenfield-storage-provider/modular/blocksyncer/database"
-	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
 )
 
 const (
@@ -43,47 +41,7 @@ func (m *Module) PrepareTables() error {
 	return m.db.PrepareTables(context.TODO(), []schema.Tabler{&models.Group{}})
 }
 
-// In this version, we need to create a unique index for the groups table
-// Before creating, we need to remove duplicate data from the table
-// This code will be removed in the next version
-func (m *Module) temporaryFixGroupData() {
-	log.Infof("start fix groups data")
-	exist := m.db.Db.Migrator().HasTable("groups")
-	if !exist {
-		log.Infof("fix groups data success")
-		return
-	}
-	tx := m.db.Db.Begin()
-	err := tx.Exec("CREATE TABLE `groups_temp` LIKE `groups`").Error
-	if err != nil {
-		tx.Rollback()
-		panic(fmt.Sprintf("fix groups data failed err: %v", err))
-	}
-	err = tx.Exec("INSERT INTO `groups_temp` select c1.* FROM `groups` c1 INNER JOIN `groups` c2 WHERE c1.id < c2.id AND c1.account_id = c2.account_id and c1.group_id = c2.group_id order by c1.id").Error
-	if err != nil {
-		tx.Rollback()
-		panic(fmt.Sprintf("fix groups data failed err: %v", err))
-	}
-	err = tx.Exec("delete from `groups` where id in (select id from `groups_temp`)").Error
-	if err != nil {
-		tx.Rollback()
-		panic(fmt.Sprintf("fix groups data failed err: %v", err))
-	}
-	err = tx.Exec("DROP TABLE `groups_temp`").Error
-	if err != nil {
-		tx.Rollback()
-		panic(fmt.Sprintf("fix groups data failed err: %v", err))
-	}
-	err = tx.Commit().Error
-	if err != nil {
-		tx.Rollback()
-		panic(fmt.Sprintf("fix groups data failed err: %v", err))
-	}
-	log.Infof("fix groups data success")
-}
-
 // AutoMigrate implements
 func (m *Module) AutoMigrate() error {
-	m.temporaryFixGroupData()
 	return m.db.AutoMigrate(context.TODO(), []schema.Tabler{&models.Group{}})
 }

--- a/modular/executor/execute_replicate.go
+++ b/modular/executor/execute_replicate.go
@@ -184,7 +184,10 @@ func (e *ExecuteModular) handleReplicatePiece(ctx context.Context, rTask coretas
 	var replicateErr error
 	for {
 		select {
-		case replicateErr = <-errChan:
+		case err = <-errChan:
+			if replicateErr == nil {
+				replicateErr = err
+			}
 			cancel()
 		case <-quitChan:
 			if replicateErr != nil {

--- a/modular/executor/execute_task.go
+++ b/modular/executor/execute_task.go
@@ -46,6 +46,7 @@ var (
 	ErrInvalidRedundancyIndex     = gfsperrors.Register(module.ExecuteModularName, http.StatusInternalServerError, 45212, "invalid redundancy index")
 	ErrSetObjectIntegrity         = gfsperrors.Register(module.ExecuteModularName, http.StatusInternalServerError, 45213, "failed to set object integrity into spdb")
 	ErrInvalidPieceChecksumLength = gfsperrors.Register(module.ExecuteModularName, http.StatusInternalServerError, 45214, "invalid piece checksum length")
+	ErrRecoveryObjectStatus       = gfsperrors.Register(module.ExecuteModularName, http.StatusNotAcceptable, 45215, "the recovered object has not been sealed state")
 )
 
 func ErrGfSpDBWithDetail(detail string) *gfsperrors.GfSpError {
@@ -377,6 +378,11 @@ func (e *ExecuteModular) HandleRecoverPieceTask(ctx context.Context, task coreta
 
 	if task == nil || task.GetObjectInfo() == nil || task.GetStorageParams() == nil {
 		err = ErrDanglingPointer
+		return
+	}
+
+	if task.GetObjectInfo().ObjectStatus != storagetypes.OBJECT_STATUS_SEALED {
+		err = ErrRecoveryObjectStatus
 		return
 	}
 

--- a/modular/gater/admin_handler.go
+++ b/modular/gater/admin_handler.go
@@ -452,7 +452,7 @@ func (g *GateModular) replicateHandler(w http.ResponseWriter, r *http.Request) {
 
 	err = g.checkReplicatePermission(reqCtx.Context(), receiveTask, signatureAddr.String())
 	if err != nil {
-		log.CtxErrorw(reqCtx.Context(), "failed to check the replicate permission", "error", err)
+		log.CtxErrorw(reqCtx.Context(), "failed to check the replicate permission", "object name", receiveTask.ObjectInfo.ObjectName, "error", err)
 		return
 	}
 
@@ -634,6 +634,11 @@ func (g *GateModular) getRecoverDataHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	if chainObjectInfo.ObjectStatus != storagetypes.OBJECT_STATUS_SEALED {
+		err = ErrNotSealedState
+		return
+	}
+
 	redundancyIdx := recoveryTask.EcIdx
 	maxRedundancyIndex := int32(params.GetRedundantParityChunkNum()+params.GetRedundantDataChunkNum()) - 1
 	if redundancyIdx < int32(RecoveryMinEcIndex) || redundancyIdx > maxRedundancyIndex {
@@ -706,7 +711,7 @@ func (g *GateModular) getRecoverPiece(ctx context.Context, objectInfo *storagety
 		sspAddress = append(sspAddress, sp.OperatorAddress)
 	}
 
-	// if myself is secondary, the sender of the request can be both of  the primary SP or the secondary SP of the gvg
+	// if myself is secondary, the sender of the request can be both of the primary SP or the secondary SP of the gvg
 	if primarySp.OperatorAddress != signatureAddr.String() {
 		log.CtxDebug(ctx, "recovery request not come from primary sp", "secondary sp", signatureAddr.String())
 		// judge if the sender is not one of the secondary SP

--- a/modular/gater/errors.go
+++ b/modular/gater/errors.go
@@ -54,9 +54,9 @@ var (
 	ErrReplyData              = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50037, "reply the downloaded data to client failed")
 	ErrTaskMsgExpired         = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50038, "the update time of the task has exceed the expire time")
 	ErrSecondaryMismatch      = gfsperrors.Register(module.GateModularName, http.StatusNotAcceptable, 50039, "secondary sp mismatch")
-	ErrPrimaryMismatch        = gfsperrors.Register(module.GateModularName, http.StatusNotAcceptable, 50040, "primary sp mismatch")
-	ErrNotCreatedState        = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50041, "object has not been created state")
-	ErrNotSealedState         = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50041, "object has not been sealed state")
+	ErrPrimaryMismatch        = gfsperrors.Register(module.GateModularName, http.StatusNotAcceptable, 50041, "primary sp mismatch")
+	ErrNotCreatedState        = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50042, "object has not been created state")
+	ErrNotSealedState         = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50043, "object has not been sealed state")
 )
 
 func ErrEncodeResponseWithDetail(detail string) *gfsperrors.GfSpError {

--- a/modular/gater/errors.go
+++ b/modular/gater/errors.go
@@ -19,7 +19,7 @@ var (
 	ErrDecodeMsg                 = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50005, "gnfd msg encoding error")
 	ErrValidateMsg               = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50006, "gnfd msg validate error")
 	ErrRefuseApproval            = gfsperrors.Register(module.GateModularName, http.StatusOK, 50007, "approval request is refused")
-	ErrUnsupportedRequestType    = gfsperrors.Register(module.GateModularName, http.StatusNotFound, 50008, "unsupported request type")
+	ErrUnsupportedRequestType    = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50008, "unsupported request type")
 	ErrInvalidHeader             = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50009, "invalid request header")
 	ErrInvalidQuery              = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50010, "invalid request params for query")
 	ErrInvalidRange              = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50012, "invalid range params")

--- a/modular/gater/helper_test.go
+++ b/modular/gater/helper_test.go
@@ -8,10 +8,12 @@ import (
 )
 
 const (
-	testDomain     = "www.route-test.com"
-	scheme         = "https://"
-	mockBucketName = "mock-bucket-name"
-	mockObjectName = "mock-object-name"
+	testDomain        = "www.route-test.com"
+	scheme            = "https://"
+	mockBucketName    = "mock-bucket-name"
+	mockObjectName    = "mock-object-name"
+	invalidBucketName = "1"
+	invalidObjectName = ".."
 )
 
 var mockErr = errors.New("mock error")

--- a/modular/gater/metadata_handler.go
+++ b/modular/gater/metadata_handler.go
@@ -1713,7 +1713,7 @@ func (g *GateModular) listObjectsInGVGAndBucketHandler(w http.ResponseWriter, r 
 		return
 	}
 
-	grpcResponse := &types.GfSpListObjectsInGVGResponse{Objects: objects}
+	grpcResponse := &types.GfSpListObjectsInGVGAndBucketResponse{Objects: objects}
 
 	respBytes, err = xml.Marshal(grpcResponse)
 	if err != nil {

--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bnb-chain/greenfield-storage-provider/store/sqldb"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	commonhttp "github.com/bnb-chain/greenfield-common/go/http"
@@ -20,6 +19,7 @@ import (
 	"github.com/bnb-chain/greenfield-storage-provider/modular/metadata"
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/metrics"
+	"github.com/bnb-chain/greenfield-storage-provider/store/sqldb"
 	servicetypes "github.com/bnb-chain/greenfield-storage-provider/store/types"
 	"github.com/bnb-chain/greenfield-storage-provider/util"
 	"github.com/bnb-chain/greenfield/types/s3util"
@@ -680,8 +680,12 @@ func (g *GateModular) queryUploadProgressHandler(w http.ResponseWriter, r *http.
 		taskState, errDescription, err = g.baseApp.GfSpClient().GetUploadObjectState(reqCtx.Context(), objectInfo.Id.Uint64())
 		if err != nil {
 			log.CtxErrorw(reqCtx.Context(), "failed to get uploading job state", "error", err)
+			if !strings.Contains(err.Error(), "no uploading record") {
+				return
+			}
 			taskState = int32(servicetypes.TaskState_TASK_STATE_INIT_UNSPECIFIED)
 			taskStateDescription = servicetypes.StateToDescription(servicetypes.TaskState(taskState))
+			err = nil
 		} else {
 			taskStateDescription = servicetypes.StateToDescription(servicetypes.TaskState(taskState))
 		}

--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -813,7 +813,7 @@ func (g *GateModular) getObjectByUniversalEndpointHandler(w http.ResponseWriter,
 			return
 		}
 
-		redirectURL = spEndpoint + r.RequestURI
+		redirectURL = spEndpoint + r.URL.RequestURI()
 		log.Debugw("getting redirect url:", "redirectURL", redirectURL)
 
 		http.Redirect(w, r, redirectURL, 302)
@@ -838,11 +838,13 @@ func (g *GateModular) getObjectByUniversalEndpointHandler(w http.ResponseWriter,
 			expiry    string
 			signature string
 		)
-		splitPeriod := strings.Split(r.RequestURI, ".")
+		requestURI := r.URL.RequestURI()
+
+		splitPeriod := strings.Split(requestURI, ".")
 		splitSuffix := splitPeriod[len(splitPeriod)-1]
-		if !strings.Contains(r.RequestURI, objectSpecialSuffixUrlReplacement) &&
+		if !strings.Contains(requestURI, objectSpecialSuffixUrlReplacement) &&
 			(strings.EqualFold(splitSuffix, ObjectPdfSuffix) || strings.EqualFold(splitSuffix, ObjectXmlSuffix)) {
-			objectPathRequestURL := "/" + strings.Replace(r.RequestURI[1:], "/", objectSpecialSuffixUrlReplacement, 1)
+			objectPathRequestURL := "/" + strings.Replace(requestURI[1:], "/", objectSpecialSuffixUrlReplacement, 1)
 			redirectURL = spEndpoint + objectPathRequestURL
 			log.Debugw("getting redirect url for private object:", "redirectURL", redirectURL)
 			http.Redirect(w, r, redirectURL, 302)
@@ -907,6 +909,8 @@ func (g *GateModular) getObjectByUniversalEndpointHandler(w http.ResponseWriter,
 				"greenfield_7971-1":    "{\n  \"envType\": \"dev\",\n  \"signedMsg\": \"Sign this message to access the file:\\n$1\\nThis signature will not cost you any fees.\\nExpiration Time: $2\",\n  \"chainId\": 7971,\n  \"chainName\": \"dev - greenfield\",\n  \"rpcUrls\": [\"https://gnfd-dev.qa.bnbchain.world\"],\n  \"nativeCurrency\": { \"name\": \"BNB\", \"symbol\": \"BNB\", \"decimals\": 18 },\n  \"blockExplorerUrls\": [\"https://greenfieldscan-qanet.fe.nodereal.cc/\"]\n}\n",
 				"greenfield_9000-1741": "{\n  \"envType\": \"qa\",\n  \"signedMsg\": \"Sign this message to access the file:\\n$1\\nThis signature will not cost you any fees.\\nExpiration Time: $2\",\n  \"chainId\": 9000,\n  \"chainName\": \"qa - greenfield\",\n  \"rpcUrls\": [\"https://gnfd.qa.bnbchain.world\"],\n  \"nativeCurrency\": { \"name\": \"BNB\", \"symbol\": \"BNB\", \"decimals\": 18 },\n  \"blockExplorerUrls\": [\"https://greenfieldscan-qanet.fe.nodereal.cc/\"]\n}\n",
 				"greenfield_5600-1":    "{\n  \"envType\": \"testnet\",\n  \"signedMsg\": \"Sign this message to access the file:\\n$1\\nThis signature will not cost you any fees.\\nExpiration Time: $2\",\n  \"chainId\": 5600,\n  \"chainName\": \"greenfield testnet\",\n  \"rpcUrls\": [\"https://gnfd-testnet-fullnode-tendermint-us.bnbchain.org\"],\n  \"nativeCurrency\": { \"name\": \"BNB\", \"symbol\": \"BNB\", \"decimals\": 18 },\n  \"blockExplorerUrls\": [\"https://greenfieldscan.com/\"]\n}\n",
+				"greenfield_920-1":     "{\n  \"envType\": \"pre-mainnet\",\n  \"signedMsg\": \"Sign this message to access the file:\\n$1\\nThis signature will not cost you any fees.\\nExpiration Time: $2\",\n  \"chainId\": 920,\n  \"chainName\": \"greenfield pre-main-net\",\n  \"rpcUrls\": [\"https://greenfield-chain.bnbchain.org\"],\n  \"nativeCurrency\": { \"name\": \"BNB\", \"symbol\": \"BNB\", \"decimals\": 18 },\n  \"blockExplorerUrls\": [\"https://greenfieldscan.com/\"]\n}\n",
+				"greenfield_1017-1":    "{\n  \"envType\": \"mainnet\",\n  \"signedMsg\": \"Sign this message to access the file:\\n$1\\nThis signature will not cost you any fees.\\nExpiration Time: $2\",\n  \"chainId\": 1017,\n  \"chainName\": \"greenfield main-net\",\n  \"rpcUrls\": [\"https://greenfield-chain.bnbchain.org\"],\n  \"nativeCurrency\": { \"name\": \"BNB\", \"symbol\": \"BNB\", \"decimals\": 18 },\n  \"blockExplorerUrls\": [\"https://greenfieldscan.com/\"]\n}\n",
 			}
 
 			htmlConfig := htmlConfigMap[g.baseApp.ChainID()]

--- a/modular/manager/bucket_migrate_scheduler.go
+++ b/modular/manager/bucket_migrate_scheduler.go
@@ -974,7 +974,7 @@ func (c *BucketCache) removeElement(e *list.Element) {
 	if c.expiration > 0 {
 		for i, se := range c.ttlIndex {
 			if se == e {
-				//delete
+				// delete
 				copy(c.ttlIndex[i:], c.ttlIndex[i+1:])
 				c.ttlIndex[len(c.ttlIndex)-1] = nil
 				c.ttlIndex = c.ttlIndex[:len(c.ttlIndex)-1]

--- a/modular/manager/manage_task.go
+++ b/modular/manager/manage_task.go
@@ -142,7 +142,6 @@ func (m *ManageModular) pickGVGAndReplicate(ctx context.Context, vgfID uint32, t
 	if err != nil {
 		return err
 	}
-
 	replicateTask := &gfsptask.GfSpReplicatePieceTask{}
 	replicateTask.InitReplicatePieceTask(task.GetObjectInfo(), task.GetStorageParams(),
 		m.baseApp.TaskPriority(replicateTask),

--- a/modular/manager/manage_task.go
+++ b/modular/manager/manage_task.go
@@ -89,8 +89,13 @@ func (m *ManageModular) HandleCreateUploadObjectTask(ctx context.Context, task t
 		return err
 	}
 	if err := m.baseApp.GfSpDB().InsertUploadProgress(task.GetObjectInfo().Id.Uint64()); err != nil {
-		log.CtxErrorw(ctx, "failed to create upload object progress", "task_info", task.Info(), "error", err)
-		return ErrGfSpDBWithDetail("failed to create upload object progress, task_info: " + task.Info() + ", error: " + err.Error())
+		if strings.Contains(err.Error(), "Duplicate entry") {
+			log.Infow("insert upload progress with duplicate entry", "task_info", task.Info())
+			return nil
+		} else {
+			log.CtxErrorw(ctx, "failed to create upload object progress", "task_info", task.Info(), "error", err)
+			return ErrGfSpDBWithDetail("failed to create upload object progress, task_info: " + task.Info() + ", error: " + err.Error())
+		}
 	}
 	return nil
 }

--- a/modular/metadata/metadata_bucket_service.go
+++ b/modular/metadata/metadata_bucket_service.go
@@ -265,7 +265,7 @@ func (r *MetadataModular) GfSpGetBucketMeta(ctx context.Context, req *types.GfSp
 	bucketFullMeta, err := r.baseApp.GfBsDB().GetBucketMetaByName(req.GetBucketName(), req.GetIncludePrivate())
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get bucket meta by name", "error", err)
-		if systemerrors.Is(err, gorm.ErrRecordNotFound) {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNoSuchBucket
 		}
 		return

--- a/modular/metadata/metadata_bucket_service.go
+++ b/modular/metadata/metadata_bucket_service.go
@@ -2,7 +2,7 @@ package metadata
 
 import (
 	"context"
-	systemerrors "errors"
+	"errors"
 	"net/http"
 	"sync/atomic"
 
@@ -36,9 +36,7 @@ func ErrGfSpDBWithDetail(detail string) *gfsperrors.GfSpError {
 	return gfsperrors.Register(coremodule.MetadataModularName, http.StatusInternalServerError, 95202, detail)
 }
 
-func (r *MetadataModular) GfSpGetUserBuckets(
-	ctx context.Context,
-	req *types.GfSpGetUserBucketsRequest) (
+func (r *MetadataModular) GfSpGetUserBuckets(ctx context.Context, req *types.GfSpGetUserBucketsRequest) (
 	resp *types.GfSpGetUserBucketsResponse, err error) {
 	ctx = log.Context(ctx, req)
 	buckets, err := r.baseApp.GfBsDB().GetUserBuckets(common.HexToAddress(req.AccountId), req.GetIncludeRemoved())
@@ -149,7 +147,8 @@ func (r *MetadataModular) GfSpGetBucketByBucketName(ctx context.Context, req *ty
 }
 
 // GfSpGetBucketByBucketID get buckets info by by a bucket id
-func (r *MetadataModular) GfSpGetBucketByBucketID(ctx context.Context, req *types.GfSpGetBucketByBucketIDRequest) (resp *types.GfSpGetBucketByBucketIDResponse, err error) {
+func (r *MetadataModular) GfSpGetBucketByBucketID(ctx context.Context, req *types.GfSpGetBucketByBucketIDRequest) (
+	resp *types.GfSpGetBucketByBucketIDResponse, err error) {
 	var (
 		bucket *model.Bucket
 		res    *types.Bucket
@@ -192,7 +191,8 @@ func (r *MetadataModular) GfSpGetBucketByBucketID(ctx context.Context, req *type
 }
 
 // GfSpGetUserBucketsCount get buckets count by a user address
-func (r *MetadataModular) GfSpGetUserBucketsCount(ctx context.Context, req *types.GfSpGetUserBucketsCountRequest) (resp *types.GfSpGetUserBucketsCountResponse, err error) {
+func (r *MetadataModular) GfSpGetUserBucketsCount(ctx context.Context, req *types.GfSpGetUserBucketsCountRequest) (
+	resp *types.GfSpGetUserBucketsCountResponse, err error) {
 	ctx = log.Context(ctx, req)
 
 	count, err := r.baseApp.GfBsDB().GetUserBucketsCount(common.HexToAddress(req.AccountId), req.GetIncludeRemoved())
@@ -207,7 +207,8 @@ func (r *MetadataModular) GfSpGetUserBucketsCount(ctx context.Context, req *type
 }
 
 // GfSpListExpiredBucketsBySp list expired bucket by sp
-func (r *MetadataModular) GfSpListExpiredBucketsBySp(ctx context.Context, req *types.GfSpListExpiredBucketsBySpRequest) (resp *types.GfSpListExpiredBucketsBySpResponse, err error) {
+func (r *MetadataModular) GfSpListExpiredBucketsBySp(ctx context.Context, req *types.GfSpListExpiredBucketsBySpRequest) (
+	resp *types.GfSpListExpiredBucketsBySpResponse, err error) {
 	ctx = log.Context(ctx, req)
 	buckets, err := r.baseApp.GfBsDB().ListExpiredBucketsBySp(req.GetCreateAt(), req.GetPrimarySpId(), req.GetLimit())
 	if err != nil {
@@ -241,9 +242,7 @@ func (r *MetadataModular) GfSpListExpiredBucketsBySp(ctx context.Context, req *t
 }
 
 // GfSpGetBucketMeta get bucket metadata
-func (r *MetadataModular) GfSpGetBucketMeta(
-	ctx context.Context,
-	req *types.GfSpGetBucketMetaRequest) (
+func (r *MetadataModular) GfSpGetBucketMeta(ctx context.Context, req *types.GfSpGetBucketMetaRequest) (
 	resp *types.GfSpGetBucketMetaResponse, err error) {
 	var (
 		bucket          *model.Bucket
@@ -334,7 +333,7 @@ func (r *MetadataModular) GfSpGetBucketReadQuota(
 		req.GetBucketInfo().Id.Uint64(), req.YearMonth)
 	if err != nil {
 		// if the traffic table has not been created and initialized yet, return the chain info
-		if systemerrors.Is(err, gorm.ErrRecordNotFound) || bucketTraffic == nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) || bucketTraffic == nil {
 			var freeQuotaSize uint64
 			freeQuotaSize, err = r.baseApp.Consensus().QuerySPFreeQuota(ctx, r.baseApp.OperatorAddress())
 			if err != nil {
@@ -387,7 +386,7 @@ func (r *MetadataModular) GfSpListBucketReadRecord(
 			EndTimestampUs:   req.EndTimestampUs,
 			LimitNum:         int(req.MaxRecordNum),
 		})
-	if systemerrors.Is(err, gorm.ErrRecordNotFound) {
+	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return &types.GfSpListBucketReadRecordResponse{
 			NextStartTimestampUs: 0,
 		}, nil
@@ -422,7 +421,8 @@ func (r *MetadataModular) GfSpListBucketReadRecord(
 }
 
 // GfSpListBucketsByIDs list buckets by bucket ids
-func (r *MetadataModular) GfSpListBucketsByIDs(ctx context.Context, req *types.GfSpListBucketsByIDsRequest) (resp *types.GfSpListBucketsByIDsResponse, err error) {
+func (r *MetadataModular) GfSpListBucketsByIDs(ctx context.Context, req *types.GfSpListBucketsByIDsRequest) (
+	resp *types.GfSpListBucketsByIDsResponse, err error) {
 	var (
 		buckets    []*model.Bucket
 		ids        []common.Hash

--- a/modular/metadata/metadata_permission_service.go
+++ b/modular/metadata/metadata_permission_service.go
@@ -23,19 +23,6 @@ import (
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 )
 
-var (
-	// ErrInvalidParams defines invalid params
-	ErrInvalidParams = errors.New("invalid params")
-	// ErrInvalidBucketName defines invalid bucket name
-	ErrInvalidBucketName = errors.New("invalid bucket name")
-	// ErrNoSuchBucket defines not existed bucket error
-	ErrNoSuchBucket = errors.New("the specified bucket does not exist")
-	// ErrNoSuchGroup defines not existed group error
-	ErrNoSuchGroup = errors.New("the specified group does not exist")
-	// ErrNoSuchObject defines not existed object error
-	ErrNoSuchObject = errors.New("the specified key does not exist")
-)
-
 // GfSpVerifyPermission Verify the input account’s permission to input items
 func (r *MetadataModular) GfSpVerifyPermission(ctx context.Context, req *storagetypes.QueryVerifyPermissionRequest) (resp *storagetypes.QueryVerifyPermissionResponse, err error) {
 	var (
@@ -55,7 +42,7 @@ func (r *MetadataModular) GfSpVerifyPermission(ctx context.Context, req *storage
 	operator, err = sdk.AccAddressFromHexUnsafe(req.Operator)
 	if err != nil && err != sdk.ErrEmptyHexAddress {
 		log.CtxErrorw(ctx, "failed to creates an AccAddress from a HEX-encoded string", "req.Operator", operator.String(), "error", err)
-		return nil, err
+		return nil, ErrInvalidParams
 	}
 
 	if err = s3util.CheckValidBucketName(req.BucketName); err != nil {
@@ -249,7 +236,7 @@ func (r *MetadataModular) VerifyBucketPermission(ctx context.Context, bucketInfo
 	owner, err = sdk.AccAddressFromHexUnsafe(bucketInfo.Owner.String())
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to creates an AccAddress from a HEX-encoded string", "bucketInfo.Owner.String()", bucketInfo.Owner.String(), "error", err)
-		return permtypes.EFFECT_DENY, err
+		return permtypes.EFFECT_DENY, ErrInvalidParams
 	}
 
 	// the owner has full permissions

--- a/modular/metadata/metadata_query_service.go
+++ b/modular/metadata/metadata_query_service.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"gorm.io/gorm"
 
@@ -13,10 +14,8 @@ func (r *MetadataModular) GfSpQueryUploadProgress(ctx context.Context, req *type
 	*types.GfSpQueryUploadProgressResponse, error) {
 	state, errDescription, err := r.baseApp.GfSpDB().GetUploadState(req.GetObjectId())
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return &types.GfSpQueryUploadProgressResponse{
-				Err: ErrNoRecord,
-			}, nil
+		if strings.Contains(err.Error(), gorm.ErrRecordNotFound.Error()) {
+			return &types.GfSpQueryUploadProgressResponse{Err: ErrNoRecord}, nil
 		}
 		return &types.GfSpQueryUploadProgressResponse{
 			Err: ErrGfSpDBWithDetail("GfSpQueryUploadProgress error:" + err.Error()),

--- a/modular/receiver/receive_task.go
+++ b/modular/receiver/receive_task.go
@@ -45,6 +45,7 @@ func (r *ReceiveModular) HandleReceivePieceTask(ctx context.Context, task task.R
 	if r.receiveQueue.Has(task.Key()) {
 		metrics.PerfReceivePieceTimeHistogram.WithLabelValues("receive_piece_server_check_has_time").Observe(time.Since(checkHasTime).Seconds())
 		log.CtxErrorw(ctx, "has repeat receive task", "task", task)
+		err = ErrRepeatedTask
 		return ErrRepeatedTask
 	}
 	metrics.PerfReceivePieceTimeHistogram.WithLabelValues("receive_piece_server_check_has_time").Observe(time.Since(checkHasTime).Seconds())
@@ -60,6 +61,7 @@ func (r *ReceiveModular) HandleReceivePieceTask(ctx context.Context, task task.R
 	checksum := hash.GenerateChecksum(data)
 	if !bytes.Equal(checksum, task.GetPieceChecksum()) {
 		log.CtxErrorw(ctx, "failed to compare checksum", "task", task, "actual_checksum", checksum, "expected_checksum", task.GetPieceChecksum())
+		err = ErrInvalidDataChecksum
 		return ErrInvalidDataChecksum
 	}
 

--- a/modular/signer/signer_client.go
+++ b/modular/signer/signer_client.go
@@ -803,7 +803,7 @@ func (client *GreenfieldChainSignClient) broadcastTx(ctx context.Context, gnfdCl
 		return "", sdkErrors.ErrWrongSequence
 	}
 	if resp.TxResponse.Code != 0 {
-		return "", fmt.Errorf("failed to broadcast tx, resp code: %d", resp.TxResponse.Code)
+		return "", fmt.Errorf("failed to broadcast tx, resp code: %d, code space: %s", resp.TxResponse.Code, resp.TxResponse.Codespace)
 	}
 	return resp.TxResponse.TxHash, nil
 }

--- a/pkg/middleware/http/ratelimiter.go
+++ b/pkg/middleware/http/ratelimiter.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"encoding/xml"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -9,10 +10,20 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsperrors"
+
 	slimiter "github.com/ulule/limiter/v3"
 	smemory "github.com/ulule/limiter/v3/drivers/store/memory"
 
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
+)
+
+const (
+	Middleware = "Middleware"
+)
+
+var (
+	ErrTooManyRequest = gfsperrors.Register(Middleware, http.StatusTooManyRequests, 960001, "too many requests, please try it again later")
 )
 
 type RateLimiterCell struct {
@@ -181,19 +192,36 @@ func (t *apiLimiter) HTTPAllow(ctx context.Context, r *http.Request) bool {
 func Limit(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !limiter.Allow(context.Background(), r) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusTooManyRequests)
+			MakeLimitErrorResponse(w, ErrTooManyRequest)
 			return
 		}
-
 		if !limiter.HTTPAllow(context.Background(), r) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusTooManyRequests)
+			MakeLimitErrorResponse(w, ErrTooManyRequest)
 			return
 		}
-
 		next.ServeHTTP(w, r)
 	})
+}
+
+func MakeLimitErrorResponse(w http.ResponseWriter, err error) {
+	gfspErr := gfsperrors.MakeGfSpError(err)
+	var xmlInfo = struct {
+		XMLName xml.Name `xml:"Error"`
+		Code    int32    `xml:"Code"`
+		Message string   `xml:"Message"`
+	}{
+		Code:    gfspErr.GetInnerCode(),
+		Message: gfspErr.GetDescription(),
+	}
+	xmlBody, err := xml.Marshal(&xmlInfo)
+	if err != nil {
+		log.Errorw("failed to marshal error response", "gfsp_error", gfspErr.String(), "error", err)
+	}
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(int(gfspErr.GetHttpStatusCode()))
+	if _, err = w.Write(xmlBody); err != nil {
+		log.Errorw("failed to write error response", "gfsp_error", gfspErr.String(), "error", err)
+	}
 }
 
 // GetIP gets a requests IP address by reading off the forwarded-for

--- a/store/sqldb/upload_object.go
+++ b/store/sqldb/upload_object.go
@@ -23,6 +23,7 @@ func (s *SpDBImpl) InsertUploadProgress(objectID uint64) error {
 	}
 	return nil
 }
+
 func (s *SpDBImpl) DeleteUploadProgress(objectID uint64) error {
 	return s.db.Delete(&UploadObjectProgressTable{
 		ObjectID: objectID, // should be the primary key
@@ -61,7 +62,8 @@ func (s *SpDBImpl) GetUploadState(objectID uint64) (storetypes.TaskState, string
 	queryReturn := &UploadObjectProgressTable{}
 	result := s.db.First(queryReturn, "object_id = ?", objectID)
 	if result.Error != nil {
-		return storetypes.TaskState_TASK_STATE_INIT_UNSPECIFIED, "failed to query upload table", fmt.Errorf("failed to query upload table: %s", result.Error)
+		return storetypes.TaskState_TASK_STATE_INIT_UNSPECIFIED, "failed to query upload table", fmt.Errorf(
+			"failed to query upload table: %s", result.Error)
 	}
 	return storetypes.TaskState(queryReturn.TaskState), queryReturn.ErrorDescription, nil
 }

--- a/test/e2e/spworkflow/e2e_test.sh
+++ b/test/e2e/spworkflow/e2e_test.sh
@@ -6,11 +6,11 @@ export CGO_CFLAGS_ALLOW="-O -D__BLST_PORTABLE__"
 workspace=${GITHUB_WORKSPACE}
 
 # some constants
-GREENFIELD_TAG="v0.2.6"
+GREENFIELD_TAG="v0.2.6-hf.1"
 # greenfield cmd tag name: v0.1.0
 GREENFIELD_CMD_TAG="v0.1.0"
-# greenfield go sdk tag name: v0.2.5-alpha.1
-GREENFIELD_GO_SDK_TAG="v0.2.5-alpha.1"
+# greenfield go sdk tag name: v0.2.6
+GREENFIELD_GO_SDK_TAG="v0.2.6"
 MYSQL_USER="root"
 MYSQL_PASSWORD="root"
 MYSQL_ADDRESS="127.0.0.1:3306"


### PR DESCRIPTION
### Description

This release contains several bugfix.

### Rationale

BUGFIX
* [#1166](https://github.com/bnb-chain/greenfield-storage-provider/pull/1166) fix: delete group fix job
* [#1160](https://github.com/bnb-chain/greenfield-storage-provider/pull/1160) fix: fix replication failed SP err recording issue
* [#1159](https://github.com/bnb-chain/greenfield-storage-provider/pull/1159) fix: list objects by gvg sql bug
* [#1165](https://github.com/bnb-chain/greenfield-storage-provider/pull/1165) fix: verify permission 500 code and update UT
* [#1155](https://github.com/bnb-chain/greenfield-storage-provider/pull/1155) fix: fix manager duplicate entry when inserting upload progress
* [#1158](https://github.com/bnb-chain/greenfield-storage-provider/pull/1158) fix: add xml response for rate limit error
* [#1156](https://github.com/bnb-chain/greenfield-storage-provider/pull/1156) fix: recovery object status should be sealed
* [#1154](https://github.com/bnb-chain/greenfield-storage-provider/pull/1154) fix: add ut for universal endpoint


### Example

N/A

### Changes

Notable changes: 
* N/A
