### PR TITLE
fix: list object policies meta expiration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -281,7 +281,7 @@ require (
 	golang.org/x/text v0.10.0 // indirect
 	golang.org/x/tools v0.10.0 // indirect
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
-	google.golang.org/protobuf v1.30.0
+	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/modular/metadata/metadata_permission_service.go
+++ b/modular/metadata/metadata_permission_service.go
@@ -446,7 +446,7 @@ func (r *MetadataModular) GfSpListObjectPolicies(ctx context.Context, req *types
 		object      *bsdb.Object
 		limit       int
 		policies    []*types.Policy
-		permissions []*bsdb.Permission
+		permissions []*bsdb.PermissionWithStatement
 	)
 
 	ctx = log.Context(ctx, req)
@@ -485,7 +485,12 @@ func (r *MetadataModular) GfSpListObjectPolicies(ctx context.Context, req *types
 			ResourceId:      perm.ResourceID.String(),
 			CreateTimestamp: perm.CreateTimestamp,
 			UpdateTimestamp: perm.UpdateTimestamp,
-			ExpirationTime:  perm.ExpirationTime,
+			ExpirationTime:  perm.Permission.ExpirationTime,
+		}
+		if perm.Permission.ExpirationTime == 0 {
+			if perm.Statement.ExpirationTime != 0 && perm.Statement.ExpirationTime >= time.Now().Unix() {
+				policies[i].ExpirationTime = perm.Statement.ExpirationTime
+			}
 		}
 	}
 

