### PR TITLE
fix: skip error when object is deleted

### DIFF
--- a/modular/executor/migrate_task.go
+++ b/modular/executor/migrate_task.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/bnb-chain/greenfield-common/go/hash"
@@ -73,7 +74,7 @@ func (e *ExecuteModular) HandleMigrateGVGTask(ctx context.Context, gvgTask coret
 				log.CtxErrorw(ctx, "failed to check and renew gvg task signature", "gvg_task", gvgTask, "error", err)
 				return
 			}
-			if err = e.doObjectMigration(ctx, gvgTask, bucketID, object); err != nil && !e.IsSkipFailedToMigrateObject(ctx, object) {
+			if err = e.doObjectMigration(ctx, gvgTask, bucketID, object); err != nil && !e.isSkipFailedToMigrateObject(ctx, object) {
 				log.CtxErrorw(ctx, "failed to do migration gvg task", "gvg_id", srcGvgID,
 					"bucket_id", bucketID, "object_info", object,
 					"enable_skip_failed_to_migrate_object", e.enableSkipFailedToMigrateObject, "error", err)
@@ -416,17 +417,21 @@ func (e *ExecuteModular) setMigratePiecesMetadata(objectInfo *storagetypes.Objec
 	return nil
 }
 
-// IsSkipFailedToMigrateObject Incorrect migration can be an expected error, errors will be ignored.
+// isSkipFailedToMigrateObject incorrect migration can be an expected error, errors will be ignored.
 // such as: 1) deletion of objects during migration, or 2) the enableSkipFailedToMigrateObject parameter being set.
-func (e *ExecuteModular) IsSkipFailedToMigrateObject(ctx context.Context, objectDetails *metadatatypes.ObjectDetails) bool {
-	// check chain object whether exist
-	objectInfo, err := e.baseApp.Consensus().QueryObjectInfo(ctx, objectDetails.GetObject().GetObjectInfo().GetBucketName(), objectDetails.GetObject().GetObjectInfo().GetObjectName())
-	if err != nil && err == storagetypes.ErrNoSuchObject {
-		log.CtxDebugw(ctx, "failed to get object info from consensus, the object may be deleted", "object", objectInfo, "error", err)
-		return true
-	}
+func (e *ExecuteModular) isSkipFailedToMigrateObject(ctx context.Context, objectDetails *metadatatypes.ObjectDetails) bool {
 	if e.enableSkipFailedToMigrateObject {
 		return true
 	}
+	// if the object do not exist on chain, should ignore the error
+	objectInfo, err := e.baseApp.Consensus().QueryObjectInfo(ctx, objectDetails.GetObject().GetObjectInfo().GetBucketName(), objectDetails.GetObject().GetObjectInfo().GetObjectName())
+	if err != nil {
+		if strings.Contains(err.Error(), "No such object") {
+			log.CtxErrorw(ctx, "failed to get object info from consensus, the object may be deleted", "object", objectInfo, "error", err)
+			return true
+		}
+		return false
+	}
+
 	return false
 }


### PR DESCRIPTION
### Description

The current design restricts users from uploading new objects during bucket migration. Nevertheless, users retain the capability to update and delete objects through direct interactions with the on-chain interface. It's important to note that performing deletions during bucket migration can potentially result in migration task failures.


### Rationale

In cases where a migrate task does fail, the system performs a check on the chain to verify the status of objects involved. If an object is found to be nonexistent, the system will gracefully handle the error by ignoring it.

### Example

NA

### Changes

Notable changes: 
* NA
* ...
