### PR TITLE
fix: fix panic when xml marshal nil objects

### DIFF
--- a/modular/metadata/metadata_object_service.go
+++ b/modular/metadata/metadata_object_service.go
@@ -189,7 +189,7 @@ func (r *MetadataModular) GfSpGetObjectMeta(ctx context.Context, req *types.GfSp
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get object by object name", "error", err)
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, ErrNoSuchBucket
+			return nil, ErrNoSuchObject
 		}
 		return nil, err
 	}

--- a/modular/metadata/metadata_object_service_test.go
+++ b/modular/metadata/metadata_object_service_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/forbole/juno/v4/common"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+	"gorm.io/gorm"
 
 	"github.com/bnb-chain/greenfield-storage-provider/modular/metadata/types"
 	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
@@ -528,6 +529,25 @@ func TestMetadataModular_GfSpGetObjectMeta_Failed2(t *testing.T) {
 		IncludePrivate: false,
 	})
 	assert.NotNil(t, err)
+}
+
+func TestMetadataModular_GfSpGetObjectMeta_Failed3(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().GetObjectByName(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(string, string, bool) (*bsdb.Object, error) {
+			return nil, gorm.ErrRecordNotFound
+		},
+	).Times(1)
+	_, err := a.GfSpGetObjectMeta(context.Background(), &types.GfSpGetObjectMetaRequest{
+		ObjectName:     "test",
+		BucketName:     "test",
+		IncludePrivate: false,
+	})
+	assert.NotNil(t, err)
+	assert.Equal(t, ErrNoSuchObject, err)
 }
 
 func TestMetadataModular_GfSpListObjectsByIDs_Success(t *testing.T) {

--- a/modular/metadata/types/metadata_types.go
+++ b/modular/metadata/types/metadata_types.go
@@ -22,8 +22,10 @@ func (m GfSpGetObjectMetaResponse) MarshalXML(e *xml.Encoder, start xml.StartEle
 	// Create a new struct with Base64-encoded Checksums field
 	responseAlias := Alias(m)
 	o := responseAlias.Object
-	for i, c := range o.ObjectInfo.Checksums {
-		o.ObjectInfo.Checksums[i] = []byte(base64.StdEncoding.EncodeToString(c))
+	if o != nil && o.ObjectInfo != nil && o.ObjectInfo.Checksums != nil {
+		for i, c := range o.ObjectInfo.Checksums {
+			o.ObjectInfo.Checksums[i] = []byte(base64.StdEncoding.EncodeToString(c))
+		}
 	}
 	return e.EncodeElement(responseAlias, start)
 }
@@ -66,8 +68,10 @@ func (m GfSpListObjectsByIDsResponse) MarshalXML(e *xml.Encoder, start xml.Start
 	}
 
 	for k, o := range m.Objects {
-		for i, c := range o.ObjectInfo.Checksums {
-			o.ObjectInfo.Checksums[i] = []byte(base64.StdEncoding.EncodeToString(c))
+		if o != nil && o.ObjectInfo != nil && o.ObjectInfo.Checksums != nil {
+			for i, c := range o.ObjectInfo.Checksums {
+				o.ObjectInfo.Checksums[i] = []byte(base64.StdEncoding.EncodeToString(c))
+			}
 		}
 		e.Encode(ObjectEntry{Id: k, Value: o})
 	}


### PR DESCRIPTION
### Description

fix: fix panic when xml marshal nil objects

### Rationale

Xmlmarshal would fail into panic if the queried object doesn't exist.  This fix will solve this issue.

### Example

```
curl --location 'http://127.0.0.1:9133/?groups-query=null&ids=12323412341234'
```
```xml
<GfSpListGroupsByIDsResponse>
    <GroupEntry>
        <Id>12323412341234</Id>
    </GroupEntry>
</GfSpListGroupsByIDsResponse>
```
### Changes

Notable changes: 
* add more nil checking 
* add more ut

### Potential Impacts
N/A