### PR TITLE
fix: wrong error code  when invalid signature 

### DIFF
--- a/modular/authenticator/off_chain_signer.go
+++ b/modular/authenticator/off_chain_signer.go
@@ -51,7 +51,7 @@ func VerifyEddsaSignature(pubKey string, sig, message []byte) error {
 		return err
 	}
 	if !valid {
-		return errors.New("invalid signature")
+		return ErrBadSignature
 	}
 	return nil
 }

--- a/modular/authenticator/off_chain_signer_test.go
+++ b/modular/authenticator/off_chain_signer_test.go
@@ -72,7 +72,7 @@ func TestUserOffChainAuthSignature(t *testing.T) {
 	require.NoError(t, err)
 
 	err = VerifyEddsaSignature(userEddsaPublicKeyStr, sig, []byte("This msg doesn't match with the sig"))
-	assert.Equal(t, "invalid signature", err.Error())
+	assert.Equal(t, ErrBadSignature, err)
 }
 
 // TestUseUserPublicKeyToVerifyUserOffChainAuthSignature
@@ -105,7 +105,7 @@ func TestUseUserPublicKeyToVerifyUserOffChainAuthSignature(t *testing.T) {
 	require.NoError(t, err)
 
 	err = VerifyEddsaSignature(userEddsaPublicKeyStr, sig, []byte("This msg doesn't match with the sig"))
-	assert.Equal(t, "invalid signature", err.Error())
+	assert.Equal(t, ErrBadSignature, err)
 }
 
 func TestErrorCases(t *testing.T) {


### PR DESCRIPTION
### Description

If there is a problem with the signature in the request, a 400 (ErrBadSignature) error should be returned to the user;

### Rationale

NA

### Example

NA

### Changes

Notable changes: 
* NA
* ...
