### PR TITLE
fix: abort replication task if an object sealed

### DIFF
--- a/modular/manager/manage_task.go
+++ b/modular/manager/manage_task.go
@@ -132,6 +132,7 @@ func (m *ManageModular) HandleDoneUploadObjectTask(ctx context.Context, task tas
 		metrics.ManagerTime.WithLabelValues(ManagerSuccessUpload).Observe(
 			time.Since(time.Unix(task.GetCreateTime(), 0)).Seconds())
 	}
+	log.Debugw("UploadObjectTask info", "task", task)
 	return m.pickGVGAndReplicate(ctx, task.GetVirtualGroupFamilyId(), task)
 }
 

--- a/modular/manager/manage_task.go
+++ b/modular/manager/manage_task.go
@@ -359,6 +359,17 @@ func (m *ManageModular) HandleReplicatePieceTask(ctx context.Context, task task.
 
 func (m *ManageModular) handleFailedReplicatePieceTask(ctx context.Context, handleTask task.ReplicatePieceTask) error {
 	if handleTask.GetNotAvailableSpIdx() != -1 {
+		objectInfo, queryErr := m.baseApp.Consensus().QueryObjectInfoByID(ctx, util.Uint64ToString(handleTask.GetObjectInfo().Id.Uint64()))
+		if queryErr != nil {
+			log.Errorw("failed to query object info", "object", handleTask.GetObjectInfo(), "error", queryErr)
+			return queryErr
+		}
+		if objectInfo.GetObjectStatus() == storagetypes.OBJECT_STATUS_SEALED {
+			log.CtxInfow(ctx, "object already sealed, abort replicate task", "object_info", objectInfo)
+			m.replicateQueue.PopByKey(handleTask.Key())
+			return nil
+		}
+
 		gvgID := handleTask.GetGlobalVirtualGroupId()
 		gvg, err := m.baseApp.Consensus().QueryGlobalVirtualGroup(context.Background(), gvgID)
 		if err != nil {


### PR DESCRIPTION
### Description

A replicate task from manager queue might be asked by more than 1 executor. So that manager needs to check the object status from reported task and abort the it if object sealed.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
