### PR TITLE
feat: invalid object name

### DIFF
--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -2,7 +2,7 @@ name: Docker-CI
 
 on:
   push:
-    branches: [ develop, master, feat-invalid-object-name ]
+    branches: [ develop, master ]
 
 env:
   IMAGE_NAME: ghcr.io/bnb-chain/greenfield-storage-provider-invisible

--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -2,7 +2,7 @@ name: Docker-CI
 
 on:
   push:
-    branches: [ develop, master ]
+    branches: [ develop, master, feat-invalid-object-name ]
 
 env:
   IMAGE_NAME: ghcr.io/bnb-chain/greenfield-storage-provider-invisible

--- a/modular/gater/admin_handler.go
+++ b/modular/gater/admin_handler.go
@@ -196,6 +196,21 @@ func (g *GateModular) getApprovalHandler(w http.ResponseWriter, r *http.Request)
 			err = ErrValidateMsg
 			return
 		}
+		// This code block checks for unsupported or potentially risky formats in object names.
+		// The checks are essential for ensuring the security and compatibility of the object names within the system.
+		// 1. ".." in object names: Checked to prevent path traversal attacks which might access directories outside the intended scope.
+		// 2. Object name being "/": The root directory should not be used as an object name due to potential security risks and ambiguity.
+		// 3. "\\" in object names: Backslashes are checked because they are often not supported in UNIX-like file systems and can cause issues in path parsing.
+		// 4. SQL Injection patterns in object names: Ensures that the object name does not contain patterns that could be used for SQL injection attacks, maintaining the integrity of the database.
+		if strings.Contains(createObjectApproval.GetObjectName(), "..") ||
+			createObjectApproval.GetObjectName() == "/" ||
+			strings.Contains(createObjectApproval.GetObjectName(), "\\") ||
+			util.IsSQLInjection(createObjectApproval.GetObjectName()) {
+			log.Errorw("failed to check object name", "object_approval_msg",
+				createObjectApproval, "error", err)
+			err = ErrInvalidObjectName
+			return
+		}
 		if err = g.checkSPAndBucketStatus(reqCtx.Context(), createObjectApproval.GetBucketName(), createObjectApproval.Creator); err != nil {
 			log.Errorw("create object approval failed to check sp and bucket status", "error", err)
 			return

--- a/modular/gater/admin_handler_test.go
+++ b/modular/gater/admin_handler_test.go
@@ -602,6 +602,28 @@ func TestGateModular_getApprovalHandlerCreateObjectApproval(t *testing.T) {
 			wantedResult: "gnfd msg validate error",
 		},
 		{
+			name: "failed to invalid object approval msg",
+			fn: func() *GateModular {
+				g := setup(t)
+				ctrl := gomock.NewController(t)
+				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
+				clientMock.EXPECT().VerifyGNFD1EddsaSignature(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any()).Return(false, nil).Times(1)
+				g.baseApp.SetGfSpClient(clientMock)
+				return g
+			},
+			request: func() *http.Request {
+				path := fmt.Sprintf("%s%s%s?%s=%s", scheme, testDomain, GetApprovalPath, ActionQuery, createObjectApprovalAction)
+				req := httptest.NewRequest(http.MethodGet, path, strings.NewReader(""))
+				validExpiryDateStr := time.Now().Add(time.Hour * 60).Format(ExpiryDateFormat)
+				req.Header.Set(commonhttp.HTTPHeaderExpiryTimestamp, validExpiryDateStr)
+				req.Header.Set(GnfdAuthorizationHeader, "GNFD1-EDDSA,Signature=48656c6c6f20476f7068657221")
+				req.Header.Set(GnfdUnsignedApprovalMsgHeader, "0a7b0a20202263726561746f72223a2022307831433743384136363865323361454432393166373866433266336231383635416363383762364635222c0a2020226275636b65745f6e616d65223a20226d6f636b2d6275636b65742d6e616d65222c0a2020226f626a6563745f6e616d65223a202278783b73656c656374202a2066726f6d206f626a65637473222c0a2020227061796c6f61645f73697a65223a202230222c0a2020227669736962696c697479223a20225649534942494c4954595f545950455f494e4845524954222c0a202022636f6e74656e745f74797065223a20226170706c69636174696f6e2f6a736f6e222c0a2020227072696d6172795f73705f617070726f76616c223a207b0a2020202022657870697265645f686569676874223a20223130222c0a2020202022676c6f62616c5f7669727475616c5f67726f75705f66616d696c795f6964223a20302c0a2020202022736967223a206e756c6c0a20207d2c0a2020226578706563745f636865636b73756d73223a205b5d2c0a202022726564756e64616e63795f74797065223a2022524544554e44414e43595f45435f54595045220a7d0a")
+				return req
+			},
+			wantedResult: "invalid object name",
+		},
+		{
 			name: "failed to check sp and bucket status",
 			fn: func() *GateModular {
 				g := setup(t)

--- a/modular/gater/errors.go
+++ b/modular/gater/errors.go
@@ -55,6 +55,7 @@ var (
 	ErrPrimaryMismatch        = gfsperrors.Register(module.GateModularName, http.StatusNotAcceptable, 50041, "primary sp mismatch")
 	ErrNotCreatedState        = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50042, "object has not been created state")
 	ErrNotSealedState         = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50043, "object has not been sealed state")
+	ErrInvalidObjectName      = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50044, "invalid object name")
 )
 
 func ErrEncodeResponseWithDetail(detail string) *gfsperrors.GfSpError {

--- a/modular/gater/errors.go
+++ b/modular/gater/errors.go
@@ -55,7 +55,12 @@ var (
 	ErrPrimaryMismatch        = gfsperrors.Register(module.GateModularName, http.StatusNotAcceptable, 50041, "primary sp mismatch")
 	ErrNotCreatedState        = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50042, "object has not been created state")
 	ErrNotSealedState         = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50043, "object has not been sealed state")
