### PR TITLE
fix:httpcode

### DIFF
--- a/base/gfspclient/approver.go
+++ b/base/gfspclient/approver.go
@@ -14,7 +14,7 @@ func (s *GfSpClient) AskCreateBucketApproval(ctx context.Context, task coretask.
 	conn, connErr := s.ApproverConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect approver", "error", connErr)
-		return false, nil, ErrRPCUnknownWithDetail("client failed to connect approver, error: " + connErr.Error())
+		return false, nil, ErrRPCUnknownWithDetail("client failed to connect approver, error: ", connErr)
 	}
 	req := &gfspserver.GfSpAskApprovalRequest{
 		Request: &gfspserver.GfSpAskApprovalRequest_CreateBucketApprovalTask{
@@ -23,7 +23,7 @@ func (s *GfSpClient) AskCreateBucketApproval(ctx context.Context, task coretask.
 	resp, err := gfspserver.NewGfSpApprovalServiceClient(conn).GfSpAskApproval(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to ask create bucket approval", "error", err)
-		return false, nil, ErrRPCUnknownWithDetail("client failed to ask create bucket approval, error: " + err.Error())
+		return false, nil, ErrRPCUnknownWithDetail("client failed to ask create bucket approval, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return false, nil, resp.GetErr()
@@ -42,7 +42,7 @@ func (s *GfSpClient) AskMigrateBucketApproval(ctx context.Context, task coretask
 	conn, connErr := s.ApproverConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect approver", "error", connErr)
-		return false, nil, ErrRPCUnknownWithDetail("client failed to connect approver, error: " + connErr.Error())
+		return false, nil, ErrRPCUnknownWithDetail("client failed to connect approver, error: ", connErr)
 	}
 	req := &gfspserver.GfSpAskApprovalRequest{
 		Request: &gfspserver.GfSpAskApprovalRequest_MigrateBucketApprovalTask{
@@ -51,7 +51,7 @@ func (s *GfSpClient) AskMigrateBucketApproval(ctx context.Context, task coretask
 	resp, err := gfspserver.NewGfSpApprovalServiceClient(conn).GfSpAskApproval(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to ask create bucket approval", "error", err)
-		return false, nil, ErrRPCUnknownWithDetail("client failed to ask create bucket approval, error: " + err.Error())
+		return false, nil, ErrRPCUnknownWithDetail("client failed to ask create bucket approval, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return false, nil, resp.GetErr()
@@ -70,7 +70,7 @@ func (s *GfSpClient) AskCreateObjectApproval(ctx context.Context, task coretask.
 	conn, connErr := s.ApproverConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect approver", "error", connErr)
-		return false, nil, ErrRPCUnknownWithDetail("client failed to connect approver, error: " + connErr.Error())
+		return false, nil, ErrRPCUnknownWithDetail("client failed to connect approver, error: ", connErr)
 	}
 	req := &gfspserver.GfSpAskApprovalRequest{
 		Request: &gfspserver.GfSpAskApprovalRequest_CreateObjectApprovalTask{
@@ -79,7 +79,7 @@ func (s *GfSpClient) AskCreateObjectApproval(ctx context.Context, task coretask.
 	resp, err := gfspserver.NewGfSpApprovalServiceClient(conn).GfSpAskApproval(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to ask create object approval", "error", err)
-		return false, nil, ErrRPCUnknownWithDetail("client failed to ask create object approval, error: " + err.Error())
+		return false, nil, ErrRPCUnknownWithDetail("client failed to ask create object approval, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return false, nil, resp.GetErr()

--- a/base/gfspclient/authenticator.go
+++ b/base/gfspclient/authenticator.go
@@ -22,7 +22,7 @@ func (s *GfSpClient) VerifyAuthentication(ctx context.Context, auth coremodule.A
 	metrics.PerfAuthTimeHistogram.WithLabelValues("auth_client_create_conn_time").Observe(time.Since(startTime).Seconds())
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect authenticator", "error", connErr)
-		return false, ErrRPCUnknownWithDetail("client failed to connect authenticator, error:" + connErr.Error())
+		return false, ErrRPCUnknownWithDetail("client failed to connect authenticator, error:", connErr)
 	}
 	defer conn.Close()
 	req := &gfspserver.GfSpAuthenticationRequest{
@@ -36,7 +36,7 @@ func (s *GfSpClient) VerifyAuthentication(ctx context.Context, auth coremodule.A
 	metrics.PerfAuthTimeHistogram.WithLabelValues("auth_client_network_time").Observe(time.Since(startRequestTime).Seconds())
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to verify authentication", "error", err)
-		return false, ErrRPCUnknownWithDetail("client failed to verify authentication, error: " + err.Error())
+		return false, ErrRPCUnknownWithDetail("client failed to verify authentication, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return false, resp.GetErr()
@@ -50,7 +50,7 @@ func (s *GfSpClient) GetAuthNonce(ctx context.Context, account string, domain st
 	conn, connErr := s.Connection(ctx, s.authenticatorEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect authenticator", "error", connErr)
-		return 0, 0, "", 0, ErrRPCUnknownWithDetail("client failed to connect authenticator, error: " + connErr.Error())
+		return 0, 0, "", 0, ErrRPCUnknownWithDetail("client failed to connect authenticator, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &gfspserver.GetAuthNonceRequest{
@@ -75,7 +75,7 @@ func (s *GfSpClient) UpdateUserPublicKey(ctx context.Context, account string, do
 	conn, connErr := s.Connection(ctx, s.authenticatorEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect authenticator", "error", connErr)
-		return false, ErrRPCUnknownWithDetail("client failed to connect authenticator, error: " + connErr.Error())
+		return false, ErrRPCUnknownWithDetail("client failed to connect authenticator, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &gfspserver.UpdateUserPublicKeyRequest{
@@ -104,7 +104,7 @@ func (s *GfSpClient) VerifyGNFD1EddsaSignature(ctx context.Context, account stri
 	conn, connErr := s.Connection(ctx, s.authenticatorEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect authenticator", "error", connErr)
-		return false, ErrRPCUnknownWithDetail("client failed to connect authenticator, error: " + connErr.Error())
+		return false, ErrRPCUnknownWithDetail("client failed to connect authenticator, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &gfspserver.VerifyGNFD1EddsaSignatureRequest{

--- a/base/gfspclient/client.go
+++ b/base/gfspclient/client.go
@@ -35,8 +35,11 @@ var (
 	ErrNoSuchObject     = gfsperrors.Register(ClientCodeSpace, http.StatusBadRequest, 98093, "no such object from metadata")
 )
 
-func ErrRPCUnknownWithDetail(detail string) *gfsperrors.GfSpError {
-	return gfsperrors.Register(ClientCodeSpace, http.StatusInternalServerError, 98001, detail)
+func ErrRPCUnknownWithDetail(detail string, err error) *gfsperrors.GfSpError {
+	if gfspErr := gfsperrors.GetGfSpErr(err); gfspErr != nil {
+		return gfspErr
+	}
+	return gfsperrors.Register(ClientCodeSpace, http.StatusInternalServerError, 98001, detail+err.Error())
 }
 
 type GfSpClient struct {
@@ -94,7 +97,7 @@ func (s *GfSpClient) ApproverConn(ctx context.Context, opts ...grpc.DialOption) 
 		conn, err := s.Connection(ctx, s.approverEndpoint, options...)
 		if err != nil {
 			log.CtxErrorw(ctx, "failed to create connection", "error", err)
-			return nil, ErrRPCUnknownWithDetail("failed to create connection, error: " + err.Error())
+			return nil, ErrRPCUnknownWithDetail("failed to create connection, error: ", err)
 		}
 		s.approverConn = conn
 	}
@@ -112,7 +115,7 @@ func (s *GfSpClient) ManagerConn(ctx context.Context, opts ...grpc.DialOption) (
 		conn, err := s.Connection(ctx, s.managerEndpoint, options...)
 		if err != nil {
 			log.CtxErrorw(ctx, "failed to create connection", "error", err)
-			return nil, ErrRPCUnknownWithDetail("failed to create connection, error: " + err.Error())
+			return nil, ErrRPCUnknownWithDetail("failed to create connection, error: ", err)
 		}
 		s.managerConn = conn
 	}
@@ -130,7 +133,7 @@ func (s *GfSpClient) P2PConn(ctx context.Context, opts ...grpc.DialOption) (*grp
 		conn, err := s.Connection(ctx, s.p2pEndpoint, options...)
 		if err != nil {
 			log.CtxErrorw(ctx, "failed to create connection", "error", err)
-			return nil, ErrRPCUnknownWithDetail("failed to create connection, error: " + err.Error())
+			return nil, ErrRPCUnknownWithDetail("failed to create connection, error: ", err)
 		}
 		s.p2pConn = conn
 	}
@@ -148,7 +151,7 @@ func (s *GfSpClient) SignerConn(ctx context.Context, opts ...grpc.DialOption) (*
 		conn, err := s.Connection(ctx, s.signerEndpoint, options...)
 		if err != nil {
 			log.CtxErrorw(ctx, "failed to create connection", "error", err)
-			return nil, ErrRPCUnknownWithDetail("failed to create connection, error: " + err.Error())
+			return nil, ErrRPCUnknownWithDetail("failed to create connection, error: ", err)
 		}
 		s.signerConn = conn
 	}

--- a/base/gfspclient/client.go
+++ b/base/gfspclient/client.go
@@ -36,7 +36,7 @@ var (
 )
 
 func ErrRPCUnknownWithDetail(detail string, err error) *gfsperrors.GfSpError {
-	if gfspErr := gfsperrors.GetGfSpErr(err); gfspErr != nil {
+	if gfspErr := gfsperrors.MakeGfSpError(err); gfspErr != nil {
 		return gfspErr
 	}
 	return gfsperrors.Register(ClientCodeSpace, http.StatusInternalServerError, 98001, detail+err.Error())

--- a/base/gfspclient/client_test.go
+++ b/base/gfspclient/client_test.go
@@ -2,6 +2,7 @@ package gfspclient
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +11,7 @@ import (
 const mockAddress = "localhost:0"
 
 func TestErrRPCUnknownWithDetail(t *testing.T) {
-	err := ErrRPCUnknownWithDetail("mock")
+	err := ErrRPCUnknownWithDetail("mock", errors.New("mock"))
 	assert.NotNil(t, err)
 }
 

--- a/base/gfspclient/downloader.go
+++ b/base/gfspclient/downloader.go
@@ -18,7 +18,7 @@ func (s *GfSpClient) GetObject(ctx context.Context, downloadObjectTask coretask.
 	conn, connErr := s.Connection(ctx, s.downloaderEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect downloader", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect downloader, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect downloader, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &gfspserver.GfSpDownloadObjectRequest{
@@ -27,7 +27,7 @@ func (s *GfSpClient) GetObject(ctx context.Context, downloadObjectTask coretask.
 	resp, err := gfspserver.NewGfSpDownloadServiceClient(conn).GfSpDownloadObject(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to download object", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to download object, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to download object, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return nil, resp.GetErr()
@@ -40,7 +40,7 @@ func (s *GfSpClient) GetPiece(ctx context.Context, downloadPieceTask coretask.Do
 	conn, connErr := s.Connection(ctx, s.downloaderEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect downloader", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect downloader, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect downloader, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &gfspserver.GfSpDownloadPieceRequest{
@@ -49,7 +49,7 @@ func (s *GfSpClient) GetPiece(ctx context.Context, downloadPieceTask coretask.Do
 	resp, err := gfspserver.NewGfSpDownloadServiceClient(conn).GfSpDownloadPiece(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to download piece", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to download piece, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to download piece, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return nil, resp.GetErr()
@@ -61,7 +61,7 @@ func (s *GfSpClient) RecoupQuota(ctx context.Context, bucketID, extraQuota uint6
 	conn, connErr := s.Connection(ctx, s.downloaderEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect downloader", "error", connErr)
-		return ErrRPCUnknownWithDetail("client failed to connect downloader, error: " + connErr.Error())
+		return ErrRPCUnknownWithDetail("client failed to connect downloader, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &gfspserver.GfSpReimburseQuotaRequest{
@@ -73,7 +73,7 @@ func (s *GfSpClient) RecoupQuota(ctx context.Context, bucketID, extraQuota uint6
 	resp, err := gfspserver.NewGfSpDownloadServiceClient(conn).GfSpReimburseQuota(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to recoup the extra quota", "error", err)
-		return ErrRPCUnknownWithDetail("client failed to recoup extra quota, error: " + err.Error())
+		return ErrRPCUnknownWithDetail("client failed to recoup extra quota, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return resp.GetErr()
@@ -85,7 +85,7 @@ func (s *GfSpClient) DeductQuotaForBucketMigrate(ctx context.Context, bucketID, 
 	conn, connErr := s.Connection(ctx, s.downloaderEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect downloader", "error", connErr)
-		return ErrRPCUnknownWithDetail("client failed to connect downloader, error: " + connErr.Error())
+		return ErrRPCUnknownWithDetail("client failed to connect downloader, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &gfspserver.GfSpDeductQuotaForBucketMigrateRequest{
@@ -97,7 +97,7 @@ func (s *GfSpClient) DeductQuotaForBucketMigrate(ctx context.Context, bucketID, 
 	resp, err := gfspserver.NewGfSpDownloadServiceClient(conn).GfSpDeductQuotaForBucketMigrate(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to deduct the quota for bucket migrate", "request", req, "error", err)
-		return ErrRPCUnknownWithDetail("client failed to deduct the quota for bucket migrate, error: " + err.Error())
+		return ErrRPCUnknownWithDetail("client failed to deduct the quota for bucket migrate, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return resp.GetErr()
@@ -110,7 +110,7 @@ func (s *GfSpClient) GetChallengeInfo(ctx context.Context, challengePieceTask co
 	conn, connErr := s.Connection(ctx, s.downloaderEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect downloader", "error", connErr)
-		return nil, nil, nil, ErrRPCUnknownWithDetail("client failed to connect downloader, error: " + connErr.Error())
+		return nil, nil, nil, ErrRPCUnknownWithDetail("client failed to connect downloader, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &gfspserver.GfSpGetChallengeInfoRequest{
@@ -121,7 +121,7 @@ func (s *GfSpClient) GetChallengeInfo(ctx context.Context, challengePieceTask co
 	metrics.PerfChallengeTimeHistogram.WithLabelValues("challenge_client_total_time").Observe(time.Since(startTime).Seconds())
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to get challenge piece info", "error", err)
-		return nil, nil, nil, ErrRPCUnknownWithDetail("client failed to get challenge piece info, error: " + err.Error())
+		return nil, nil, nil, ErrRPCUnknownWithDetail("client failed to get challenge piece info, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return nil, nil, nil, resp.GetErr()

--- a/base/gfspclient/manager.go
+++ b/base/gfspclient/manager.go
@@ -16,7 +16,7 @@ func (s *GfSpClient) CreateUploadObject(ctx context.Context, task coretask.Uploa
 	conn, connErr := s.ManagerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect manager", "error", connErr)
-		return ErrRPCUnknownWithDetail("client failed to connect manager, error: " + connErr.Error())
+		return ErrRPCUnknownWithDetail("client failed to connect manager, error: ", connErr)
 	}
 	req := &gfspserver.GfSpBeginTaskRequest{
 		Request: &gfspserver.GfSpBeginTaskRequest_UploadObjectTask{
@@ -26,7 +26,7 @@ func (s *GfSpClient) CreateUploadObject(ctx context.Context, task coretask.Uploa
 	resp, err := gfspserver.NewGfSpManageServiceClient(conn).GfSpBeginTask(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to create upload object task", "error", err)
-		return ErrRPCUnknownWithDetail("client failed to create upload object task, error: " + err.Error())
+		return ErrRPCUnknownWithDetail("client failed to create upload object task, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return resp.GetErr()
@@ -38,7 +38,7 @@ func (s *GfSpClient) CreateResumableUploadObject(ctx context.Context, task coret
 	conn, connErr := s.ManagerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect manager", "error", connErr)
-		return ErrRPCUnknownWithDetail("client failed to connect manager, error: " + connErr.Error())
+		return ErrRPCUnknownWithDetail("client failed to connect manager, error: ", connErr)
 	}
 	req := &gfspserver.GfSpBeginTaskRequest{
 		Request: &gfspserver.GfSpBeginTaskRequest_ResumableUploadObjectTask{
@@ -48,7 +48,7 @@ func (s *GfSpClient) CreateResumableUploadObject(ctx context.Context, task coret
 	resp, err := gfspserver.NewGfSpManageServiceClient(conn).GfSpBeginTask(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to create resummable upload object task", "error", err)
-		return ErrRPCUnknownWithDetail("client failed to create resummable upload object task, error: " + err.Error())
+		return ErrRPCUnknownWithDetail("client failed to create resummable upload object task, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return resp.GetErr()
@@ -60,7 +60,7 @@ func (s *GfSpClient) AskTask(ctx context.Context, limit corercmgr.Limit) (coreta
 	conn, connErr := s.ManagerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect manager", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect manager, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect manager, error: ", connErr)
 	}
 	req := &gfspserver.GfSpAskTaskRequest{
 		NodeLimit: limit.(*gfsplimit.GfSpLimit),
@@ -68,7 +68,7 @@ func (s *GfSpClient) AskTask(ctx context.Context, limit corercmgr.Limit) (coreta
 	resp, err := gfspserver.NewGfSpManageServiceClient(conn).GfSpAskTask(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to ask task", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to ask task, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to ask task, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return nil, resp.GetErr()
@@ -99,7 +99,7 @@ func (s *GfSpClient) ReportTask(ctx context.Context, report coretask.Task) error
 	conn, connErr := s.ManagerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect manager", "error", connErr)
-		return ErrRPCUnknownWithDetail("client failed to connect manager, error: " + connErr.Error())
+		return ErrRPCUnknownWithDetail("client failed to connect manager, error: ", connErr)
 	}
 	req := &gfspserver.GfSpReportTaskRequest{}
 	switch t := report.(type) {
@@ -134,7 +134,7 @@ func (s *GfSpClient) ReportTask(ctx context.Context, report coretask.Task) error
 	resp, err := gfspserver.NewGfSpManageServiceClient(conn).GfSpReportTask(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to report task", "error", err)
-		return ErrRPCUnknownWithDetail("client failed to report task, error: " + err.Error())
+		return ErrRPCUnknownWithDetail("client failed to report task, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return resp.GetErr()
@@ -146,7 +146,7 @@ func (s *GfSpClient) PickVirtualGroupFamilyID(ctx context.Context, task coretask
 	conn, connErr := s.ManagerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect manager", "error", connErr)
-		return 0, ErrRPCUnknownWithDetail("client failed to connect manager, error: " + connErr.Error())
+		return 0, ErrRPCUnknownWithDetail("client failed to connect manager, error: ", connErr)
 	}
 	req := &gfspserver.GfSpPickVirtualGroupFamilyRequest{
 		CreateBucketApprovalTask: task.(*gfsptask.GfSpCreateBucketApprovalTask),
@@ -154,7 +154,7 @@ func (s *GfSpClient) PickVirtualGroupFamilyID(ctx context.Context, task coretask
 	resp, err := gfspserver.NewGfSpManageServiceClient(conn).GfSpPickVirtualGroupFamily(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to pick virtual group family id", "error", err)
-		return 0, ErrRPCUnknownWithDetail("client failed to pick virtual group family id, error: " + err.Error())
+		return 0, ErrRPCUnknownWithDetail("client failed to pick virtual group family id, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return 0, resp.GetErr()
@@ -166,7 +166,7 @@ func (s *GfSpClient) NotifyMigrateSwapOut(ctx context.Context, swapOut *virtualg
 	conn, connErr := s.ManagerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect manager", "error", connErr)
-		return ErrRPCUnknownWithDetail("client failed to connect manager, error: " + connErr.Error())
+		return ErrRPCUnknownWithDetail("client failed to connect manager, error: ", connErr)
 	}
 	req := &gfspserver.GfSpNotifyMigrateSwapOutRequest{
 		SwapOut: swapOut,
@@ -174,7 +174,7 @@ func (s *GfSpClient) NotifyMigrateSwapOut(ctx context.Context, swapOut *virtualg
 	resp, err := gfspserver.NewGfSpManageServiceClient(conn).GfSpNotifyMigrateSwapOut(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to notify migrate swap out", "request", req, "error", err)
-		return ErrRPCUnknownWithDetail("client failed to notify migrate swap out, error: " + err.Error())
+		return ErrRPCUnknownWithDetail("client failed to notify migrate swap out, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		log.CtxErrorw(ctx, "failed to notify migrate swap out", "request", req, "error", resp.GetErr())
@@ -187,12 +187,12 @@ func (s *GfSpClient) GetTasksStats(ctx context.Context) (*gfspserver.TasksStats,
 	conn, connErr := s.ManagerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect manager", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect manager, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect manager, error: ", connErr)
 	}
 	resp, err := gfspserver.NewGfSpManageServiceClient(conn).GfSpQueryTasksStats(ctx, &gfspserver.GfSpQueryTasksStatsRequest{})
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to query manager's task stats", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to query manager's task stats, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to query manager's task stats, error: ", err)
 	}
 	return resp.GetStats(), nil
 }
@@ -201,7 +201,7 @@ func (s *GfSpClient) NotifyPreMigrateBucket(ctx context.Context, bucketID uint64
 	conn, connErr := s.ManagerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect manager", "error", connErr)
-		return ErrRPCUnknownWithDetail("client failed to connect manager, error: " + connErr.Error())
+		return ErrRPCUnknownWithDetail("client failed to connect manager, error: ", connErr)
 	}
 	req := &gfspserver.GfSpNotifyPreMigrateBucketRequest{
 		BucketId: bucketID,
@@ -209,7 +209,7 @@ func (s *GfSpClient) NotifyPreMigrateBucket(ctx context.Context, bucketID uint64
 	resp, err := gfspserver.NewGfSpManageServiceClient(conn).GfSpNotifyPreMigrate(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to notify pre migrate bucket", "request", req, "error", err)
-		return ErrRPCUnknownWithDetail("client failed to notify pre migrate bucket, error: " + err.Error())
+		return ErrRPCUnknownWithDetail("client failed to notify pre migrate bucket, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		log.CtxErrorw(ctx, "failed to notify pre migrate bucket", "request", req, "error", resp.GetErr())
@@ -222,7 +222,7 @@ func (s *GfSpClient) NotifyPostMigrateBucket(ctx context.Context, bucketID uint6
 	conn, connErr := s.ManagerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect manager", "error", connErr)
-		return ErrRPCUnknownWithDetail("client failed to connect manager, error: " + connErr.Error())
+		return ErrRPCUnknownWithDetail("client failed to connect manager, error: ", connErr)
 	}
 	req := &gfspserver.GfSpNotifyPostMigrateBucketRequest{
 		BucketId: bucketID,
@@ -230,7 +230,7 @@ func (s *GfSpClient) NotifyPostMigrateBucket(ctx context.Context, bucketID uint6
 	resp, err := gfspserver.NewGfSpManageServiceClient(conn).GfSpNotifyPostMigrate(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to notify post migrate bucket", "request", req, "error", err)
-		return ErrRPCUnknownWithDetail("client failed to notify post migrate bucket, error: " + err.Error())
+		return ErrRPCUnknownWithDetail("client failed to notify post migrate bucket, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		log.CtxErrorw(ctx, "failed to notify post migrate bucket", "request", req, "error", resp.GetErr())
@@ -243,12 +243,12 @@ func (s *GfSpClient) ResetRecoveryFailedList(ctx context.Context) ([]string, err
 	conn, connErr := s.ManagerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect manager", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect manager, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect manager, error: ", connErr)
 	}
 	resp, err := gfspserver.NewGfSpManageServiceClient(conn).GfSpResetRecoveryFailedList(ctx, &gfspserver.GfSpResetRecoveryFailedListRequest{})
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to reset manager's recovery failed list", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to reset manager's recovery failed list, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to reset manager's recovery failed list, error: ", err)
 	}
 	return resp.GetRecoveryFailedList(), nil
 }

--- a/base/gfspclient/metadata.go
+++ b/base/gfspclient/metadata.go
@@ -19,7 +19,7 @@ import (
 func (s *GfSpClient) GetUserBucketsCount(ctx context.Context, account string, includeRemoved bool, opts ...grpc.DialOption) (int64, error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
-		return 0, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + err.Error())
+		return 0, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", err)
 	}
 	defer conn.Close()
 	req := &types.GfSpGetUserBucketsCountRequest{
@@ -29,7 +29,7 @@ func (s *GfSpClient) GetUserBucketsCount(ctx context.Context, account string, in
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetUserBucketsCount(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get user buckets count", "error", err)
-		return 0, ErrRPCUnknownWithDetail("failed to get user buckets count, error: " + err.Error())
+		return 0, ErrRPCUnknownWithDetail("failed to get user buckets count, error: ", err)
 	}
 	return resp.GetCount(), nil
 }
@@ -38,7 +38,7 @@ func (s *GfSpClient) ListDeletedObjectsByBlockNumberRange(ctx context.Context, s
 	endBlockNumber uint64, includePrivate bool, opts ...grpc.DialOption) ([]*types.Object, uint64, error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
-		return nil, uint64(0), ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + err.Error())
+		return nil, uint64(0), ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", err)
 	}
 	defer conn.Close()
 	req := &types.GfSpListDeletedObjectsByBlockNumberRangeRequest{
@@ -49,7 +49,7 @@ func (s *GfSpClient) ListDeletedObjectsByBlockNumberRange(ctx context.Context, s
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpListDeletedObjectsByBlockNumberRange(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to list deleted objects by block number range", "error", err)
-		return nil, uint64(0), ErrRPCUnknownWithDetail("failed to list deleted objects by block number range, error: " + err.Error())
+		return nil, uint64(0), ErrRPCUnknownWithDetail("failed to list deleted objects by block number range, error: ", err)
 	}
 	return resp.GetObjects(), uint64(resp.GetEndBlockNumber()), nil
 }
@@ -57,7 +57,7 @@ func (s *GfSpClient) ListDeletedObjectsByBlockNumberRange(ctx context.Context, s
 func (s *GfSpClient) GetUserBuckets(ctx context.Context, account string, includeRemoved bool, opts ...grpc.DialOption) ([]*types.VGFInfoBucket, error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", err)
 	}
 	defer conn.Close()
 	req := &types.GfSpGetUserBucketsRequest{
@@ -67,7 +67,7 @@ func (s *GfSpClient) GetUserBuckets(ctx context.Context, account string, include
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetUserBuckets(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get user buckets", "error", err)
-		return nil, ErrRPCUnknownWithDetail("failed to get user buckets, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("failed to get user buckets, error: ", err)
 	}
 	return resp.GetBuckets(), nil
 }
@@ -79,7 +79,7 @@ func (s *GfSpClient) ListObjectsByBucketName(ctx context.Context, bucketName str
 	commonPrefixes []string, continuationTokenRe string, err error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
-		return nil, 0, 0, false, "", "", "", "", nil, "", ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + err.Error())
+		return nil, 0, 0, false, "", "", "", "", nil, "", ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", err)
 	}
 	defer conn.Close()
 
@@ -98,7 +98,7 @@ func (s *GfSpClient) ListObjectsByBucketName(ctx context.Context, bucketName str
 	ctx = log.Context(ctx, resp)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to send list objects by bucket name rpc", "error", err)
-		return nil, 0, 0, false, "", "", "", "", nil, "", ErrRPCUnknownWithDetail("failed to send list objects by bucket name rpc, error: " + err.Error())
+		return nil, 0, 0, false, "", "", "", "", nil, "", ErrRPCUnknownWithDetail("failed to send list objects by bucket name rpc, error: ", err)
 	}
 	return resp.GetObjects(), resp.GetKeyCount(), resp.GetMaxKeys(), resp.GetIsTruncated(), resp.GetNextContinuationToken(),
 		resp.GetName(), resp.GetPrefix(), resp.GetDelimiter(), resp.GetCommonPrefixes(), resp.GetContinuationToken(), nil
@@ -109,7 +109,7 @@ func (s *GfSpClient) GetBucketByBucketName(ctx context.Context, bucketName strin
 	opts ...grpc.DialOption) (*types.Bucket, error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", err)
 	}
 	defer conn.Close()
 
@@ -122,7 +122,7 @@ func (s *GfSpClient) GetBucketByBucketName(ctx context.Context, bucketName strin
 	ctx = log.Context(ctx, resp)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to send get bucket rpc by bucket name", "error", err)
-		return nil, ErrRPCUnknownWithDetail("failed to send get bucket rpc by bucket name, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("failed to send get bucket rpc by bucket name, error: ", err)
 	}
 	return resp.GetBucket(), nil
 }
@@ -132,7 +132,7 @@ func (s *GfSpClient) GetBucketByBucketID(ctx context.Context, bucketID int64, in
 	opts ...grpc.DialOption) (*types.Bucket, error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", err)
 	}
 	defer conn.Close()
 
@@ -145,7 +145,7 @@ func (s *GfSpClient) GetBucketByBucketID(ctx context.Context, bucketID int64, in
 	ctx = log.Context(ctx, resp)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to send get bucket by bucket id rpc", "error", err)
-		return nil, ErrRPCUnknownWithDetail("failed to send get bucket by bucket id rpc, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("failed to send get bucket by bucket id rpc, error: ", err)
 	}
 	return resp.GetBucket(), nil
 }
@@ -155,7 +155,7 @@ func (s *GfSpClient) ListExpiredBucketsBySp(ctx context.Context, createAt int64,
 	limit int64, opts ...grpc.DialOption) ([]*types.Bucket, error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", err)
 	}
 	defer conn.Close()
 
@@ -169,7 +169,7 @@ func (s *GfSpClient) ListExpiredBucketsBySp(ctx context.Context, createAt int64,
 	ctx = log.Context(ctx, resp)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to send list expired buckets by sp rpc", "error", err)
-		return nil, ErrRPCUnknownWithDetail("failed to send list expired buckets by sp rpc, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("failed to send list expired buckets by sp rpc, error: ", err)
 	}
 	return resp.GetBuckets(), nil
 }
@@ -179,7 +179,7 @@ func (s *GfSpClient) GetObjectMeta(ctx context.Context, objectName string, bucke
 	includePrivate bool, opts ...grpc.DialOption) (*types.Object, error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", err)
 	}
 	defer conn.Close()
 
@@ -193,7 +193,7 @@ func (s *GfSpClient) GetObjectMeta(ctx context.Context, objectName string, bucke
 	ctx = log.Context(ctx, resp)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to send get object meta rpc", "error", err)
-		return nil, ErrRPCUnknownWithDetail("failed to send get object meta rpc, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("failed to send get object meta rpc, error: ", err)
 	}
 	return resp.GetObject(), nil
 }
@@ -203,7 +203,7 @@ func (s *GfSpClient) GetPaymentByBucketName(ctx context.Context, bucketName stri
 	opts ...grpc.DialOption) (*payment_types.StreamRecord, error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", err)
 	}
 	defer conn.Close()
 
@@ -216,7 +216,7 @@ func (s *GfSpClient) GetPaymentByBucketName(ctx context.Context, bucketName stri
 	ctx = log.Context(ctx, resp)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to send get payment by bucket name rpc", "error", err)
-		return nil, ErrRPCUnknownWithDetail("failed to send get payment by bucket name rpc, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("failed to send get payment by bucket name rpc, error: ", err)
 	}
 	return resp.GetStreamRecord(), nil
 }
@@ -226,7 +226,7 @@ func (s *GfSpClient) GetPaymentByBucketID(ctx context.Context, bucketID int64, i
 	opts ...grpc.DialOption) (*payment_types.StreamRecord, error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", err)
 	}
 	defer conn.Close()
 
@@ -239,7 +239,7 @@ func (s *GfSpClient) GetPaymentByBucketID(ctx context.Context, bucketID int64, i
 	ctx = log.Context(ctx, resp)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to send get payment by bucket id rpc", "error", err)
-		return nil, ErrRPCUnknownWithDetail("failed to send get payment by bucket id rpc, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("failed to send get payment by bucket id rpc, error: ", err)
 	}
 	return resp.GetStreamRecord(), nil
 }
@@ -249,7 +249,7 @@ func (s *GfSpClient) VerifyPermission(ctx context.Context, Operator string, buck
 	actionType permission_types.ActionType, opts ...grpc.DialOption) (*permission_types.Effect, error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", err)
 	}
 	defer conn.Close()
 
@@ -264,7 +264,7 @@ func (s *GfSpClient) VerifyPermission(ctx context.Context, Operator string, buck
 	ctx = log.Context(ctx, resp)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to send verify permission rpc", "error", err)
-		return nil, ErrRPCUnknownWithDetail("failed to send verify permission rpc, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("failed to send verify permission rpc, error: ", err)
 	}
 	return &resp.Effect, nil
 }
@@ -274,7 +274,7 @@ func (s *GfSpClient) GetBucketMeta(ctx context.Context, bucketName string, inclu
 	opts ...grpc.DialOption) (*types.VGFInfoBucket, *payment_types.StreamRecord, error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
-		return nil, nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + err.Error())
+		return nil, nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", err)
 	}
 	defer conn.Close()
 
@@ -287,7 +287,7 @@ func (s *GfSpClient) GetBucketMeta(ctx context.Context, bucketName string, inclu
 	ctx = log.Context(ctx, resp)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to send get bucket meta rpc", "error", err)
-		return nil, nil, ErrRPCUnknownWithDetail("failed to send get bucket meta rpc, error: " + err.Error())
+		return nil, nil, ErrRPCUnknownWithDetail("failed to send get bucket meta rpc, error: ", err)
 	}
 	return resp.GetBucket(), resp.GetStreamRecord(), nil
 }
@@ -297,7 +297,7 @@ func (s *GfSpClient) GetEndpointBySpID(ctx context.Context, spId uint32, opts ..
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return "", ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpGetEndpointBySpIDRequest{
@@ -307,7 +307,7 @@ func (s *GfSpClient) GetEndpointBySpID(ctx context.Context, spId uint32, opts ..
 	ctx = log.Context(ctx, resp)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to send get sp by address rpc", "error", err)
-		return "", ErrRPCUnknownWithDetail("failed to send get sp by address rpc, error: " + err.Error())
+		return "", ErrRPCUnknownWithDetail("failed to send get sp by address rpc, error: ", err)
 	}
 	return resp.GetEndpoint(), nil
 }
@@ -317,7 +317,7 @@ func (s *GfSpClient) GetBucketReadQuota(ctx context.Context, bucket *storage_typ
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return uint64(0), uint64(0), uint64(0), uint64(0), ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return uint64(0), uint64(0), uint64(0), uint64(0), ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpGetBucketReadQuotaRequest{
@@ -327,7 +327,7 @@ func (s *GfSpClient) GetBucketReadQuota(ctx context.Context, bucket *storage_typ
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetBucketReadQuota(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to get bucket read quota", "error", err)
-		return uint64(0), uint64(0), uint64(0), uint64(0), ErrRPCUnknownWithDetail("client failed to get bucket read quota, error: " + err.Error())
+		return uint64(0), uint64(0), uint64(0), uint64(0), ErrRPCUnknownWithDetail("client failed to get bucket read quota, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return uint64(0), uint64(0), uint64(0), uint64(0), resp.GetErr()
@@ -341,7 +341,7 @@ func (s *GfSpClient) GetLatestBucketReadQuota(ctx context.Context, bucketID uint
 	quota := gfsptask.GfSpBucketQuotaInfo{}
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return quota, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return quota, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpGetLatestBucketReadQuotaRequest{
@@ -350,7 +350,7 @@ func (s *GfSpClient) GetLatestBucketReadQuota(ctx context.Context, bucketID uint
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetLatestBucketReadQuota(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to get latest bucket read quota", "error", err)
-		return quota, ErrRPCUnknownWithDetail("client failed to get latest bucket read quota, error: " + err.Error())
+		return quota, ErrRPCUnknownWithDetail("client failed to get latest bucket read quota, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return quota, resp.GetErr()
@@ -371,7 +371,7 @@ func (s *GfSpClient) ListBucketReadRecord(ctx context.Context, bucket *storage_t
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, 0, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, 0, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpListBucketReadRecordRequest{
@@ -383,7 +383,7 @@ func (s *GfSpClient) ListBucketReadRecord(ctx context.Context, bucket *storage_t
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpListBucketReadRecord(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to list bucket read record", "error", err)
-		return nil, 0, ErrRPCUnknownWithDetail("client failed to list bucket read record, error: " + err.Error())
+		return nil, 0, ErrRPCUnknownWithDetail("client failed to list bucket read record, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return nil, 0, resp.GetErr()
@@ -395,7 +395,7 @@ func (s *GfSpClient) GetUploadObjectState(ctx context.Context, objectID uint64, 
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return 0, "", ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return 0, "", ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpQueryUploadProgressRequest{
@@ -404,7 +404,7 @@ func (s *GfSpClient) GetUploadObjectState(ctx context.Context, objectID uint64, 
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpQueryUploadProgress(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to get uploading object state", "error", err)
-		return 0, "", ErrRPCUnknownWithDetail("client failed to get uploading object state, error: " + err.Error())
+		return 0, "", ErrRPCUnknownWithDetail("client failed to get uploading object state, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return 0, "", resp.GetErr()
@@ -416,7 +416,7 @@ func (s *GfSpClient) GetUploadObjectSegment(ctx context.Context, objectID uint64
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return 0, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return 0, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpQueryResumableUploadSegmentRequest{
@@ -425,7 +425,7 @@ func (s *GfSpClient) GetUploadObjectSegment(ctx context.Context, objectID uint64
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpQueryResumableUploadSegment(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to get uploading object segment", "error", err)
-		return 0, ErrRPCUnknownWithDetail("client failed to get uploading object segment, error: " + err.Error())
+		return 0, ErrRPCUnknownWithDetail("client failed to get uploading object segment, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return 0, resp.GetErr()
@@ -438,7 +438,7 @@ func (s *GfSpClient) GetGroupList(ctx context.Context, name string, prefix strin
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, 0, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, 0, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpGetGroupListRequest{
@@ -452,7 +452,7 @@ func (s *GfSpClient) GetGroupList(ctx context.Context, name string, prefix strin
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetGroupList(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to get group list", "error", err)
-		return nil, 0, ErrRPCUnknownWithDetail("client failed to get group list, error: " + err.Error())
+		return nil, 0, ErrRPCUnknownWithDetail("client failed to get group list, error: ", err)
 	}
 	return resp.Groups, resp.Count, nil
 }
@@ -461,7 +461,7 @@ func (s *GfSpClient) ListBucketsByIDs(ctx context.Context, bucketIDs []uint64, i
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpListBucketsByIDsRequest{
@@ -471,7 +471,7 @@ func (s *GfSpClient) ListBucketsByIDs(ctx context.Context, bucketIDs []uint64, i
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpListBucketsByIDs(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to list buckets by bucket ids", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to list buckets by bucket ids, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to list buckets by bucket ids, error: ", err)
 	}
 	return resp.Buckets, nil
 }
@@ -480,7 +480,7 @@ func (s *GfSpClient) ListObjectsByIDs(ctx context.Context, objectIDs []uint64, i
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpListObjectsByIDsRequest{
@@ -490,7 +490,7 @@ func (s *GfSpClient) ListObjectsByIDs(ctx context.Context, objectIDs []uint64, i
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpListObjectsByIDs(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to list objects by object ids", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to list objects by object ids, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to list objects by object ids, error: ", err)
 	}
 	return resp.Objects, nil
 }
@@ -499,14 +499,14 @@ func (s *GfSpClient) ListVirtualGroupFamiliesSpID(ctx context.Context, spID uint
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpListVirtualGroupFamiliesBySpIDRequest{SpId: spID}
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpListVirtualGroupFamiliesBySpID(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to list virtual group families by sp id", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to list virtual group families by sp id, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to list virtual group families by sp id, error: ", err)
 	}
 	return resp.GlobalVirtualGroupFamilies, nil
 }
@@ -515,14 +515,14 @@ func (s *GfSpClient) GetGlobalVirtualGroupByGvgID(ctx context.Context, gvgID uin
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpGetGlobalVirtualGroupByGvgIDRequest{GvgId: gvgID}
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetGlobalVirtualGroupByGvgID(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to get global virtual group by gvg id", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to get global virtual group by gvg id, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to get global virtual group by gvg id, error: ", err)
 	}
 	return resp.GlobalVirtualGroup, nil
 }
@@ -531,7 +531,7 @@ func (s *GfSpClient) ListObjectsInGVGAndBucket(ctx context.Context, gvgID uint32
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpListObjectsInGVGAndBucketRequest{
@@ -543,7 +543,7 @@ func (s *GfSpClient) ListObjectsInGVGAndBucket(ctx context.Context, gvgID uint32
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpListObjectsInGVGAndBucket(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to list objects by gvg id in gvg and bucket", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to list objects by gvg id in gvg and bucket, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to list objects by gvg id in gvg and bucket, error: ", err)
 	}
 	return resp.Objects, nil
 }
@@ -552,7 +552,7 @@ func (s *GfSpClient) ListObjectsInGVG(ctx context.Context, gvgID uint32, startAf
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpListObjectsInGVGRequest{
@@ -563,7 +563,7 @@ func (s *GfSpClient) ListObjectsInGVG(ctx context.Context, gvgID uint32, startAf
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpListObjectsInGVG(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to list objects by gvg id", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to list objects by gvg id, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to list objects by gvg id, error: ", err)
 	}
 	return resp.Objects, nil
 }
@@ -572,7 +572,7 @@ func (s *GfSpClient) ListObjectsByGVGAndBucketForGC(ctx context.Context, gvgID u
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpListObjectsByGVGAndBucketForGCRequest{
@@ -584,7 +584,7 @@ func (s *GfSpClient) ListObjectsByGVGAndBucketForGC(ctx context.Context, gvgID u
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpListObjectsByGVGAndBucketForGC(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to list objects by gvg and bucket for gc", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to list objects by gvg and bucket for gc, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to list objects by gvg and bucket for gc, error: ", err)
 	}
 	return resp.Objects, nil
 }
@@ -593,14 +593,14 @@ func (s *GfSpClient) GetVirtualGroupFamily(ctx context.Context, vgfID uint32, op
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpGetVirtualGroupFamilyRequest{VgfId: vgfID}
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetVirtualGroupFamily(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to get global virtual group family by vgf id", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to get global virtual group family by vgf id, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to get global virtual group family by vgf id, error: ", err)
 	}
 	return resp.Vgf, nil
 }
@@ -609,7 +609,7 @@ func (s *GfSpClient) GetGlobalVirtualGroup(ctx context.Context, bucketID uint64,
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpGetGlobalVirtualGroupRequest{
@@ -619,7 +619,7 @@ func (s *GfSpClient) GetGlobalVirtualGroup(ctx context.Context, bucketID uint64,
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetGlobalVirtualGroup(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to get global virtual group by lvg id and bucket id", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to get global virtual group by lvg id and bucket id, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to get global virtual group by lvg id and bucket id, error: ", err)
 	}
 	return resp.Gvg, nil
 }
@@ -628,7 +628,7 @@ func (s *GfSpClient) ListGlobalVirtualGroupsByBucket(ctx context.Context, bucket
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpListGlobalVirtualGroupsByBucketRequest{
@@ -637,7 +637,7 @@ func (s *GfSpClient) ListGlobalVirtualGroupsByBucket(ctx context.Context, bucket
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpListGlobalVirtualGroupsByBucket(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to list global virtual group by bucket id", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to list global virtual group by bucket id: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to list global virtual group by bucket id: ", err)
 	}
 	return resp.Groups, nil
 }
@@ -646,7 +646,7 @@ func (s *GfSpClient) ListGlobalVirtualGroupsBySecondarySP(ctx context.Context, s
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpListGlobalVirtualGroupsBySecondarySPRequest{
@@ -655,7 +655,7 @@ func (s *GfSpClient) ListGlobalVirtualGroupsBySecondarySP(ctx context.Context, s
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpListGlobalVirtualGroupsBySecondarySP(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to list global virtual group by secondary sp id", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to list global virtual group by secondary sp id: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to list global virtual group by secondary sp id: ", err)
 	}
 	return resp.Groups, nil
 }
@@ -664,7 +664,7 @@ func (s *GfSpClient) ListMigrateBucketEvents(ctx context.Context, blockID uint64
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpListMigrateBucketEventsRequest{
@@ -674,7 +674,7 @@ func (s *GfSpClient) ListMigrateBucketEvents(ctx context.Context, blockID uint64
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpListMigrateBucketEvents(ctx, req)
 	if err != nil {
 		// log.CtxErrorw(ctx, "client failed to list migrate bucket events", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to list migrate bucket events, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to list migrate bucket events, error: ", err)
 	}
 	return resp.Events, nil
 }
@@ -683,7 +683,7 @@ func (s *GfSpClient) ListSwapOutEvents(ctx context.Context, blockID uint64, spID
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpListSwapOutEventsRequest{
@@ -693,7 +693,7 @@ func (s *GfSpClient) ListSwapOutEvents(ctx context.Context, blockID uint64, spID
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpListSwapOutEvents(ctx, req)
 	if err != nil {
 		// log.CtxErrorw(ctx, "client failed to list migrate swap out events", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to list migrate swap out events, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to list migrate swap out events, error: ", err)
 	}
 	return resp.Events, nil
 }
@@ -702,7 +702,7 @@ func (s *GfSpClient) ListSpExitEvents(ctx context.Context, blockID uint64, spID 
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpListSpExitEventsRequest{
@@ -712,7 +712,7 @@ func (s *GfSpClient) ListSpExitEvents(ctx context.Context, blockID uint64, spID 
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpListSpExitEvents(ctx, req)
 	if err != nil {
 		// log.CtxErrorw(ctx, "client failed to list sp exit events", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to list sp exit events, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to list sp exit events, error: ", err)
 	}
 	return resp.Events, nil
 }
@@ -721,7 +721,7 @@ func (s *GfSpClient) GetObjectByID(ctx context.Context, objectID uint64, opts ..
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpListObjectsByIDsRequest{
@@ -731,7 +731,7 @@ func (s *GfSpClient) GetObjectByID(ctx context.Context, objectID uint64, opts ..
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpListObjectsByIDs(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to list objects by object ids", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to list objects by object ids, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to list objects by object ids, error: ", err)
 	}
 	if len(resp.GetObjects()) == 0 {
 		return nil, ErrNoSuchObject
@@ -750,7 +750,7 @@ func (s *GfSpClient) VerifyPermissionByID(ctx context.Context, Operator string, 
 	actionType permission_types.ActionType, opts ...grpc.DialOption) (*permission_types.Effect, error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", err)
 	}
 	defer conn.Close()
 
@@ -765,7 +765,7 @@ func (s *GfSpClient) VerifyPermissionByID(ctx context.Context, Operator string, 
 	ctx = log.Context(ctx, resp)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to send verify permission by id rpc", "error", err)
-		return nil, ErrRPCUnknownWithDetail("failed to send verify permission by id rpc, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("failed to send verify permission by id rpc, error: ", err)
 	}
 	return &resp.Effect, nil
 }
@@ -774,7 +774,7 @@ func (s *GfSpClient) GetSPInfo(ctx context.Context, operatorAddress string, opts
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpGetSPInfoRequest{
@@ -783,7 +783,7 @@ func (s *GfSpClient) GetSPInfo(ctx context.Context, operatorAddress string, opts
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetSPInfo(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to get sp info by operator address", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to get sp info by operator address, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to get sp info by operator address, error: ", err)
 	}
 	return resp.GetStorageProvider(), nil
 }
@@ -792,14 +792,14 @@ func (s *GfSpClient) GetStatus(ctx context.Context, opts ...grpc.DialOption) (*t
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpGetStatusRequest{}
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetStatus(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to get debug info", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to get debug info, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to get debug info, error: ", err)
 	}
 	return resp.GetStatus(), nil
 }
@@ -808,7 +808,7 @@ func (s *GfSpClient) GetUserGroups(ctx context.Context, accountID string, startA
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpGetUserGroupsRequest{
@@ -819,7 +819,7 @@ func (s *GfSpClient) GetUserGroups(ctx context.Context, accountID string, startA
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetUserGroups(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to get user groups", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to get user groups, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to get user groups, error: ", err)
 	}
 	return resp.Groups, nil
 }
@@ -828,7 +828,7 @@ func (s *GfSpClient) GetGroupMembers(ctx context.Context, groupID uint64, startA
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpGetGroupMembersRequest{
@@ -839,7 +839,7 @@ func (s *GfSpClient) GetGroupMembers(ctx context.Context, groupID uint64, startA
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetGroupMembers(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to get group members", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to get group members, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to get group members, error: ", err)
 	}
 	return resp.Groups, nil
 }
@@ -848,7 +848,7 @@ func (s *GfSpClient) GetUserOwnedGroups(ctx context.Context, accountID string, s
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpGetUserOwnedGroupsRequest{
@@ -859,7 +859,7 @@ func (s *GfSpClient) GetUserOwnedGroups(ctx context.Context, accountID string, s
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetUserOwnedGroups(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to retrieve groups where the user is the owner", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to retrieve groups where the user is the owner, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to retrieve groups where the user is the owner, error: ", err)
 	}
 	return resp.Groups, nil
 }
@@ -868,7 +868,7 @@ func (s *GfSpClient) ListObjectPolicies(ctx context.Context, objectName, bucketN
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpListObjectPoliciesRequest{
@@ -881,7 +881,7 @@ func (s *GfSpClient) ListObjectPolicies(ctx context.Context, objectName, bucketN
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpListObjectPolicies(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to list policies by object info", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to list policies by object info, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to list policies by object info, error: ", err)
 	}
 	return resp.Policies, nil
 }
@@ -890,14 +890,14 @@ func (s *GfSpClient) ListPaymentAccountStreams(ctx context.Context, paymentAccou
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpListPaymentAccountStreamsRequest{PaymentAccount: paymentAccount}
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpListPaymentAccountStreams(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to list payment account streams", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to list payment account streams, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to list payment account streams, error: ", err)
 	}
 	return resp.Buckets, nil
 }
@@ -906,14 +906,14 @@ func (s *GfSpClient) ListUserPaymentAccounts(ctx context.Context, accountID stri
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpListUserPaymentAccountsRequest{AccountId: accountID}
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpListUserPaymentAccounts(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to list payment accounts by owner address", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to list payment accounts by owner address, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to list payment accounts by owner address, error: ", err)
 	}
 	return resp.PaymentAccounts, nil
 }
@@ -922,14 +922,14 @@ func (s *GfSpClient) ListGroupsByIDs(ctx context.Context, groupIDs []uint64, opt
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpListGroupsByIDsRequest{GroupIds: groupIDs}
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpListGroupsByIDs(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to list groups by ids", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to list groups by ids, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to list groups by ids, error: ", err)
 	}
 	return resp.Groups, nil
 }
@@ -938,7 +938,7 @@ func (s *GfSpClient) GetSPMigratingBucketNumber(ctx context.Context, spID uint32
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return 0, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return 0, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpGetSPMigratingBucketNumberRequest{
@@ -946,7 +946,7 @@ func (s *GfSpClient) GetSPMigratingBucketNumber(ctx context.Context, spID uint32
 	}
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpGetSPMigratingBucketNumber(ctx, req)
 	if err != nil {
-		return 0, ErrRPCUnknownWithDetail("client failed to get the latest active migrating bucket by specific sp, error: " + err.Error())
+		return 0, ErrRPCUnknownWithDetail("client failed to get the latest active migrating bucket by specific sp, error: ", err)
 	}
 	return resp.Count, nil
 }
@@ -955,7 +955,7 @@ func (s *GfSpClient) GetSPMigratingBucketNumber(ctx context.Context, spID uint32
 func (s *GfSpClient) VerifyMigrateGVGPermission(ctx context.Context, bucketID uint64, gvgID, dstSpID uint32, opts ...grpc.DialOption) (*permission_types.Effect, error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
-		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", err)
 	}
 	defer conn.Close()
 
@@ -968,7 +968,7 @@ func (s *GfSpClient) VerifyMigrateGVGPermission(ctx context.Context, bucketID ui
 	ctx = log.Context(ctx, resp)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to send verify migrate GVG permission rpc", "error", err)
-		return nil, ErrRPCUnknownWithDetail("failed to send verify migrate GVG permission rpc, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("failed to send verify migrate GVG permission rpc, error: ", err)
 	}
 	return &resp.Effect, nil
 }
@@ -978,7 +978,7 @@ func (s *GfSpClient) PrimarySpIncomeDetails(ctx context.Context, spID uint32, op
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return 0, nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return 0, nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpPrimarySpIncomeDetailsRequest{
@@ -987,7 +987,7 @@ func (s *GfSpClient) PrimarySpIncomeDetails(ctx context.Context, spID uint32, op
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpPrimarySpIncomeDetails(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to get primary sp income details", "error", err)
-		return 0, nil, ErrRPCUnknownWithDetail("client failed to get primary sp income details: " + err.Error())
+		return 0, nil, ErrRPCUnknownWithDetail("client failed to get primary sp income details: ", err)
 	}
 	return resp.CurrentTimestamp, resp.PrimarySpIncomeDetails, nil
 }
@@ -997,7 +997,7 @@ func (s *GfSpClient) SecondarySpIncomeDetails(ctx context.Context, spID uint32, 
 	conn, connErr := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect metadata", "error", connErr)
-		return 0, nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + connErr.Error())
+		return 0, nil, ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &types.GfSpSecondarySpIncomeDetailsRequest{
@@ -1006,7 +1006,7 @@ func (s *GfSpClient) SecondarySpIncomeDetails(ctx context.Context, spID uint32, 
 	resp, err := types.NewGfSpMetadataServiceClient(conn).GfSpSecondarySpIncomeDetails(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to get secondary sp income details", "error", err)
-		return 0, nil, ErrRPCUnknownWithDetail("client failed to get secondary sp income details: " + err.Error())
+		return 0, nil, ErrRPCUnknownWithDetail("client failed to get secondary sp income details: ", err)
 	}
 	return resp.CurrentTimestamp, resp.SecondarySpIncomeDetails, nil
 }
@@ -1015,7 +1015,7 @@ func (s *GfSpClient) SecondarySpIncomeDetails(ctx context.Context, spID uint32, 
 func (s *GfSpClient) GetBucketSize(ctx context.Context, bucketID uint64, opts ...grpc.DialOption) (string, error) {
 	conn, err := s.Connection(ctx, s.metadataEndpoint, opts...)
 	if err != nil {
-		return "", ErrRPCUnknownWithDetail("client failed to connect metadata, error: " + err.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to connect metadata, error: ", err)
 	}
 	defer conn.Close()
 
@@ -1026,7 +1026,7 @@ func (s *GfSpClient) GetBucketSize(ctx context.Context, bucketID uint64, opts ..
 	ctx = log.Context(ctx, resp)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to send get bucket total object size rpc", "error", err)
-		return "", ErrRPCUnknownWithDetail("failed to send get bucket total object size rpc, error: " + err.Error())
+		return "", ErrRPCUnknownWithDetail("failed to send get bucket total object size rpc, error: ", err)
 	}
 	return resp.BucketSize, nil
 }

--- a/base/gfspclient/p2p.go
+++ b/base/gfspclient/p2p.go
@@ -14,7 +14,7 @@ func (s *GfSpClient) AskSecondaryReplicatePieceApproval(ctx context.Context, tas
 	conn, connErr := s.P2PConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect p2p", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect p2p, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect p2p, error: ", connErr)
 	}
 	req := &gfspserver.GfSpAskSecondaryReplicatePieceApprovalRequest{
 		ReplicatePieceApprovalTask: task.(*gfsptask.GfSpReplicatePieceApprovalTask),
@@ -25,7 +25,7 @@ func (s *GfSpClient) AskSecondaryReplicatePieceApproval(ctx context.Context, tas
 	resp, err := gfspserver.NewGfSpP2PServiceClient(conn).GfSpAskSecondaryReplicatePieceApproval(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to ask replicate piece approval", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to ask replicate piece approval, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to ask replicate piece approval, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return nil, resp.GetErr()
@@ -37,12 +37,12 @@ func (s *GfSpClient) QueryP2PBootstrap(ctx context.Context) ([]string, error) {
 	conn, connErr := s.P2PConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect p2p", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect p2p, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect p2p, error: ", connErr)
 	}
 	resp, err := gfspserver.NewGfSpP2PServiceClient(conn).GfSpQueryP2PBootstrap(ctx, &gfspserver.GfSpQueryP2PNodeRequest{})
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to query p2p bootstrap", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to query p2p bootstrap, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to query p2p bootstrap, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return nil, resp.GetErr()

--- a/base/gfspclient/query_task.go
+++ b/base/gfspclient/query_task.go
@@ -14,7 +14,7 @@ func (s *GfSpClient) QueryTasks(ctx context.Context, endpoint string, subKey str
 	conn, connErr := s.Connection(ctx, endpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect gfsp server", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect gfsp server, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect gfsp server, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &gfspserver.GfSpQueryTasksRequest{
@@ -23,7 +23,7 @@ func (s *GfSpClient) QueryTasks(ctx context.Context, endpoint string, subKey str
 	resp, err := gfspserver.NewGfSpQueryTaskServiceClient(conn).GfSpQueryTasks(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to query tasks", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to query tasks, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to query tasks, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return nil, resp.GetErr()
@@ -35,14 +35,14 @@ func (s *GfSpClient) QueryBucketMigrate(ctx context.Context, endpoint string, op
 	conn, connErr := s.Connection(ctx, endpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect gfsp server", "error", connErr)
-		return "", ErrRPCUnknownWithDetail("client failed to connect gfsp server, error: " + connErr.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to connect gfsp server, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &gfspserver.GfSpQueryBucketMigrateRequest{}
 	resp, err := gfspserver.NewGfSpQueryTaskServiceClient(conn).GfSpQueryBucketMigrate(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to query tasks", "error", err)
-		return "", ErrRPCUnknownWithDetail("client failed to query tasks, error: " + err.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to query tasks, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return "", resp.GetErr()
@@ -58,14 +58,14 @@ func (s *GfSpClient) QuerySPExit(ctx context.Context, endpoint string, opts ...g
 	conn, connErr := s.Connection(ctx, endpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect gfsp server", "error", connErr)
-		return "", ErrRPCUnknownWithDetail("client failed to connect gfsp server, error: " + connErr.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to connect gfsp server, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &gfspserver.GfSpQuerySpExitRequest{}
 	resp, err := gfspserver.NewGfSpQueryTaskServiceClient(conn).GfSpQuerySpExit(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to query tasks", "error", err)
-		return "", ErrRPCUnknownWithDetail("client failed to query tasks, error: " + err.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to query tasks, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return "", resp.GetErr()

--- a/base/gfspclient/receiver.go
+++ b/base/gfspclient/receiver.go
@@ -18,7 +18,7 @@ func (s *GfSpClient) ReplicatePiece(ctx context.Context, task coretask.ReceivePi
 	conn, connErr := s.Connection(ctx, s.receiverEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect receiver", "error", connErr)
-		return ErrRPCUnknownWithDetail("client failed to connect receiver, error: " + connErr.Error())
+		return ErrRPCUnknownWithDetail("client failed to connect receiver, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &gfspserver.GfSpReplicatePieceRequest{
@@ -30,7 +30,7 @@ func (s *GfSpClient) ReplicatePiece(ctx context.Context, task coretask.ReceivePi
 	metrics.PerfReceivePieceTimeHistogram.WithLabelValues("receive_piece_client_total_time").Observe(time.Since(startTime).Seconds())
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to replicate piece", "error", err)
-		return ErrRPCUnknownWithDetail("client failed to replicate piece, error: " + err.Error())
+		return ErrRPCUnknownWithDetail("client failed to replicate piece, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return resp.GetErr()
@@ -43,7 +43,7 @@ func (s *GfSpClient) DoneReplicatePiece(ctx context.Context, task coretask.Recei
 	conn, connErr := s.Connection(ctx, s.receiverEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect receiver", "error", connErr)
-		return nil, nil, ErrRPCUnknownWithDetail("client failed to connect receiver, error: " + connErr.Error())
+		return nil, nil, ErrRPCUnknownWithDetail("client failed to connect receiver, error: ", connErr)
 	}
 	defer conn.Close()
 	req := &gfspserver.GfSpDoneReplicatePieceRequest{
@@ -54,7 +54,7 @@ func (s *GfSpClient) DoneReplicatePiece(ctx context.Context, task coretask.Recei
 	metrics.PerfReceivePieceTimeHistogram.WithLabelValues("receive_piece_done_client_total_time").Observe(time.Since(startTime).Seconds())
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to done replicate piece", "error", err)
-		return nil, nil, ErrRPCUnknownWithDetail("client failed to done replicate piece, error: " + err.Error())
+		return nil, nil, ErrRPCUnknownWithDetail("client failed to done replicate piece, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return nil, nil, resp.GetErr()

--- a/base/gfspclient/signer.go
+++ b/base/gfspclient/signer.go
@@ -17,7 +17,7 @@ func (s *GfSpClient) SignCreateBucketApproval(ctx context.Context, bucket *stora
 	conn, connErr := s.SignerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect to signer", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", connErr)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_CreateBucketInfo{
@@ -27,7 +27,7 @@ func (s *GfSpClient) SignCreateBucketApproval(ctx context.Context, bucket *stora
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to sign create bucket approval", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to sign create bucket approval, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to sign create bucket approval, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return nil, resp.GetErr()
@@ -39,7 +39,7 @@ func (s *GfSpClient) SignMigrateBucketApproval(ctx context.Context, bucket *stor
 	conn, connErr := s.SignerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect to signer", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", connErr)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_MigrateBucketInfo{
@@ -49,7 +49,7 @@ func (s *GfSpClient) SignMigrateBucketApproval(ctx context.Context, bucket *stor
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to sign migrate bucket approval", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to sign migrate bucket approval, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to sign migrate bucket approval, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return nil, resp.GetErr()
@@ -61,7 +61,7 @@ func (s *GfSpClient) SignCreateObjectApproval(ctx context.Context, object *stora
 	conn, connErr := s.SignerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect to signer", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", connErr)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_CreateObjectInfo{
@@ -71,7 +71,7 @@ func (s *GfSpClient) SignCreateObjectApproval(ctx context.Context, object *stora
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to sign create object approval", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to sign create object approval, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to sign create object approval, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return nil, resp.GetErr()
@@ -83,7 +83,7 @@ func (s *GfSpClient) SealObject(ctx context.Context, object *storagetypes.MsgSea
 	conn, connErr := s.SignerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect to signer", "error", connErr)
-		return "", ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + connErr.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", connErr)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_SealObjectInfo{
@@ -93,7 +93,7 @@ func (s *GfSpClient) SealObject(ctx context.Context, object *storagetypes.MsgSea
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to seal object approval", "error", err)
-		return "", ErrRPCUnknownWithDetail("client failed to seal object approval, error: " + err.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to seal object approval, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return "", resp.GetErr()
@@ -105,7 +105,7 @@ func (s *GfSpClient) UpdateSPPrice(ctx context.Context, price *sptypes.MsgUpdate
 	conn, connErr := s.SignerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect to signer", "error", connErr)
-		return "", ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + connErr.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", connErr)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_SpStoragePrice{
@@ -115,7 +115,7 @@ func (s *GfSpClient) UpdateSPPrice(ctx context.Context, price *sptypes.MsgUpdate
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to update SP price info", "error", err)
-		return "", ErrRPCUnknownWithDetail("client failed to update SP price info, error: " + err.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to update SP price info, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return "", resp.GetErr()
@@ -127,7 +127,7 @@ func (s *GfSpClient) CreateGlobalVirtualGroup(ctx context.Context, group *gfspse
 	conn, connErr := s.SignerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect to signer", "error", connErr)
-		return ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + connErr.Error())
+		return ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", connErr)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_CreateGlobalVirtualGroup{
@@ -137,7 +137,7 @@ func (s *GfSpClient) CreateGlobalVirtualGroup(ctx context.Context, group *gfspse
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to create global virtual group", "error", err)
-		return ErrRPCUnknownWithDetail("client failed to create global virtual group, error: " + err.Error())
+		return ErrRPCUnknownWithDetail("client failed to create global virtual group, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return resp.GetErr()
@@ -149,7 +149,7 @@ func (s *GfSpClient) RejectUnSealObject(ctx context.Context, object *storagetype
 	conn, connErr := s.SignerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect to signer", "error", connErr)
-		return "", ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + connErr.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", connErr)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_RejectObjectInfo{
@@ -159,7 +159,7 @@ func (s *GfSpClient) RejectUnSealObject(ctx context.Context, object *storagetype
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to reject unseal object approval", "error", err)
-		return "", ErrRPCUnknownWithDetail("client failed to reject unseal object approval, error: " + err.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to reject unseal object approval, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return "", resp.GetErr()
@@ -171,7 +171,7 @@ func (s *GfSpClient) DiscontinueBucket(ctx context.Context, bucket *storagetypes
 	conn, connErr := s.SignerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect signer", "error", connErr)
-		return "", ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + connErr.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", connErr)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_DiscontinueBucketInfo{
@@ -181,7 +181,7 @@ func (s *GfSpClient) DiscontinueBucket(ctx context.Context, bucket *storagetypes
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to discontinue bucket", "error", err)
-		return "", ErrRPCUnknownWithDetail("client failed to discontinue bucket, error: " + err.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to discontinue bucket, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return "", resp.GetErr()
@@ -193,7 +193,7 @@ func (s *GfSpClient) SignReplicatePieceApproval(ctx context.Context, task coreta
 	conn, connErr := s.SignerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect to signer", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", connErr)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_GfspReplicatePieceApprovalTask{
@@ -203,7 +203,7 @@ func (s *GfSpClient) SignReplicatePieceApproval(ctx context.Context, task coreta
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to sign replicate piece approval", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to sign replicate piece approval, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to sign replicate piece approval, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return nil, resp.GetErr()
@@ -215,7 +215,7 @@ func (s *GfSpClient) SignSecondarySealBls(ctx context.Context, objectID uint64, 
 	conn, connErr := s.SignerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect to signer", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", connErr)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_SignSecondarySealBls{
@@ -229,7 +229,7 @@ func (s *GfSpClient) SignSecondarySealBls(ctx context.Context, objectID uint64, 
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to sign secondary bls signature", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to sign secondary bls signature, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to sign secondary bls signature, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return nil, resp.GetErr()
@@ -241,7 +241,7 @@ func (s *GfSpClient) SignReceiveTask(ctx context.Context, receiveTask coretask.R
 	conn, connErr := s.SignerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect to signer", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", connErr)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_GfspReceivePieceTask{
@@ -251,7 +251,7 @@ func (s *GfSpClient) SignReceiveTask(ctx context.Context, receiveTask coretask.R
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to sign receive task", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to sign receive task, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to sign receive task, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return nil, resp.GetErr()
@@ -263,7 +263,7 @@ func (s *GfSpClient) SignRecoveryTask(ctx context.Context, recoveryTask coretask
 	conn, connErr := s.SignerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect to signer", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", connErr)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_GfspRecoverPieceTask{
@@ -273,7 +273,7 @@ func (s *GfSpClient) SignRecoveryTask(ctx context.Context, recoveryTask coretask
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to sign recovery task", "object name", recoveryTask.GetObjectInfo().ObjectName, "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to sign recovery task, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to sign recovery task, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return nil, resp.GetErr()
@@ -285,7 +285,7 @@ func (s *GfSpClient) SignP2PPingMsg(ctx context.Context, ping *gfspp2p.GfSpPing)
 	conn, connErr := s.SignerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect to signer", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", connErr)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_PingMsg{
@@ -295,7 +295,7 @@ func (s *GfSpClient) SignP2PPingMsg(ctx context.Context, ping *gfspp2p.GfSpPing)
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to sign p2p ping msg", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to sign p2p ping msg, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to sign p2p ping msg, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return nil, resp.GetErr()
@@ -307,7 +307,7 @@ func (s *GfSpClient) SignP2PPongMsg(ctx context.Context, pong *gfspp2p.GfSpPong)
 	conn, connErr := s.SignerConn(ctx)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect to signer", "error", connErr)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + connErr.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", connErr)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_PongMsg{
@@ -317,7 +317,7 @@ func (s *GfSpClient) SignP2PPongMsg(ctx context.Context, pong *gfspp2p.GfSpPong)
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to sign p2p pong msg", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to sign p2p pong msg, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to sign p2p pong msg, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return nil, resp.GetErr()
@@ -329,7 +329,7 @@ func (s *GfSpClient) CompleteMigrateBucket(ctx context.Context, migrateBucket *s
 	conn, err := s.SignerConn(ctx)
 	if err != nil {
 		log.Errorw("failed to connect to signer", "error", err)
-		return "", ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + err.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", err)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_CompleteMigrateBucket{
@@ -339,7 +339,7 @@ func (s *GfSpClient) CompleteMigrateBucket(ctx context.Context, migrateBucket *s
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to sign complete migrate bucket", "error", err)
-		return "", ErrRPCUnknownWithDetail("client failed to sign complete migrate bucket, error: " + err.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to sign complete migrate bucket, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return "", resp.GetErr()
@@ -351,7 +351,7 @@ func (s *GfSpClient) SignSecondarySPMigrationBucket(ctx context.Context, signDoc
 	conn, err := s.SignerConn(ctx)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to connect to signer", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", err)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_SignSecondarySpMigrationBucket{
@@ -361,7 +361,7 @@ func (s *GfSpClient) SignSecondarySPMigrationBucket(ctx context.Context, signDoc
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to sign secondary sp bls migration bucket", "error", err)
-		return nil, ErrRPCUnknownWithDetail("failed to sign secondary sp bls migration bucket, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("failed to sign secondary sp bls migration bucket, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return nil, resp.GetErr()
@@ -373,7 +373,7 @@ func (s *GfSpClient) SignSwapOut(ctx context.Context, swapOut *virtualgrouptypes
 	conn, err := s.SignerConn(ctx)
 	if err != nil {
 		log.Errorw("failed to connect signer", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", err)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_SignSwapOut{
@@ -383,7 +383,7 @@ func (s *GfSpClient) SignSwapOut(ctx context.Context, swapOut *virtualgrouptypes
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to sign swap out", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to sign swap out, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to sign swap out, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return nil, resp.GetErr()
@@ -395,7 +395,7 @@ func (s *GfSpClient) SwapOut(ctx context.Context, swapOut *virtualgrouptypes.Msg
 	conn, err := s.SignerConn(ctx)
 	if err != nil {
 		log.Errorw("failed to connect to signer", "error", err)
-		return "", ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + err.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", err)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_SwapOut{
@@ -405,7 +405,7 @@ func (s *GfSpClient) SwapOut(ctx context.Context, swapOut *virtualgrouptypes.Msg
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to sign swap out", "error", err)
-		return "", ErrRPCUnknownWithDetail("client failed to sign swap out, error: " + err.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to sign swap out, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return "", resp.GetErr()
@@ -417,7 +417,7 @@ func (s *GfSpClient) CompleteSwapOut(ctx context.Context, completeSwapOut *virtu
 	conn, err := s.SignerConn(ctx)
 	if err != nil {
 		log.Errorw("failed to connect to signer", "error", err)
-		return "", ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + err.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", err)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_CompleteSwapOut{
@@ -427,7 +427,7 @@ func (s *GfSpClient) CompleteSwapOut(ctx context.Context, completeSwapOut *virtu
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to sign complete swap out", "error", err)
-		return "", ErrRPCUnknownWithDetail("client failed to sign complete swap out, error: " + err.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to sign complete swap out, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return "", resp.GetErr()
@@ -439,7 +439,7 @@ func (s *GfSpClient) SPExit(ctx context.Context, spExit *virtualgrouptypes.MsgSt
 	conn, err := s.SignerConn(ctx)
 	if err != nil {
 		log.Errorw("failed to connect to signer", "error", err)
-		return "", ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + err.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", err)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_SpExit{
@@ -449,7 +449,7 @@ func (s *GfSpClient) SPExit(ctx context.Context, spExit *virtualgrouptypes.MsgSt
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to sign sp exit", "error", err)
-		return "", ErrRPCUnknownWithDetail("client failed to sign sp exit, error: " + err.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to sign sp exit, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return "", resp.GetErr()
@@ -461,7 +461,7 @@ func (s *GfSpClient) CompleteSPExit(ctx context.Context, completeSPExit *virtual
 	conn, err := s.SignerConn(ctx)
 	if err != nil {
 		log.Errorw("failed to connect to signer", "error", err)
-		return "", ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + err.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", err)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_CompleteSpExit{
@@ -471,7 +471,7 @@ func (s *GfSpClient) CompleteSPExit(ctx context.Context, completeSPExit *virtual
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to sign complete sp exit", "error", err)
-		return "", ErrRPCUnknownWithDetail("client failed to sign complete sp exit, error: " + err.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to sign complete sp exit, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return "", resp.GetErr()
@@ -483,7 +483,7 @@ func (s *GfSpClient) SignMigrateGVG(ctx context.Context, task *gfsptask.GfSpMigr
 	conn, err := s.SignerConn(ctx)
 	if err != nil {
 		log.Errorw("client failed to connect to signer", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", err)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_GfspMigrateGvgTask{
@@ -493,7 +493,7 @@ func (s *GfSpClient) SignMigrateGVG(ctx context.Context, task *gfsptask.GfSpMigr
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to sign migrate gvg", "migrate_gvg", task, "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to sign migrate gvg, migrate_gvg: " + task.Info() + ", error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to sign migrate gvg, migrate_gvg: "+task.Info()+", error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return nil, resp.GetErr()
@@ -505,7 +505,7 @@ func (s *GfSpClient) SignBucketMigrationInfo(ctx context.Context, task *gfsptask
 	conn, err := s.SignerConn(ctx)
 	if err != nil {
 		log.Errorw("client failed to connect to signer", "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", err)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_GfspBucketMigrateInfo{
@@ -515,7 +515,7 @@ func (s *GfSpClient) SignBucketMigrationInfo(ctx context.Context, task *gfsptask
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to sign bucket migrate info", "bucket_migration_info", task, "error", err)
-		return nil, ErrRPCUnknownWithDetail("client failed to sign bucket migrate info, bucket migration info: " + task.Info() + ", error: " + err.Error())
+		return nil, ErrRPCUnknownWithDetail("client failed to sign bucket migrate info, bucket migration info: "+task.Info()+", error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return nil, resp.GetErr()
@@ -527,7 +527,7 @@ func (s *GfSpClient) RejectMigrateBucket(ctx context.Context, rejectMigrateBucke
 	conn, err := s.SignerConn(ctx)
 	if err != nil {
 		log.Errorw("failed to connect to signer", "error", err)
-		return "", ErrRPCUnknownWithDetail("client failed to connect to signer, error: " + err.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to connect to signer, error: ", err)
 	}
 	req := &gfspserver.GfSpSignRequest{
 		Request: &gfspserver.GfSpSignRequest_RejectMigrateBucket{
@@ -537,7 +537,7 @@ func (s *GfSpClient) RejectMigrateBucket(ctx context.Context, rejectMigrateBucke
 	resp, err := gfspserver.NewGfSpSignServiceClient(conn).GfSpSign(ctx, req)
 	if err != nil {
 		log.CtxErrorw(ctx, "client failed to sign reject migrate bucket", "msg", rejectMigrateBucket, "error", err)
-		return "", ErrRPCUnknownWithDetail("client failed to sign reject migrate bucket, error: " + err.Error())
+		return "", ErrRPCUnknownWithDetail("client failed to sign reject migrate bucket, error: ", err)
 	}
 	if resp.GetErr() != nil {
 		return "", resp.GetErr()

--- a/base/gfspclient/uploader.go
+++ b/base/gfspclient/uploader.go
@@ -20,7 +20,7 @@ func (s *GfSpClient) UploadObject(ctx context.Context, task coretask.UploadObjec
 	conn, connErr := s.Connection(ctx, s.uploaderEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect uploader", "error", connErr)
-		return ErrRPCUnknownWithDetail("client failed to connect uploader, error: " + connErr.Error())
+		return ErrRPCUnknownWithDetail("client failed to connect uploader, error: ", connErr)
 	}
 	var sendSize = 0
 	defer func() {
@@ -35,7 +35,7 @@ func (s *GfSpClient) UploadObject(ctx context.Context, task coretask.UploadObjec
 	client, err := gfspserver.NewGfSpUploadServiceClient(conn).GfSpUploadObject(ctx)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to new uploader stream client", "error", err)
-		return ErrRPCUnknownWithDetail("failed to new uploader stream client, error: " + err.Error())
+		return ErrRPCUnknownWithDetail("failed to new uploader stream client, error: ", err)
 	}
 	buf := make([]byte, DefaultStreamBufSize)
 	metrics.PerfPutObjectTime.WithLabelValues("client_put_object_prepare_cost").Observe(time.Since(startTime).Seconds())
@@ -58,7 +58,7 @@ func (s *GfSpClient) UploadObject(ctx context.Context, task coretask.UploadObjec
 				metrics.PerfPutObjectTime.WithLabelValues("client_put_object_send_end").Observe(time.Since(startTime).Seconds())
 				if err != nil {
 					log.CtxErrorw(ctx, "failed to send the last upload stream data", "error", err)
-					return ErrRPCUnknownWithDetail("failed to send the last upload stream data, error: " + err.Error())
+					return ErrRPCUnknownWithDetail("failed to send the last upload stream data, error: ", err)
 				}
 			}
 			startCloseClient := time.Now()
@@ -67,7 +67,7 @@ func (s *GfSpClient) UploadObject(ctx context.Context, task coretask.UploadObjec
 			metrics.PerfPutObjectTime.WithLabelValues("client_put_object_send_last_end").Observe(time.Since(time.Unix(task.GetCreateTime(), 0)).Seconds())
 			if closeErr != nil {
 				log.CtxErrorw(ctx, "failed to close upload stream", "error", closeErr)
-				return ErrRPCUnknownWithDetail("failed to new uploader stream client, error: " + closeErr.Error())
+				return ErrRPCUnknownWithDetail("failed to new uploader stream client, error: ", closeErr)
 			}
 			if resp.GetErr() != nil {
 				return resp.GetErr()
@@ -88,7 +88,7 @@ func (s *GfSpClient) UploadObject(ctx context.Context, task coretask.UploadObjec
 		metrics.PerfPutObjectTime.WithLabelValues("client_put_object_send_end").Observe(time.Since(time.Unix(task.GetCreateTime(), 0)).Seconds())
 		if err != nil {
 			log.CtxErrorw(ctx, "failed to send the upload stream data", "error", err)
-			return ErrRPCUnknownWithDetail("failed to send the upload stream data, error: " + err.Error())
+			return ErrRPCUnknownWithDetail("failed to send the upload stream data, error: ", err)
 		}
 	}
 }
@@ -98,7 +98,7 @@ func (s *GfSpClient) ResumableUploadObject(ctx context.Context, task coretask.Re
 	conn, connErr := s.Connection(ctx, s.uploaderEndpoint, opts...)
 	if connErr != nil {
 		log.CtxErrorw(ctx, "client failed to connect uploader", "error", connErr)
-		return ErrRPCUnknownWithDetail("client failed to connect uploader, error: " + connErr.Error())
+		return ErrRPCUnknownWithDetail("client failed to connect uploader, error: ", connErr)
 	}
 	var sendSize = 0
 	defer func() {
@@ -114,7 +114,7 @@ func (s *GfSpClient) ResumableUploadObject(ctx context.Context, task coretask.Re
 
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to new uploader stream client", "error", err)
-		return ErrRPCUnknownWithDetail("failed to new uploader stream client, error: " + connErr.Error())
+		return ErrRPCUnknownWithDetail("failed to new uploader stream client, error: ", connErr)
 	}
 	var (
 		buf = make([]byte, DefaultStreamBufSize)
@@ -131,13 +131,13 @@ func (s *GfSpClient) ResumableUploadObject(ctx context.Context, task coretask.Re
 				err = client.Send(req)
 				if err != nil {
 					log.CtxErrorw(ctx, "failed to send the last upload stream data", "error", err)
-					return ErrRPCUnknownWithDetail("failed to send the last upload stream data, error: " + err.Error())
+					return ErrRPCUnknownWithDetail("failed to send the last upload stream data, error: ", err)
 				}
 			}
 			resp, closeErr := client.CloseAndRecv()
 			if closeErr != nil {
 				log.CtxErrorw(ctx, "failed to close upload stream", "error", closeErr)
-				return ErrRPCUnknownWithDetail("failed to close upload stream, error: " + closeErr.Error())
+				return ErrRPCUnknownWithDetail("failed to close upload stream, error: ", closeErr)
 			}
 			if resp.GetErr() != nil {
 				return resp.GetErr()
@@ -155,7 +155,7 @@ func (s *GfSpClient) ResumableUploadObject(ctx context.Context, task coretask.Re
 		err = client.Send(req)
 		if err != nil {
 			log.CtxErrorw(ctx, "failed to send the upload stream data", "error", err)
-			return ErrRPCUnknownWithDetail("failed to send the upload stream data, error: " + err.Error())
+			return ErrRPCUnknownWithDetail("failed to send the upload stream data, error: ", err)
 		}
 	}
 }

--- a/base/types/gfsperrors/error.go
+++ b/base/types/gfsperrors/error.go
@@ -46,26 +46,6 @@ func init() {
 	})
 }
 
-func GetGfSpErr(err error) *GfSpError {
-	if err == nil {
-		return nil
-	}
-	if gfspErr, ok := err.(*GfSpError); ok {
-		return gfspErr
-	}
-	i := strings.Index(err.Error(), "desc = ")
-	if i == -1 || len(err.Error())-1 < i+6 {
-		return nil
-	}
-	errInfo := err.Error()[i+6:]
-	var gfspErr GfSpError
-	unmarshalErr := json.Unmarshal([]byte(errInfo), &gfspErr)
-	if unmarshalErr == nil && gfspErr.HttpStatusCode != 0 {
-		return &gfspErr
-	}
-	return nil
-}
-
 // MakeGfSpError returns an GfSpError from the build-in error interface. It is
 // difficult to predefine all errors. For undefined errors, there needs to be a
 // way to capture them and return them to the client according to the GfSpError
@@ -79,19 +59,28 @@ func MakeGfSpError(err error) *GfSpError {
 	if err == nil {
 		return nil
 	}
-	switch e := err.(type) {
-	case *GfSpError:
-		if e.GetInnerCode() == 0 {
+
+	if gfspErr, ok := err.(*GfSpError); ok {
+		if gfspErr.GetInnerCode() == 0 {
 			return nil
 		}
-		return e
-	default:
-		return &GfSpError{
-			CodeSpace:      DefaultCodeSpace,
-			HttpStatusCode: int32(http.StatusInternalServerError),
-			InnerCode:      int32(DefaultInnerCode),
-			Description:    err.Error(),
+		return gfspErr
+	}
+	i := strings.Index(err.Error(), "desc = ")
+	if i != -1 && len(err.Error())-1 >= i+6 {
+		errInfo := err.Error()[i+6:]
+		var gfspErr GfSpError
+		unmarshalErr := json.Unmarshal([]byte(errInfo), &gfspErr)
+		if unmarshalErr == nil && gfspErr.HttpStatusCode != 0 {
+			return &gfspErr
 		}
+	}
+
+	return &GfSpError{
+		CodeSpace:      DefaultCodeSpace,
+		HttpStatusCode: int32(http.StatusInternalServerError),
+		InnerCode:      int32(DefaultInnerCode),
+		Description:    err.Error(),
 	}
 }
 

--- a/base/types/gfsperrors/error.go
+++ b/base/types/gfsperrors/error.go
@@ -66,6 +66,9 @@ func MakeGfSpError(err error) *GfSpError {
 		}
 		return gfspErr
 	}
+	// Attempting to check if the error is an RPC error; if so, trying to extract its error description and convert it to the GfSpError type.
+	// Expected error should be: "rpc error: code = Unknown desc = xxx"
+	// We only need to focus on xxx, and can extract the substring using string.Index().
 	i := strings.Index(err.Error(), "desc = ")
 	if i != -1 && len(err.Error())-1 >= i+6 {
 		errInfo := err.Error()[i+6:]

--- a/base/types/gfsperrors/error_test.go
+++ b/base/types/gfsperrors/error_test.go
@@ -12,7 +12,7 @@ import (
 func TestGfSpError_Error(t *testing.T) {
 	m := &GfSpError{}
 	result := m.Error()
-	assert.Equal(t, "", result)
+	assert.Equal(t, "{}", result)
 }
 
 func TestGfSpError_SetError(t *testing.T) {

--- a/modular/gater/metadata_handler_test.go
+++ b/modular/gater/metadata_handler_test.go
@@ -1,0 +1,168 @@
+package gater
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/bnb-chain/greenfield-storage-provider/base/gfspclient"
+)
+
+func mockListObjectPoliciesRoute(t *testing.T, g *GateModular) *mux.Router {
+	t.Helper()
+	router := mux.NewRouter().SkipClean(true)
+	var routers []*mux.Router
+	routers = append(routers, router.Host("{bucket:.+}."+g.domain).Subrouter())
+	routers = append(routers, router.PathPrefix("/{bucket}").Subrouter())
+	for _, r := range routers {
+		r.NewRoute().Name(listObjectPoliciesRouterName).Methods(http.MethodGet).Path("/{object:.+}").Queries(ListObjectPoliciesQuery, "").
+			HandlerFunc(g.listObjectPoliciesHandler)
+	}
+	return router
+}
+
+func TestGateModular_listObjectPoliciesHandler(t *testing.T) {
+	cases := []struct {
+		name       string
+		fn         func() *GateModular
+		request    func() *http.Request
+		wantedCode int
+	}{
+		{
+			name: "bukcet name error",
+			fn: func() *GateModular {
+				g := setup(t)
+				ctrl := gomock.NewController(t)
+				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
+				g.baseApp.SetGfSpClient(clientMock)
+				return g
+			},
+			request: func() *http.Request {
+				path := fmt.Sprintf("%s%s.%s/%s?%s&%s", scheme, invalidBucketName, testDomain, invalidObjectName, ListObjectPoliciesQuery,
+					"limit=10&action-type=6")
+				req := httptest.NewRequest(http.MethodGet, path, strings.NewReader(""))
+				return req
+			},
+			wantedCode: 400,
+		},
+		{
+			name: "object name error",
+			fn: func() *GateModular {
+				g := setup(t)
+				ctrl := gomock.NewController(t)
+				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
+				g.baseApp.SetGfSpClient(clientMock)
+				return g
+			},
+			request: func() *http.Request {
+				path := fmt.Sprintf("%s%s.%s/%s?%s&%s", scheme, mockBucketName, testDomain, invalidObjectName, ListObjectPoliciesQuery,
+					"limit=10&action-type=6")
+				req := httptest.NewRequest(http.MethodGet, path, strings.NewReader(""))
+				return req
+			},
+			wantedCode: 400,
+		},
+		{
+			name: "limit value error",
+			fn: func() *GateModular {
+				g := setup(t)
+				ctrl := gomock.NewController(t)
+				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
+				g.baseApp.SetGfSpClient(clientMock)
+				return g
+			},
+			request: func() *http.Request {
+				path := fmt.Sprintf("%s%s.%s/%s?%s&%s", scheme, mockBucketName, testDomain, mockObjectName, ListObjectPoliciesQuery,
+					"limit=a&action-type=6")
+				req := httptest.NewRequest(http.MethodGet, path, strings.NewReader(""))
+				return req
+			},
+			wantedCode: 400,
+		},
+		{
+			name: "start-after value error",
+			fn: func() *GateModular {
+				g := setup(t)
+				ctrl := gomock.NewController(t)
+				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
+				g.baseApp.SetGfSpClient(clientMock)
+				return g
+			},
+			request: func() *http.Request {
+				path := fmt.Sprintf("%s%s.%s/%s?%s&%s", scheme, mockBucketName, testDomain, mockObjectName, ListObjectPoliciesQuery,
+					"limit=10&action-type=6&start-after=a")
+				req := httptest.NewRequest(http.MethodGet, path, strings.NewReader(""))
+				return req
+			},
+			wantedCode: 400,
+		},
+		{
+			name: "action type value error",
+			fn: func() *GateModular {
+				g := setup(t)
+				ctrl := gomock.NewController(t)
+				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
+				g.baseApp.SetGfSpClient(clientMock)
+				return g
+			},
+			request: func() *http.Request {
+				path := fmt.Sprintf("%s%s.%s/%s?%s&%s", scheme, mockBucketName, testDomain, mockObjectName, ListObjectPoliciesQuery,
+					"limit=10&action-type=100")
+				req := httptest.NewRequest(http.MethodGet, path, strings.NewReader(""))
+				return req
+			},
+			wantedCode: 400,
+		},
+		{
+			name: "action type value error 2",
+			fn: func() *GateModular {
+				g := setup(t)
+				ctrl := gomock.NewController(t)
+				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
+				g.baseApp.SetGfSpClient(clientMock)
+				return g
+			},
+			request: func() *http.Request {
+				path := fmt.Sprintf("%s%s.%s/%s?%s&%s", scheme, mockBucketName, testDomain, mockObjectName, ListObjectPoliciesQuery,
+					"limit=10&action-type=a")
+				req := httptest.NewRequest(http.MethodGet, path, strings.NewReader(""))
+				return req
+			},
+			wantedCode: 400,
+		},
+		{
+			name: "rpc error",
+			fn: func() *GateModular {
+				g := setup(t)
+				ctrl := gomock.NewController(t)
+				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
+				clientMock.EXPECT().ListObjectPolicies(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any()).Return(nil, errors.New(`rpc error: code = Unknown desc = {"code_space":"metadata","http_status_code":404,"inner_code":90008,"description":"the specified bucket does not exist"}`)).Times(1)
+				g.baseApp.SetGfSpClient(clientMock)
+				return g
+			},
+			request: func() *http.Request {
+				path := fmt.Sprintf("%s%s.%s/%s?%s&%s", scheme, mockBucketName, testDomain, mockObjectName, ListObjectPoliciesQuery,
+					"limit=10&action-type=6")
+				req := httptest.NewRequest(http.MethodGet, path, strings.NewReader(""))
+				return req
+			},
+			wantedCode: 404,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			router := mockListObjectPoliciesRoute(t, tt.fn())
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, tt.request())
+			assert.Equal(t, w.Code, tt.wantedCode)
+		})
+	}
+}


### PR DESCRIPTION
### Description

Addressing the issue of inaccurate error codes in the gateway interface.

### Rationale

The error message is lost during the RPC call process, and we need to reparse it.

### Example

“the specified bucket does not exist”
The error should return a 404, but it is actually returning a 500.

### Changes

Notable changes: 
* Modified the string method of gfspError to make it easier to parse.
* Added parsing logic to the gateway.

### Potential Impacts
* print log
* http code