### PR TITLE
fix: remove the order by clause for discontinuing function

### DIFF
--- a/store/bsdb/bucket.go
+++ b/store/bsdb/bucket.go
@@ -166,7 +166,6 @@ func (b *BsDBImpl) ListExpiredBucketsBySp(createAt int64, primarySpID uint32, li
 		AND buckets.status = 'BUCKET_STATUS_CREATED' 
 		AND buckets.create_time < ? 
 		AND buckets.removed = false
-		ORDER BY buckets.create_at
 		LIMIT ?`,
 		primarySpID, createAt, limit).
 		Find(&buckets).Error


### PR DESCRIPTION

### Description

fix: remove the order by clause when querying buckets for discontinuing function

### Rationale

The original sql 
```sql
SELECT buckets.* FROM buckets INNER JOIN global_virtual_group_families ON buckets.global_virtual_group_family_id = global_virtual_group_families.global_virtual_group_family_id WHERE global_virtual_group_families.primary_sp_id = 5 AND buckets.status = 'BUCKET_STATUS_CREATED' AND buckets.create_time < 1697955241 AND buckets.removed = false ORDER BY buckets.create_at LIMIT 500

```
has an unnecessary "ORDER BY buckets.create_at " clause which largely slows down this sql execution. 

### Example

N/A
### Changes

Notable changes: 
* remove the unnecessary "order by" clause