-	ErrInvalidObjectName      = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50044, "invalid object name")
+	// ErrInvalidObjectName is triggered in the following cases, indicating the object name is not compliant:
+	// 1. Contains "..": Suggests potential directory traversal.
+	// 2. Equals "/": Direct reference to the root directory, which is usually unsafe.
+	// 3. Contains "\": May indicate an attempt at illegal path or file operations, especially in Windows systems.
+	// 4. Fails SQL Injection Test (util.IsSQLInjection): Object name contains patterns that might be used for SQL injection, like ';select', 'xxx;insert', etc., or SQL comment patterns.
+	ErrInvalidObjectName = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50044, "invalid object name")
 )
 
 func ErrEncodeResponseWithDetail(detail string) *gfsperrors.GfSpError {

--- a/util/string.go
+++ b/util/string.go
@@ -163,12 +163,12 @@ func StringArrayToUint32Slice(arr pq.StringArray) ([]uint32, error) {
 func IsSQLInjection(input string) bool {
 	// define patterns that may indicate SQL injection, especially those with a semicolon followed by common SQL keywords
 	patterns := []string{
-		"(?i).+;.*select", // Matches any string with a semicolon followed by "select"
-		"(?i).+;.*insert", // Matches any string with a semicolon followed by "insert"
-		"(?i).+;.*update", // Matches any string with a semicolon followed by "update"
-		"(?i).+;.*delete", // Matches any string with a semicolon followed by "delete"
-		"(?i).+;.*drop",   // Matches any string with a semicolon followed by "drop"
-		"(?i).+;.*alter",  // Matches any string with a semicolon followed by "alter"
+		"(?i).*;.*select", // Matches any string with a semicolon followed by "select"
+		"(?i).*;.*insert", // Matches any string with a semicolon followed by "insert"
+		"(?i).*;.*update", // Matches any string with a semicolon followed by "update"
+		"(?i).*;.*delete", // Matches any string with a semicolon followed by "delete"
+		"(?i).*;.*drop",   // Matches any string with a semicolon followed by "drop"
+		"(?i).*;.*alter",  // Matches any string with a semicolon followed by "alter"
 		"/\\*.*\\*/",      // Matches SQL block comment
 	}
 

--- a/util/string.go
+++ b/util/string.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"math"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -157,4 +158,29 @@ func StringArrayToUint32Slice(arr pq.StringArray) ([]uint32, error) {
 		uint32Slice[i] = val
 	}
 	return uint32Slice, nil
+}
+
+func IsSQLInjection(input string) bool {
+	// define patterns that may indicate SQL injection, especially those with a semicolon followed by common SQL keywords
+	patterns := []string{
+		"(?i).+;.*select", // Matches any string with a semicolon followed by "select"
+		"(?i).+;.*insert", // Matches any string with a semicolon followed by "insert"
+		"(?i).+;.*update", // Matches any string with a semicolon followed by "update"
+		"(?i).+;.*delete", // Matches any string with a semicolon followed by "delete"
+		"(?i).+;.*drop",   // Matches any string with a semicolon followed by "drop"
+		"(?i).+;.*alter",  // Matches any string with a semicolon followed by "alter"
+		"/\\*.*\\*/",      // Matches SQL block comment
+	}
+
+	for _, pattern := range patterns {
+		matched, err := regexp.MatchString(pattern, input)
+		if err != nil {
+			return false
+		}
+		if matched {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
### Description

During the process of creating an object and getting approval, restrictions on illegal special characters were added

### Rationale

S3 supports, but SP does not support. Currently, all are being blocked by WAF. These objects, once created, cannot be sealed.
- `123../1.txt`
- `...barry`
- `..barry`
-`/`
- `data;DROP TABLE objects` (SQL Injection)
-`\`
- `\\`
- `\r`
- `\n`

![image](https://github.com/bnb-chain/greenfield-storage-provider/assets/122767193/224ec9f0-08d7-4ede-a0d8-c48ddd5afb55)



### Example

N/A

### Changes

Notable changes: 
* During the process of creating an object and getting approval, restrictions on illegal special characters were added

### Potential Impacts
* QA