### PR TITLE
fix: fix sp healthy checker dead lock bug

### DIFF
--- a/base/gfspvgmgr/virtual_group_manager.go
+++ b/base/gfspvgmgr/virtual_group_manager.go
@@ -657,17 +657,17 @@ func (checker *HealthChecker) checkSPHealth(sp *sptypes.StorageProvider) bool {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		log.CtxErrorw(context.Background(), "failed to connect to sp", "endpoint", endpoint, "error", err)
+		log.CtxErrorw(context.Background(), "failed to connect to sp", "sp", sp, "error", err)
 		return false
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		log.CtxErrorw(context.Background(), "failed to check sp healthy", "http_status_code", resp.StatusCode, "resp_body", resp.Body)
+		log.CtxErrorw(context.Background(), "failed to check sp healthy", "sp", sp, "http_status_code", resp.StatusCode, "resp_body", resp.Body)
 		return false
 	}
 
-	log.CtxInfow(context.Background(), "succeed to check the sp healthy", "endpoint", endpoint)
+	log.CtxInfow(context.Background(), "succeed to check the sp healthy", "sp", sp)
 	return true
 }
 


### PR DESCRIPTION
### Description

you can not have one thread call RLock twice and call RUnlock twice in sequence,and have an other thread call Lock at the same time.It will deadlock with little possibility.

reference: [sync: document that double RLock isn't safe #15418](https://github.com/golang/go/issues/15418)

### Rationale

should not use RLock twice in the same thread.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
