### PR TITLE
feat: add a DataMigrationRecord table to save the process record for data migration tasks

### DIFF
--- a/modular/blocksyncer/blocksyncer_options.go
+++ b/modular/blocksyncer/blocksyncer_options.go
@@ -517,7 +517,7 @@ func mustGetLatestHeight(ctx *parser.Context) uint64 {
 
 func (b *BlockSyncerModular) syncBucketSize() error {
 	dataMigrateKey := bsdb.ProcessKeyUpdateBucketSize
-	record, err := b.baseApp.GfBsDB().GetDataMigrationRecordByProcessKey(dataMigrateKey)
+	record, err := db.Cast(b.parserCtx.Database).GetDataMigrationRecord(context.Background(), dataMigrateKey)
 	if err != nil {
 		panic("failed to get the data migration record for " + dataMigrateKey)
 	}

--- a/modular/blocksyncer/blocksyncer_options.go
+++ b/modular/blocksyncer/blocksyncer_options.go
@@ -521,7 +521,7 @@ func (b *BlockSyncerModular) syncBucketSize() error {
 	if err != nil {
 		panic("failed to get the data migration record for " + dataMigrateKey)
 	}
-	if record != nil && record.IsCompleted == true {
+	if record != nil && record.IsCompleted {
 		log.Infof(dataMigrateKey + "has already been completed. Skip it now.")
 		return nil
 	}

--- a/modular/blocksyncer/database/bucket.go
+++ b/modular/blocksyncer/database/bucket.go
@@ -42,6 +42,13 @@ func (db *DB) BatchUpdateBucketSize(ctx context.Context, buckets []*models.Bucke
 	}).Create(buckets).Error
 }
 
+func (db *DB) UpdateDataMigrationRecord(ctx context.Context, processKey string, isCompleted bool) error {
+	return db.Db.Table((&bsdb.DataMigrationRecord{}).TableName()).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "process_key"}},
+		DoUpdates: clause.AssignmentColumns([]string{"is_completed"}),
+	}).Create(&bsdb.DataMigrationRecord{ProcessKey: processKey, IsCompleted: isCompleted}).Error
+}
+
 func (db *DB) UpdateStorageSizeToSQL(ctx context.Context, objectID common.Hash, bucketName, operation string) (string, []interface{}) {
 	tableName := bsdb.GetObjectsTableName(bucketName)
 	sql := `UPDATE buckets SET storage_size = storage_size %s CONVERT((SELECT payload_size FROM %s WHERE object_id = ?), DECIMAL(65,0)) WHERE bucket_name = ?`

--- a/modular/blocksyncer/database/bucket.go
+++ b/modular/blocksyncer/database/bucket.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/forbole/juno/v4/common"
@@ -40,6 +41,18 @@ func (db *DB) BatchUpdateBucketSize(ctx context.Context, buckets []*models.Bucke
 		Columns:   []clause.Column{{Name: "bucket_id"}},
 		DoUpdates: clause.AssignmentColumns([]string{"storage_size", "charge_size"}),
 	}).Create(buckets).Error
