### PR TITLE
fix: refine the error msg for ErrInvalidExpiryDate header and parameter

### DIFF
--- a/modular/gater/errors.go
+++ b/modular/gater/errors.go
@@ -38,9 +38,9 @@ var (
 	ErrSignedMsgNotMatchPubKey   = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50039, "The public key in signed message in "+GnfdAuthorizationHeader+" does not match the expiry time in the header "+GnfdOffChainAuthAppRegPublicKeyHeader+".")
 	ErrSignedMsgNotMatchTemplate = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50022, "The signed message in "+GnfdAuthorizationHeader+" does not match the template.")
 	ErrInvalidExpiryDateHeader   = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50023, "The "+commonhttp.HTTPHeaderExpiryTimestamp+" header is incorrect. "+
-		"The expiry date is expected to be within "+strconv.Itoa(int(MaxExpiryAgeInSec))+" seconds and formatted in YYYY-DD-MM HH:MM:SS 'GMT'Z, e.g. 2023-04-20 16:34:12 GMT+08:00 . ")
+		"The expiry date is expected to be within "+strconv.Itoa(int(MaxExpiryAgeInSec))+" seconds and formatted in RFC3339, e.g. 2006-01-02T15:04:05Z07:00 . ")
 	ErrInvalidExpiryDateParam = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50024, "The "+commonhttp.HTTPHeaderExpiryTimestamp+" parameter is incorrect. "+
-		"The expiry date is expected to be within "+strconv.Itoa(int(MaxExpiryAgeInSec))+" seconds and formatted in YYYY-DD-MM HH:MM:SS 'GMT'Z, e.g. 2023-04-20 16:34:12 GMT+08:00 . ")
+		"The expiry date is expected to be within "+strconv.Itoa(int(MaxExpiryAgeInSec))+" seconds and formatted in RFC3339, e.g. 2006-01-02T15:04:05Z07:00 . ")
 	ErrNoSuchObject           = gfsperrors.Register(module.AuthenticationModularName, http.StatusNotFound, 50025, "no such object")
 	ErrForbidden              = gfsperrors.Register(module.GateModularName, http.StatusForbidden, 50026, "Forbidden to access")
 	ErrInvalidComplete        = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50027, "invalid complete")


### PR DESCRIPTION
### Description

refine the error msg for ErrInvalidExpiryDate header and parameter

### Rationale

The original description misleads users to use a date format 2023-04-20 16:34:12 GMT+08:00, but our case and docs uses RFC3399 format, e.g. 2006-01-02T15:04:05Z07:00

### Example

N/A
### Changes

Notable changes: 
* Change the error description without other logic code change

