### PR TITLE
feat: add golang runtime metrics, process metrics and std lib db metrics

### DIFF
--- a/base/gfspapp/app_options.go
+++ b/base/gfspapp/app_options.go
@@ -256,6 +256,13 @@ func DefaultGfSpDBOption(app *GfSpBaseApp, cfg *gfspconfig.GfSpConfig) error {
 				return
 			}
 			app.gfSpDB = db
+
+			collector, err := db.RegisterStdDBStats()
+			if err != nil {
+				log.Errorw("failed to register db stats metrics", "error", err)
+				return
+			}
+			metrics.AddMetrics(collector)
 		})
 	}
 	return nil

--- a/base/gfspapp/app_options.go
+++ b/base/gfspapp/app_options.go
@@ -255,7 +255,6 @@ func DefaultGfSpDBOption(app *GfSpBaseApp, cfg *gfspconfig.GfSpConfig) error {
 				log.Panicw("failed to new spdb", "error", err)
 				return
 			}
-			app.gfSpDB = db
 
 			collector, err := db.RegisterStdDBStats()
 			if err != nil {
@@ -263,6 +262,8 @@ func DefaultGfSpDBOption(app *GfSpBaseApp, cfg *gfspconfig.GfSpConfig) error {
 				return
 			}
 			metrics.AddMetrics(collector)
+
+			app.gfSpDB = db
 		})
 	}
 	return nil

--- a/pkg/metrics/metric_items.go
+++ b/pkg/metrics/metric_items.go
@@ -11,10 +11,14 @@ import (
 )
 
 var MetricsItems = []prometheus.Collector{
-	// Grpc metrics category
+	// gRPC and HTTP metrics category
 	DefaultGRPCServerMetrics,
 	DefaultGRPCClientMetrics,
 	DefaultHTTPServerMetrics,
+
+	// golang runtime and process metrics
+	GolangRuntimeMetrics,
+	ProcessMetrics,
 
 	// task queue metrics category
 	QueueSizeGauge,
@@ -87,11 +91,6 @@ var MetricsItems = []prometheus.Collector{
 	MigrateGVGCounter,
 	MigrateObjectTimeHistogram,
 	MigrateObjectCounter,
-
-	// golang runtime and process metrics
-	collectors.NewGoCollector(collectors.WithGoCollectorRuntimeMetrics(collectors.GoRuntimeMetricsRule{
-		Matcher: regexp.MustCompile("/.*")})),
-	collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 }
 
 // basic metrics items
@@ -103,6 +102,12 @@ var (
 		openmetrics.WithClientStreamSendHistogram(), openmetrics.WithClientStreamRecvHistogram())
 	// DefaultHTTPServerMetrics defines default HTTP server metrics
 	DefaultHTTPServerMetrics = metricshttp.NewServerMetrics()
+
+	// GolangRuntimeMetrics defines some runtime metrics about golang
+	GolangRuntimeMetrics = collectors.NewGoCollector(collectors.WithGoCollectorRuntimeMetrics(
+		collectors.GoRuntimeMetricsRule{Matcher: regexp.MustCompile("/.*")}))
+	// ProcessMetrics defines some metrics about current sp process
+	ProcessMetrics = collectors.NewProcessCollector(collectors.ProcessCollectorOpts{})
 
 	// task queue metrics
 	QueueSizeGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{

--- a/pkg/metrics/metric_items.go
+++ b/pkg/metrics/metric_items.go
@@ -1,8 +1,11 @@
 package metrics
 
 import (
+	"regexp"
+
 	openmetrics "github.com/grpc-ecosystem/go-grpc-middleware/providers/openmetrics/v2"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 
 	metricshttp "github.com/bnb-chain/greenfield-storage-provider/pkg/metrics/http"
 )
@@ -84,6 +87,11 @@ var MetricsItems = []prometheus.Collector{
 	MigrateGVGCounter,
 	MigrateObjectTimeHistogram,
 	MigrateObjectCounter,
+
+	// golang runtime and process metrics
+	collectors.NewGoCollector(collectors.WithGoCollectorRuntimeMetrics(collectors.GoRuntimeMetricsRule{
+		Matcher: regexp.MustCompile("/.*")})),
+	collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 }
 
 // basic metrics items

--- a/store/sqldb/store.go
+++ b/store/sqldb/store.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 
@@ -49,6 +51,17 @@ func NewSpDB(config *config.SQLDBConfig) (*SpDBImpl, error) {
 		return nil, err
 	}
 	return &SpDBImpl{db: db}, err
+}
+
+// RegisterStdDBStats registers std lib sql DB
+func (s *SpDBImpl) RegisterStdDBStats() (prometheus.Collector, error) {
+	db, err := s.db.DB()
+	if err != nil {
+		log.Errorw("failed to get std lib db struct")
+		return nil, err
+	}
+	collector := collectors.NewDBStatsCollector(db, "spdb")
+	return collector, nil
 }
 
 // InitDB init a db instance


### PR DESCRIPTION
### Description

Add golang runtime metrics, process metrics and std lib db metrics to improve availability.

### Rationale

Improve availability and speed to debug problems.

### Example

`curl http://localhost:24367/metrics`

```
process metrics:
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 7.31
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 8192
......

golang metrics:
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 0
go_gc_duration_seconds{quantile="0.25"} 0
go_gc_duration_seconds{quantile="0.5"} 0
go_gc_duration_seconds{quantile="0.75"} 0
go_gc_duration_seconds{quantile="1"} 0
go_gc_duration_seconds_sum 0
go_gc_duration_seconds_count 0
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 7
......

db metrics:
# HELP go_sql_idle_connections The number of idle connections.
# TYPE go_sql_idle_connections gauge
go_sql_idle_connections{db_name="spdb"} 3
# HELP go_sql_in_use_connections The number of connections currently in use.
# TYPE go_sql_in_use_connections gauge
go_sql_in_use_connections{db_name="spdb"} 0
......
```

### Changes

Notable changes: 
* N/A