--- a/modular/metadata/metadata_permission_service_test.go
+++ b/modular/metadata/metadata_permission_service_test.go
@@ -1585,19 +1585,31 @@ func TestMetadataModularGfSpListObjectPolicies_Success(t *testing.T) {
 		},
 	).Times(1)
 	m.EXPECT().ListObjectPolicies(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(common.Hash, permission_types.ActionType, common.Hash, int) ([]*bsdb.Permission, error) {
-			return []*bsdb.Permission{
-				&bsdb.Permission{
-					ID:              2,
-					PrincipalType:   2,
-					PrincipalValue:  "3",
-					ResourceType:    "RESOURCE_TYPE_OBJECT",
-					ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
-					PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
-					CreateTimestamp: time.Now().Unix(),
-					UpdateTimestamp: time.Now().Unix(),
-					ExpirationTime:  time.Now().Unix() + 100000,
-					Removed:         false,
+		func(common.Hash, permission_types.ActionType, common.Hash, int) ([]*bsdb.PermissionWithStatement, error) {
+			return []*bsdb.PermissionWithStatement{
+				&bsdb.PermissionWithStatement{
+					Permission: bsdb.Permission{
+						ID:              2,
+						PrincipalType:   2,
+						PrincipalValue:  "3",
+						ResourceType:    "RESOURCE_TYPE_OBJECT",
+						ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+						PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+						CreateTimestamp: time.Now().Unix(),
+						UpdateTimestamp: time.Now().Unix(),
+						ExpirationTime:  time.Now().Unix() + 100000,
+						Removed:         false,
+					},
+					Statement: bsdb.Statement{
+						ID:             2,
+						PolicyID:       common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+						Effect:         "EFFECT_ALLOW",
+						ActionValue:    64,
+						Resources:      nil,
+						ExpirationTime: time.Now().Unix() + 100000,
+						LimitSize:      1,
+						Removed:        false,
+					},
 				},
 			}, nil
 		},
@@ -1652,19 +1664,31 @@ func TestMetadataModularGfSpListObjectPolicies_Success2(t *testing.T) {
 		},
 	).Times(1)
 	m.EXPECT().ListObjectPolicies(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(common.Hash, permission_types.ActionType, common.Hash, int) ([]*bsdb.Permission, error) {
-			return []*bsdb.Permission{
-				&bsdb.Permission{
-					ID:              2,
-					PrincipalType:   2,
-					PrincipalValue:  "3",
-					ResourceType:    "RESOURCE_TYPE_OBJECT",
-					ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
-					PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
-					CreateTimestamp: time.Now().Unix(),
-					UpdateTimestamp: time.Now().Unix(),
-					ExpirationTime:  time.Now().Unix() + 100000,
-					Removed:         false,
+		func(common.Hash, permission_types.ActionType, common.Hash, int) ([]*bsdb.PermissionWithStatement, error) {
+			return []*bsdb.PermissionWithStatement{
+				&bsdb.PermissionWithStatement{
+					Permission: bsdb.Permission{
+						ID:              2,
+						PrincipalType:   2,
+						PrincipalValue:  "3",
+						ResourceType:    "RESOURCE_TYPE_OBJECT",
+						ResourceID:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+						PolicyID:        common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+						CreateTimestamp: time.Now().Unix(),
+						UpdateTimestamp: time.Now().Unix(),
+						ExpirationTime:  time.Now().Unix() + 100000,
+						Removed:         false,
+					},
+					Statement: bsdb.Statement{
+						ID:             2,
+						PolicyID:       common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+						Effect:         "EFFECT_ALLOW",
+						ActionValue:    64,
+						Resources:      nil,
+						ExpirationTime: time.Now().Unix() + 100000,
+						LimitSize:      1,
+						Removed:        false,
+					},
 				},
 			}, nil
 		},

--- a/store/bsdb/database.go
+++ b/store/bsdb/database.go
@@ -113,7 +113,7 @@ type Metadata interface {
 	// GetUserOwnedGroups retrieve groups where the user is the owner
 	GetUserOwnedGroups(accountID common.Address, startAfter common.Hash, limit int) ([]*Group, error)
 	// ListObjectPolicies list policies by object info
-	ListObjectPolicies(objectID common.Hash, actionType types.ActionType, startAfter common.Hash, limit int) ([]*Permission, error)
+	ListObjectPolicies(objectID common.Hash, actionType types.ActionType, startAfter common.Hash, limit int) ([]*PermissionWithStatement, error)
 	// GetGroupMembersCount get the count of group members
 	GetGroupMembersCount(groupIDs []common.Hash) ([]*GroupCount, error)
 	// ListVirtualGroupFamiliesByVgfIDs list virtual group families by vgf ids

--- a/store/bsdb/database_mock.go
+++ b/store/bsdb/database_mock.go
@@ -734,10 +734,10 @@ func (mr *MockMetadataMockRecorder) ListMigrateBucketEvents(spID interface{}, fi
 }
 
 // ListObjectPolicies mocks base method.
-func (m *MockMetadata) ListObjectPolicies(objectID common.Hash, actionType types.ActionType, startAfter common.Hash, limit int) ([]*Permission, error) {
+func (m *MockMetadata) ListObjectPolicies(objectID common.Hash, actionType types.ActionType, startAfter common.Hash, limit int) ([]*PermissionWithStatement, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListObjectPolicies", objectID, actionType, startAfter, limit)
-	ret0, _ := ret[0].([]*Permission)
+	ret0, _ := ret[0].([]*PermissionWithStatement)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1676,10 +1676,10 @@ func (mr *MockBSDBMockRecorder) ListMigrateBucketEvents(spID interface{}, filter
 }
 
 // ListObjectPolicies mocks base method.
-func (m *MockBSDB) ListObjectPolicies(objectID common.Hash, actionType types.ActionType, startAfter common.Hash, limit int) ([]*Permission, error) {
+func (m *MockBSDB) ListObjectPolicies(objectID common.Hash, actionType types.ActionType, startAfter common.Hash, limit int) ([]*PermissionWithStatement, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListObjectPolicies", objectID, actionType, startAfter, limit)
-	ret0, _ := ret[0].([]*Permission)
+	ret0, _ := ret[0].([]*PermissionWithStatement)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/store/bsdb/permission.go
+++ b/store/bsdb/permission.go
@@ -129,9 +129,9 @@ func (p Permission) Eval(action permtypes.ActionType, blockTime time.Time, opts 
 }
 
 // ListObjectPolicies list policies by object info
-func (b *BsDBImpl) ListObjectPolicies(objectID common.Hash, actionType permtypes.ActionType, startAfter common.Hash, limit int) ([]*Permission, error) {
+func (b *BsDBImpl) ListObjectPolicies(objectID common.Hash, actionType permtypes.ActionType, startAfter common.Hash, limit int) ([]*PermissionWithStatement, error) {
 	var (
-		permissions  []*Permission
+		permissions  []*PermissionWithStatement
 		actionValues []int
 		now          int64
 		err          error

--- a/store/bsdb/permission_schema.go
+++ b/store/bsdb/permission_schema.go
@@ -30,6 +30,11 @@ type Permission struct {
 	Removed bool `gorm:"removed"`
 }
 
+type PermissionWithStatement struct {
+	Permission
+	Statement
+}
+
 // TableName is used to set Permission table name in database
 func (p *Permission) TableName() string {
 	return PermissionTableName


### PR DESCRIPTION
### Description

The statement expiration time has a lower priority than the Policy; if it is nil, the statement will never expire. First look at the expiration time of the Policy, if it has not expired, then look at the expiration time of the statement

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 
* update list object policies code
