### PR TITLE
chore: switch develop image to distroless

### DIFF
--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -40,7 +40,7 @@ jobs:
           --label "org.opencontainers.image.source=${IMAGE_SOURCE}" \
           --label "org.opencontainers.image.revision=$(git rev-parse HEAD)" \
           --label "org.opencontainers.image.licenses=LGPL-3.0,GPL-3.0" \
-          -f ./Dockerfile -t "${IMAGE_NAME}"
+          -f ./Dockerfile.distroless -t "${IMAGE_NAME}"
 
       - name: Log into registry
         run: echo "${{ secrets.GH_SECRET }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -40,7 +40,14 @@ jobs:
           --label "org.opencontainers.image.source=${IMAGE_SOURCE}" \
           --label "org.opencontainers.image.revision=$(git rev-parse HEAD)" \
           --label "org.opencontainers.image.licenses=LGPL-3.0,GPL-3.0" \
-          -f ./Dockerfile.distroless -t "${IMAGE_NAME}"
+          -f ./Dockerfile -t "${IMAGE_NAME}"
+          
+          docker build . \
+          --build-arg "GH_TOKEN=${{ secrets.GH_SECRET }}" \
+          --label "org.opencontainers.image.source=${IMAGE_SOURCE}" \
+          --label "org.opencontainers.image.revision=$(git rev-parse HEAD)" \
+          --label "org.opencontainers.image.licenses=LGPL-3.0,GPL-3.0" \
+          -f ./Dockerfile.distroless -t "${IMAGE_NAME}:distroless"
 
       - name: Log into registry
         run: echo "${{ secrets.GH_SECRET }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -49,4 +56,6 @@ jobs:
         run: |
           VERSION=$(echo "${{ github.sha }}" | sed -e 's,.*/\(.*\),\1,')
           docker tag $IMAGE_NAME $IMAGE_NAME:$VERSION
+          docker tag ${IMAGE_NAME}:distroless $IMAGE_NAME:$VERSION-distroless
           docker push $IMAGE_NAME:$VERSION
+          docker push $IMAGE_NAME:$VERSION-distroless


### PR DESCRIPTION
### Description

This PR switches the Dockerfile being used to `Dockerfile.distroless` for GitHub action 

### Rationale

To improve security within Kubernetes environment, it is recommended to use distroless image to prevent potential attack.

### Example

N/A

### Changes

Use `Dockerfile.distroless` to build. It has already been used in `signer`.

### Potential Impacts
The debugging will be harder, because after the change we cannot `exec into` the pods directly any more.