### PR TITLE
release: prepare v1.0.5

### DIFF
--- a/modular/executor/execute_replicate.go
+++ b/modular/executor/execute_replicate.go
@@ -19,9 +19,12 @@ import (
 )
 
 var (
-	RtyAttem = retry.Attempts(uint(5))
-	RtyDelay = retry.Delay(time.Millisecond * 500)
-	RtyErr   = retry.LastErrorOnly(true)
+	RtyAttNum = uint(3)
+	RtyAttem  = retry.Attempts(RtyAttNum)
+	RtyDelay  = retry.Delay(time.Millisecond * 500)
+	RtyErr    = retry.LastErrorOnly(true)
+
+	replicateTimeOut = 10 * time.Second
 )
 
 func (e *ExecuteModular) HandleReplicatePieceTask(ctx context.Context, task coretask.ReplicatePieceTask) {
@@ -233,11 +236,19 @@ func (e *ExecuteModular) doReplicatePiece(ctx context.Context, waitGroup *sync.W
 	}
 	receive.SetSignature(signature)
 	replicateOnePieceTime := time.Now()
+
 	if err = retry.Do(func() error {
-		return e.baseApp.GfSpClient().ReplicatePieceToSecondary(ctx, spEndpoint, receive, data)
-	}, retry.Context(ctx), RtyAttem, RtyDelay, RtyErr); err != nil {
-		log.CtxErrorw(ctx, "failed to replicate piece", "segment_idx", segmentIdx,
-			"redundancy_idx", redundancyIdx, "error", err)
+		// timeout for single piece replication
+		ctxWithTimeout, cancel := context.WithTimeout(ctx, replicateTimeOut)
+		defer cancel()
+		return e.baseApp.GfSpClient().ReplicatePieceToSecondary(ctxWithTimeout, spEndpoint, receive, data)
+	}, RtyAttem,
+		RtyDelay,
+		RtyErr,
+		retry.OnRetry(func(n uint, err error) {
+			log.CtxErrorw(ctx, "failed to replicate piece", "sp_endpoint", spEndpoint, "segment_idx", segmentIdx, "redundancy_idx", redundancyIdx, "error", err, "attempt", n, "max_attempts", RtyAttNum)
+		})); err != nil {
+		log.CtxErrorw(ctx, "failed to replicate piece", "sp_endpoint", spEndpoint, "segment_idx", segmentIdx, "redundancy_idx", redundancyIdx, "error", err)
 		return err
 	}
 	metrics.PerfPutObjectTime.WithLabelValues("background_replicate_one_piece_cost").Observe(time.Since(replicateOnePieceTime).Seconds())
@@ -285,11 +296,17 @@ func (e *ExecuteModular) doneReplicatePiece(ctx context.Context, rTask coretask.
 	receive.SetSignature(taskSignature)
 	doneReplicateTime := time.Now()
 	if err = retry.Do(func() error {
-		signature, err = e.baseApp.GfSpClient().DoneReplicatePieceToSecondary(ctx, spEndpoint, receive)
+		ctxWithTimeout, cancel := context.WithTimeout(ctx, replicateTimeOut)
+		defer cancel()
+		signature, err = e.baseApp.GfSpClient().DoneReplicatePieceToSecondary(ctxWithTimeout, spEndpoint, receive)
 		return err
-	}, retry.Context(ctx), RtyAttem, RtyDelay, RtyErr); err != nil {
-		log.CtxErrorw(ctx, "failed to done replicate piece", "endpoint", spEndpoint,
-			"redundancy_idx", redundancyIdx, "error", err)
+	}, RtyAttem,
+		RtyDelay,
+		RtyErr,
+		retry.OnRetry(func(n uint, err error) {
+			log.CtxErrorw(ctx, "failed to done replicate piece", "endpoint", spEndpoint, "redundancy_idx", redundancyIdx, "error", err, "attempt", n, "max_attempts", RtyAttNum)
+		})); err != nil {
+		log.CtxErrorw(ctx, "failed to done replicate piece", "endpoint", spEndpoint, "redundancy_idx", redundancyIdx, "error", err)
 		return nil, err
 	}
 	metrics.PerfPutObjectTime.WithLabelValues("background_done_receive_http_cost").Observe(time.Since(doneReplicateTime).Seconds())


### PR DESCRIPTION
### Description

this pr cherry-picks 2 fixes into master.
1. https://github.com/bnb-chain/greenfield-storage-provider/pull/1229 fix: sp should resume picking VGF regardless of RPC error
2. https://github.com/bnb-chain/greenfield-storage-provider/pull/1239 fix: add timeout for RPC calls to Secondary SP

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
