### PR TITLE
feat: add index to update at

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -302,7 +302,7 @@ replace (
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.6
 	github.com/cosmos/iavl => github.com/bnb-chain/greenfield-iavl v0.20.1
-	github.com/forbole/juno/v4 => github.com/bnb-chain/juno/v4 v4.0.0-20231017055033-3e9021c290f5
+	github.com/forbole/juno/v4 => github.com/bnb-chain/juno/v4 v4.0.0-20231023093717-390aca87c874
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )

--- a/go.mod
+++ b/go.mod
@@ -281,7 +281,7 @@ require (
 	golang.org/x/text v0.10.0 // indirect
 	golang.org/x/tools v0.10.0 // indirect
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
-	google.golang.org/protobuf v1.30.0 // indirect
+	google.golang.org/protobuf v1.30.0
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
@@ -302,7 +302,7 @@ replace (
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/greenfield-cosmos-sdk v0.2.6
 	github.com/cosmos/iavl => github.com/bnb-chain/greenfield-iavl v0.20.1
-	github.com/forbole/juno/v4 => github.com/bnb-chain/juno/v4 v4.0.0-20231023093717-390aca87c874
+	github.com/forbole/juno/v4 => github.com/bnb-chain/juno/v4 v4.0.0-20231023111452-7cd108f48b21
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,8 @@ github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230816082903-b48770f5e2
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230816082903-b48770f5e210/go.mod h1:An0MllWJY6PxibUpnwGk8jOm+a/qIxlKmL5Zyp9NnaM=
 github.com/bnb-chain/greenfield-iavl v0.20.1 h1:y3L64GU99otNp27/xLVBTDbv4eroR6CzoYz0rbaVotM=
 github.com/bnb-chain/greenfield-iavl v0.20.1/go.mod h1:oLksTs8dfh7DYIKBro7hbRQ+ewls7ghJ27pIXlbEXyI=
-github.com/bnb-chain/juno/v4 v4.0.0-20231017055033-3e9021c290f5 h1:RPp/w4kQUtsJE+/hG2+EQ7w24K/h1Ck+FLioq19zemw=
-github.com/bnb-chain/juno/v4 v4.0.0-20231017055033-3e9021c290f5/go.mod h1:OC/1A0E4Mp5H/25T9HX05DvfSmMGJr0lSeMUR56yD6k=
+github.com/bnb-chain/juno/v4 v4.0.0-20231023093717-390aca87c874 h1:sSECHsaQ2A5fY5XP5MbQ/RNar+qzfgzStv15Zw2FD2g=
+github.com/bnb-chain/juno/v4 v4.0.0-20231023093717-390aca87c874/go.mod h1:OC/1A0E4Mp5H/25T9HX05DvfSmMGJr0lSeMUR56yD6k=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/bradfitz/gomemcache v0.0.0-20170208213004-1952afaa557d/go.mod h1:PmM6Mmwb0LSuEubjR8N7PtNe1KxZLtOUHtbeikc5h60=

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,8 @@ github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230816082903-b48770f5e2
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230816082903-b48770f5e210/go.mod h1:An0MllWJY6PxibUpnwGk8jOm+a/qIxlKmL5Zyp9NnaM=
 github.com/bnb-chain/greenfield-iavl v0.20.1 h1:y3L64GU99otNp27/xLVBTDbv4eroR6CzoYz0rbaVotM=
 github.com/bnb-chain/greenfield-iavl v0.20.1/go.mod h1:oLksTs8dfh7DYIKBro7hbRQ+ewls7ghJ27pIXlbEXyI=
-github.com/bnb-chain/juno/v4 v4.0.0-20231023093717-390aca87c874 h1:sSECHsaQ2A5fY5XP5MbQ/RNar+qzfgzStv15Zw2FD2g=
-github.com/bnb-chain/juno/v4 v4.0.0-20231023093717-390aca87c874/go.mod h1:OC/1A0E4Mp5H/25T9HX05DvfSmMGJr0lSeMUR56yD6k=
+github.com/bnb-chain/juno/v4 v4.0.0-20231023111452-7cd108f48b21 h1:mRSILqMoZkmJBhBm5QgBKC4FerkVptLOgknorZd63ik=
+github.com/bnb-chain/juno/v4 v4.0.0-20231023111452-7cd108f48b21/go.mod h1:OC/1A0E4Mp5H/25T9HX05DvfSmMGJr0lSeMUR56yD6k=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/bradfitz/gomemcache v0.0.0-20170208213004-1952afaa557d/go.mod h1:PmM6Mmwb0LSuEubjR8N7PtNe1KxZLtOUHtbeikc5h60=

--- a/store/bsdb/object_schema.go
+++ b/store/bsdb/object_schema.go
@@ -48,7 +48,7 @@ type Object struct {
 	// Removed defines the object is deleted or not
 	Removed bool `gorm:"removed"`
 	// UpdateTime defines the time when the object updated
-	UpdateTime int64 `gorm:"update_time"`
+	UpdateTime int64 `gorm:"update_time, uniqueIndex:update_time"`
 	// UpdateAt defines the block number when the object updated
 	UpdateAt int64 `gorm:"update_at"`
 	// DeleteAt defines the block number when the object deleted

--- a/store/bsdb/object_schema.go
+++ b/store/bsdb/object_schema.go
@@ -48,9 +48,9 @@ type Object struct {
 	// Removed defines the object is deleted or not
 	Removed bool `gorm:"removed"`
 	// UpdateTime defines the time when the object updated
-	UpdateTime int64 `gorm:"update_time, uniqueIndex:update_time"`
+	UpdateTime int64 `gorm:"update_time"`
 	// UpdateAt defines the block number when the object updated
-	UpdateAt int64 `gorm:"update_at"`
+	UpdateAt int64 `gorm:"update_at;index:idx_update_at"`
 	// DeleteAt defines the block number when the object deleted
 	DeleteAt int64 `gorm:"delete_at"`
 	// DeleteReason defines the deleted reason of object


### PR DESCRIPTION
### Description

Try fix slow sql by add index to update at.

### Rationale

There are slow sql observed in testnet, which found out to be querying a sql related with object table and order by updated at. we figures adding index to update at column would help make the sql faster.

### Example

N/A

### Changes

Notable changes: 
* bsdb
