### PR TITLE
release: prepare release for v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.0.3
+This release contains 1 bugfix.
+
+BUGFIXES
+* [#1214](https://github.com/bnb-chain/greenfield-storage-provider/pull/1214) fix: abort replication task if an object sealed
+
+
 ## v1.0.2
 This release contains 2 bugfixes and 1 feature.
 


### PR DESCRIPTION
### Description

Prepare release for v1.0.3.

### Rationale

This release contains 1 bugfix.

BUGFIXES
* [#1214](https://github.com/bnb-chain/greenfield-storage-provider/pull/1214) fix: abort replication task if an object sealed


### Example

N/A.

### Changes

Notable changes: 
* N/A.
