### PR TITLE
docs: release: draft release for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.0.0
+This is the first official version for the main-net deployment.
+
 ## v0.2.6-hf.2
 BUGFIX
 * [#1171](https://github.com/bnb-chain/greenfield-storage-provider/pull/1171) fix: fix init the NotAvailableSpIdx

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aliyun/credentials-go v1.3.0
 	github.com/avast/retry-go/v4 v4.3.1
 	github.com/aws/aws-sdk-go v1.44.159
-	github.com/bnb-chain/greenfield v0.2.6-hf.1
+	github.com/bnb-chain/greenfield v1.0.0
 	github.com/bnb-chain/greenfield-common/go v0.0.0-20230906132736-eb2f0efea228
 	github.com/bytedance/gopkg v0.0.0-20221122125632-68358b8ecec6
 	github.com/cometbft/cometbft v0.37.2
@@ -123,7 +123,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.3.0 // indirect
 	github.com/golang/glog v1.1.0 // indirect
-	github.com/golang/mock v1.6.0 // indirect
+	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816/go.mod h1:+zsy
 github.com/bits-and-blooms/bitset v1.2.0 h1:Kn4yilvwNtMACtf1eYDlG8H77R07mZSPbMjLyS07ChA=
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/bnb-chain/greenfield v0.2.6-hf.1 h1:/kxz4RN0HVRb56tF6dvS0tmWcrTx5dDALKVbsv3qXq8=
-github.com/bnb-chain/greenfield v0.2.6-hf.1/go.mod h1:8kGVzKu3BEbpotk2Lmp/OzPh+nhbMsuUJueZtn0he4s=
+github.com/bnb-chain/greenfield v1.0.0 h1:eg8jFKfbM8ZBKYJ40MZvZtJMtbIcM17tnd7OvAoMC7g=
+github.com/bnb-chain/greenfield v1.0.0/go.mod h1:HAUcv20wBECrbyvVvtoAgvpeedr6plgz3m75FJ7Xxdg=
 github.com/bnb-chain/greenfield-cometbft v0.0.3 h1:tv8NMy3bzX/1urqXGQIIAZSLy83loiI+dG0VKeyh1CY=
 github.com/bnb-chain/greenfield-cometbft v0.0.3/go.mod h1:f35mk/r5ab6yvzlqEWZt68LfUje68sYgMpVlt2CUYMk=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=

--- a/test/e2e/spworkflow/e2e_test.sh
+++ b/test/e2e/spworkflow/e2e_test.sh
@@ -6,11 +6,11 @@ export CGO_CFLAGS_ALLOW="-O -D__BLST_PORTABLE__"
 workspace=${GITHUB_WORKSPACE}
 
 # some constants
-GREENFIELD_TAG="v0.2.6-hf.1"
+GREENFIELD_TAG="v1.0.0"
 # greenfield cmd tag name: v0.1.0
 GREENFIELD_CMD_TAG="v0.1.0"
-# greenfield go sdk tag name: v0.2.6
-GREENFIELD_GO_SDK_TAG="v0.2.6"
+# greenfield go sdk tag name: v1.0.0
+GREENFIELD_GO_SDK_TAG="v1.0.0"
 MYSQL_USER="root"
 MYSQL_PASSWORD="root"
 MYSQL_ADDRESS="127.0.0.1:3306"


### PR DESCRIPTION
### Description

release: draft release for v1.0.0

### Rationale

NO changes since last release v0.2.6-hf.2, but make it as the first official version for the main-net deployment

### Example

N/A

### Changes

Notable changes: 
* N/A