+}
+
+func (db *DB) GetDataMigrationRecord(ctx context.Context, processKey string) (*bsdb.DataMigrationRecord, error) {
+	var (
+		dataRecord *bsdb.DataMigrationRecord
+		err        error
+	)
+	err = db.Db.Take(&dataRecord, "process_key = ?", processKey).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	return dataRecord, err
 }
 
 func (db *DB) UpdateDataMigrationRecord(ctx context.Context, processKey string, isCompleted bool) error {

--- a/modular/blocksyncer/modules/bucket/module.go
+++ b/modular/blocksyncer/modules/bucket/module.go
@@ -2,6 +2,7 @@ package bucket
 
 import (
 	"context"
+	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
 
 	"github.com/bnb-chain/greenfield-storage-provider/modular/blocksyncer/database"
 
@@ -39,10 +40,10 @@ func (m *Module) Name() string {
 
 // PrepareTables implements
 func (m *Module) PrepareTables() error {
-	return m.db.PrepareTables(context.TODO(), []schema.Tabler{&models.Bucket{}})
+	return m.db.PrepareTables(context.TODO(), []schema.Tabler{&models.Bucket{}, &bsdb.DataMigrationRecord{}})
 }
 
 // AutoMigrate implements
 func (m *Module) AutoMigrate() error {
-	return m.db.AutoMigrate(context.TODO(), []schema.Tabler{&models.Bucket{}})
+	return m.db.AutoMigrate(context.TODO(), []schema.Tabler{&models.Bucket{}, &bsdb.DataMigrationRecord{}})
 }

--- a/modular/blocksyncer/modules/bucket/module.go
+++ b/modular/blocksyncer/modules/bucket/module.go
@@ -2,6 +2,7 @@ package bucket
 
 import (
 	"context"
+
 	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
 
 	"github.com/bnb-chain/greenfield-storage-provider/modular/blocksyncer/database"

--- a/store/bsdb/const.go
+++ b/store/bsdb/const.go
@@ -38,6 +38,8 @@ const (
 	GroupTableName = "groups"
 	// MasterDBTableName defines the name of master db table
 	MasterDBTableName = "master_db"
+	// DataMigrationRecordTableName defines the name of data migration record table
+	DataMigrationRecordTableName = "data_migration_record"
 	// PrefixTreeTableName defines the name of prefix tree node table
 	PrefixTreeTableName = "slash_prefix_tree_nodes"
 	// GlobalVirtualGroupFamilyTableName defines the name of global virtual group family table

--- a/store/bsdb/data_migration_record.go
+++ b/store/bsdb/data_migration_record.go
@@ -2,8 +2,9 @@ package bsdb
 
 import (
 	"errors"
-	"gorm.io/gorm"
 	"time"
+
+	"gorm.io/gorm"
 )
 
 // GetDataMigrationRecordByProcessKey get the record of data migration by the given process key

--- a/store/bsdb/data_migration_record.go
+++ b/store/bsdb/data_migration_record.go
@@ -1,0 +1,31 @@
+package bsdb
+
+import (
+	"errors"
+	"gorm.io/gorm"
+	"time"
+)
+
+// GetDataMigrationRecordByProcessKey get the record of data migration by the given process key
+func (b *BsDBImpl) GetDataMigrationRecordByProcessKey(processKey string) (*DataMigrationRecord, error) {
+	var (
+		dataRecord *DataMigrationRecord
+		err        error
+	)
+
+	startTime := time.Now()
+	methodName := currentFunction()
+	defer func() {
+		if err != nil {
+			MetadataDatabaseFailureMetrics(err, startTime, methodName)
+		} else {
+			MetadataDatabaseSuccessMetrics(startTime, methodName)
+		}
+	}()
+
+	err = b.db.Take(&dataRecord, "process_key = ?", processKey).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	return dataRecord, err
+}

--- a/store/bsdb/data_migration_record_schema.go
+++ b/store/bsdb/data_migration_record_schema.go
@@ -1,0 +1,17 @@
+package bsdb
+
+const (
+	ProcessKeyUpdateBucketSize = "key_update_bucket_size"
+)
+
+// DataMigrationRecord stores records of data migration processes.
+type DataMigrationRecord struct {
+	ProcessKey string `gorm:"column:process_key;not null;primaryKey"`
+	// IsCompleted defines if corresponding process has been completed.
+	IsCompleted bool `gorm:"column:is_completed;"`
+}
+
+// TableName is used to set Master table name in database
+func (m *DataMigrationRecord) TableName() string {
+	return DataMigrationRecordTableName
+}

--- a/store/bsdb/data_migration_record_schema_test.go
+++ b/store/bsdb/data_migration_record_schema_test.go
@@ -1,8 +1,9 @@
 package bsdb
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDataMigrationRecord_TableName(t *testing.T) {

--- a/store/bsdb/data_migration_record_schema_test.go
+++ b/store/bsdb/data_migration_record_schema_test.go
@@ -1,0 +1,12 @@
+package bsdb
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDataMigrationRecord_TableName(t *testing.T) {
+	dataMigrationRecord := DataMigrationRecord{ProcessKey: ProcessKeyUpdateBucketSize, IsCompleted: true}
+	name := dataMigrationRecord.TableName()
+	assert.Equal(t, DataMigrationRecordTableName, name)
+}

--- a/store/bsdb/data_migration_record_test.go
+++ b/store/bsdb/data_migration_record_test.go
@@ -1,0 +1,24 @@
+package bsdb
+
+import (
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+const (
+	mockQueryDataMigrationRecordByProcessKey = "SELECT * FROM `data_migration_record` WHERE process_key = ? LIMIT 1"
+)
+
+func TestBsDBImpl_GetDataMigrationRecordByProcessKey(t *testing.T) {
+	s, mock := setupDB(t)
+	mock.ExpectQuery(mockQueryDataMigrationRecordByProcessKey).
+		WithArgs(ProcessKeyUpdateBucketSize).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"process_key", "is_completed",
+		}).AddRow(ProcessKeyUpdateBucketSize, true))
+
+	records, err := s.GetDataMigrationRecordByProcessKey(ProcessKeyUpdateBucketSize)
+	assert.Nil(t, err)
+	assert.NotNil(t, records)
+}

--- a/store/bsdb/data_migration_record_test.go
+++ b/store/bsdb/data_migration_record_test.go
@@ -1,9 +1,10 @@
 package bsdb
 
 import (
+	"testing"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 const (

--- a/store/bsdb/database.go
+++ b/store/bsdb/database.go
@@ -135,6 +135,8 @@ type Metadata interface {
 	GetSecondarySPStreamRecordBySpID(spID uint32) ([]*SecondarySpIncomeMeta, error)
 	// GetBucketSizeByID get bucket size info by a bucket id
 	GetBucketSizeByID(bucketID uint64) (decimal.Decimal, error)
+	// GetDataMigrationRecordByProcessKey  get the record of data migration by the given process key
+	GetDataMigrationRecordByProcessKey(processKey string) (*DataMigrationRecord, error)
 }
 
 // BSDB contains all the methods required by block syncer database

--- a/store/bsdb/database_mock.go
+++ b/store/bsdb/database_mock.go
@@ -101,6 +101,21 @@ func (mr *MockMetadataMockRecorder) GetBucketSizeByID(bucketID any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketSizeByID", reflect.TypeOf((*MockMetadata)(nil).GetBucketSizeByID), bucketID)
 }
 
+// GetDataMigrationRecordByProcessKey mocks base method.
+func (m *MockMetadata) GetDataMigrationRecordByProcessKey(processKey string) (*DataMigrationRecord, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDataMigrationRecordByProcessKey", processKey)
+	ret0, _ := ret[0].(*DataMigrationRecord)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDataMigrationRecordByProcessKey indicates an expected call of GetDataMigrationRecordByProcessKey.
+func (mr *MockMetadataMockRecorder) GetDataMigrationRecordByProcessKey(processKey any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataMigrationRecordByProcessKey", reflect.TypeOf((*MockMetadata)(nil).GetDataMigrationRecordByProcessKey), processKey)
+}
+
 // GetDefaultCharacterSet mocks base method.
 func (m *MockMetadata) GetDefaultCharacterSet() (string, error) {
 	m.ctrl.T.Helper()
@@ -1087,6 +1102,21 @@ func (m *MockBSDB) GetBucketSizeByID(bucketID uint64) (decimal.Decimal, error) {
 func (mr *MockBSDBMockRecorder) GetBucketSizeByID(bucketID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketSizeByID", reflect.TypeOf((*MockBSDB)(nil).GetBucketSizeByID), bucketID)
+}
+
+// GetDataMigrationRecordByProcessKey mocks base method.
+func (m *MockBSDB) GetDataMigrationRecordByProcessKey(processKey string) (*DataMigrationRecord, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDataMigrationRecordByProcessKey", processKey)
+	ret0, _ := ret[0].(*DataMigrationRecord)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDataMigrationRecordByProcessKey indicates an expected call of GetDataMigrationRecordByProcessKey.
+func (mr *MockBSDBMockRecorder) GetDataMigrationRecordByProcessKey(processKey any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataMigrationRecordByProcessKey", reflect.TypeOf((*MockBSDB)(nil).GetDataMigrationRecordByProcessKey), processKey)
 }
 
 // GetDefaultCharacterSet mocks base method.


### PR DESCRIPTION
### Description

fix the bucket size logic

### Rationale

Fix the bucket size calculation logic

### Example

nothing

### Changes

Notable changes: 
* Modified the SQL
