### PR TITLE
fix: add challenge v2 api to avoid piece hash http header too large

### DIFF
--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -2,7 +2,7 @@ name: Docker-CI
 
 on:
   push:
-    branches: [ develop,master ]
+    branches: [ develop, master ]
 
 env:
   IMAGE_NAME: ghcr.io/bnb-chain/greenfield-storage-provider-invisible

--- a/modular/gater/const.go
+++ b/modular/gater/const.go
@@ -198,6 +198,8 @@ const (
 	OffChainAuthViewQuery = "view"
 	// GetChallengeInfoPath defines get challenge info path style suffix
 	GetChallengeInfoPath = "/greenfield/admin/v1/challenge"
+	// GetChallengeInfoV2Path defines get challenge info path style suffix
+	GetChallengeInfoV2Path = "/greenfield/admin/v2/challenge"
 	// ReplicateObjectPiecePath defines replicate-object path style
 	ReplicateObjectPiecePath = "/greenfield/receiver/v1/replicate-piece"
 	// RecoverObjectPiecePath defines recovery-object path style

--- a/modular/gater/router.go
+++ b/modular/gater/router.go
@@ -18,6 +18,7 @@ const (
 	queryResumeOffsetName                          = "QueryResumeOffsetName"
 	getObjectRouterName                            = "GetObject"
 	getChallengeInfoRouterName                     = "GetChallengeInfo"
+	getChallengeInfoV2RouterName                   = "GetChallengeInfoV2"
 	replicateObjectPieceRouterName                 = "ReplicateObjectPiece"
 	getUserBucketsRouterName                       = "GetUserBuckets"
 	listObjectsByBucketRouterName                  = "ListObjectsByBucketName"
@@ -104,6 +105,7 @@ func (g *GateModular) RegisterHandler(router *mux.Router) {
 
 	// get challenge info
 	router.Path(GetChallengeInfoPath).Name(getChallengeInfoRouterName).Methods(http.MethodGet).HandlerFunc(g.getChallengeInfoHandler)
+	router.Path(GetChallengeInfoV2Path).Name(getChallengeInfoV2RouterName).Methods(http.MethodGet).HandlerFunc(g.getChallengeInfoV2Handler)
 
 	// replicate piece to receiver
 	router.Path(ReplicateObjectPiecePath).Name(replicateObjectPieceRouterName).Methods(http.MethodPut).HandlerFunc(g.replicateHandler)

--- a/modular/gater/router_test.go
+++ b/modular/gater/router_test.go
@@ -273,6 +273,14 @@ func TestRouters(t *testing.T) {
 			wantedRouterName: getChallengeInfoRouterName,
 		},
 		{
+			name:             "Challenge router v2",
+			router:           gwRouter,
+			method:           http.MethodGet,
+			url:              fmt.Sprintf("%s%s%s", scheme, testDomain, GetChallengeInfoV2Path),
+			shouldMatch:      true,
+			wantedRouterName: getChallengeInfoV2RouterName,
+		},
+		{
 			name:             "Replicate router",
 			router:           gwRouter,
 			method:           http.MethodPut,


### PR DESCRIPTION
### Description

Add challenge v2 API to avoid piece hash HTTP header too large.

### Rationale

Components such as nginx can disconnect because the response header is too large, and users receive a 502 HTTP status code.

### Example

N/A.

### Changes

Notable changes: 
* Gateway add new challenge API v2.
