### PR TITLE
release: release for v0.2.6-hf.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.2.6-hf.2
+BUGFIX
+* [#1171](https://github.com/bnb-chain/greenfield-storage-provider/pull/1171) fix: fix init the NotAvailableSpIdx
 
 ## v0.2.6-hf.1
 

--- a/base/types/gfsptask/upload.go
+++ b/base/types/gfsptask/upload.go
@@ -341,7 +341,7 @@ func (m *GfSpReplicatePieceTask) InitReplicatePieceTask(object *storagetypes.Obj
 	m.SetPriority(priority)
 	m.SetTimeout(timeout)
 	m.SetMaxRetry(retry)
-	m.SetNotAvailableSpIdx(-1)
+	m.NotAvailableSpIdx = -1
 }
 
 func (m *GfSpReplicatePieceTask) Key() coretask.TKey {

--- a/go.mod
+++ b/go.mod
@@ -123,7 +123,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.3.0 // indirect
 	github.com/golang/glog v1.1.0 // indirect
-	github.com/golang/mock v1.6.0
+	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.1.2 // indirect


### PR DESCRIPTION
### Description

This release contains 1 bugfix.

### Rationale

BUGFIX
* [#1171](https://github.com/bnb-chain/greenfield-storage-provider/pull/1171) fix: fix init the NotAvailableSpIdx

### Example

N/A

### Changes

Notable changes: 
* N/A
