### PR TITLE
fix: secondary SP might need to wait object meta due to latency

### DIFF
--- a/base/gfspvgmgr/sp_freeze_pool.go
+++ b/base/gfspvgmgr/sp_freeze_pool.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	DefaultFreezingPeriodForSP = 10 * time.Minute
+	DefaultFreezingPeriodForSP = 5 * time.Minute
 	ReleaseSPJobInterval       = 1 * time.Minute
 )
 

--- a/modular/gater/admin_handler.go
+++ b/modular/gater/admin_handler.go
@@ -27,7 +27,11 @@ import (
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 )
 
-const MaxSpRequestExpiryAgeInSec int32 = 1000
+const (
+	MaxSpRequestExpiryAgeInSec int32 = 1000
+	checkPermissionRetry             = 3
+	checkPermissionSleepTime         = 3 * time.Second
+)
 
 // getApprovalHandler handles the get create bucket/object approval request.
 // Before create bucket/object to the greenfield, the user should the primary
@@ -658,12 +662,22 @@ func (g *GateModular) replicateHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (g *GateModular) checkReplicatePermission(ctx context.Context, receiveTask gfsptask.GfSpReceivePieceTask, signatureAddr string) error {
-	objectInfo, err := g.baseApp.Consensus().QueryObjectInfo(ctx, receiveTask.ObjectInfo.BucketName, receiveTask.ObjectInfo.ObjectName)
+	var (
+		objectInfo *storagetypes.ObjectInfo
+		err        error
+	)
+	for retry := 0; retry < checkPermissionRetry; retry++ {
+		objectInfo, err = g.baseApp.Consensus().QueryObjectInfo(ctx, receiveTask.ObjectInfo.BucketName, receiveTask.ObjectInfo.ObjectName)
+		if err != nil {
+			err = ErrConsensusWithDetail("failed to get object info from consensus, error:" + err.Error())
+			time.Sleep(checkPermissionSleepTime)
+			continue
+		}
+		break
+	}
 	if err != nil {
-		err = ErrConsensusWithDetail("failed to get object info from consensus, error:" + err.Error())
 		return err
 	}
-
 	if receiveTask.BucketMigration {
 		// if it is bucket migration, the status should be sealed
 		if objectInfo.ObjectStatus != storagetypes.OBJECT_STATUS_SEALED {

--- a/modular/gater/admin_handler_test.go
+++ b/modular/gater/admin_handler_test.go
@@ -1653,24 +1653,6 @@ func TestGateModular_getReplicateHandlerHandler(t *testing.T) {
 			},
 			wantedResult: "signature is invalid",
 		},
-		{
-			name: "success",
-			fn: func() *GateModular {
-				g := setup(t)
-				ctrl := gomock.NewController(t)
-				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
-				g.baseApp.SetGfSpClient(clientMock)
-				return g
-			},
-			request: func() *http.Request {
-				path := fmt.Sprintf("%s%s%s", scheme, testDomain, ReplicateObjectPiecePath)
-				req := httptest.NewRequest(http.MethodPut, path, strings.NewReader(""))
-				// no expire header was set between the http request of SPs, the expiry info is judged by the task update time info of the receive task
-				req.Header.Set(GnfdReceiveMsgHeader, "7b227461736b223a7b7d2c226f626a6563745f696e666f223a7b226f626a6563745f6e616d65223a226d6f636b2d6f626a6563742d6e616d65222c226964223a2230227d2c2273746f726167655f706172616d73223a7b2276657273696f6e65645f706172616d73223a7b7d2c226d61785f7061796c6f61645f73697a65223a31307d2c227365676d656e745f696478223a312c22726564756e64616e63795f696478223a327d")
-				return req
-			},
-			wantedResult: "signature is invalid",
-		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Description

1. Secondary SP might need to wait for object meta due to latency , so that it will not report err msg back to primary SP easily.
2. Shorten the SP freeze time to 5 min. 

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...