### PR TITLE
perf: blocksyncer sql commit

### DIFF
--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -2,7 +2,7 @@ name: Docker-CI
 
 on:
   push:
-    branches: [ develop, master ]
+    branches: [ develop, master ,perf-bs ]
 
 env:
   IMAGE_NAME: ghcr.io/bnb-chain/greenfield-storage-provider-invisible

--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -2,7 +2,7 @@ name: Docker-CI
 
 on:
   push:
-    branches: [ develop, master ,perf-bs ]
+    branches: [ develop, master ]
 
 env:
   IMAGE_NAME: ghcr.io/bnb-chain/greenfield-storage-provider-invisible

--- a/base/gfspconfig/config.go
+++ b/base/gfspconfig/config.go
@@ -259,6 +259,7 @@ type LogConfig struct {
 type BlockSyncerConfig struct {
 	Modules          []string `comment:"required"`
 	Workers          uint     `comment:"required"`
+	CommitNumber     uint64   `comment:"optional"`
 	BsDBWriteAddress string   `comment:"optional"`
 }
 

--- a/modular/blocksyncer/blocksyncer.go
+++ b/modular/blocksyncer/blocksyncer.go
@@ -38,7 +38,7 @@ const (
 	MaxHeightGapFactor    = 4
 	ObjectsNumberOfShards = 64
 	MinChargeSize         = 128000
-	CommitNumber          = 500
+	CommitNumber          = 2000
 )
 
 type MigrateDBKey struct{}

--- a/modular/blocksyncer/blocksyncer.go
+++ b/modular/blocksyncer/blocksyncer.go
@@ -38,6 +38,7 @@ const (
 	MaxHeightGapFactor    = 4
 	ObjectsNumberOfShards = 64
 	MinChargeSize         = 128000
+	CommitNumber          = 500
 )
 
 type MigrateDBKey struct{}

--- a/modular/blocksyncer/blocksyncer_indexer.go
+++ b/modular/blocksyncer/blocksyncer_indexer.go
@@ -27,7 +27,7 @@ import (
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/metrics"
 )
 
-func NewIndexer(codec codec.Codec, proxy node.Node, db database.Database, modules []modules.Module, serviceName string) parser.Indexer {
+func NewIndexer(codec codec.Codec, proxy node.Node, db database.Database, modules []modules.Module, serviceName string, commitNumber uint64) parser.Indexer {
 	return &Impl{
 		codec:           codec,
 		Node:            proxy,
@@ -35,7 +35,7 @@ func NewIndexer(codec codec.Codec, proxy node.Node, db database.Database, module
 		Modules:         modules,
 		ServiceName:     serviceName,
 		ProcessedHeight: 0,
-		eventTypeCount:  8,
+		CommitNumber:    commitNumber,
 	}
 }
 
@@ -48,7 +48,7 @@ type Impl struct {
 	LatestBlockHeight atomic.Value
 	ProcessedHeight   uint64
 
-	eventTypeCount int
+	CommitNumber uint64
 
 	ServiceName string
 }
@@ -193,7 +193,7 @@ func (i *Impl) Process(height uint64) error {
 		finalSQL := ""
 		finalVal := make([]interface{}, 0)
 		left := step
-		right := step + CommitNumber
+		right := step + int(i.CommitNumber)
 		if right > sqlCount {
 			right = sqlCount
 		}

--- a/modular/blocksyncer/blocksyncer_indexer.go
+++ b/modular/blocksyncer/blocksyncer_indexer.go
@@ -7,8 +7,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"gorm.io/gorm"
-
 	abci "github.com/cometbft/cometbft/abci/types"
 	cometbfttypes "github.com/cometbft/cometbft/abci/types"
 	coretypes "github.com/cometbft/cometbft/rpc/core/types"
@@ -22,6 +20,7 @@ import (
 	"github.com/forbole/juno/v4/node"
 	"github.com/forbole/juno/v4/parser"
 	"github.com/forbole/juno/v4/types"
+	"gorm.io/gorm"
 
 	localDB "github.com/bnb-chain/greenfield-storage-provider/modular/blocksyncer/database"
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
@@ -184,31 +183,41 @@ func (i *Impl) Process(height uint64) error {
 		sql: val,
 	})
 
-	finalSQL := ""
-	finalVal := make([]interface{}, 0)
-	for _, m := range allSQL {
-		for k, v := range m {
-			finalSQL += fmt.Sprintf("%s;   ", k)
-			finalVal = append(finalVal, v...)
-		}
-	}
-
 	sqlCount := len(allSQL)
-
+	log.Infof("height :%d tx count:%d sql count:%d", height, txCount, sqlCount)
 	metrics.BlocksyncerLogicTime.Set(float64(time.Since(startTime).Milliseconds()))
 
+	step := 0
 	dbStartTime := time.Now()
-	tx := i.DB.Begin(context.TODO())
-	if txErr := tx.Db.Session(&gorm.Session{DryRun: false}).Exec(finalSQL, finalVal...).Error; txErr != nil {
-		log.Errorw("failed to exec sql", "error", txErr)
-		tx.Rollback()
-		return txErr
+	for step < sqlCount {
+		finalSQL := ""
+		finalVal := make([]interface{}, 0)
+		left := step
+		right := step + CommitNumber
+		if right > sqlCount {
+			right = sqlCount
+		}
+		for _, m := range allSQL[left:right] {
+			for k, v := range m {
+				finalSQL += fmt.Sprintf("%s;   ", k)
+				finalVal = append(finalVal, v...)
+			}
+		}
+		tx := i.DB.Begin(context.TODO())
+		if txErr := tx.Db.Session(&gorm.Session{DryRun: false}).Exec(finalSQL, finalVal...).Error; txErr != nil {
+			log.Errorw("failed to exec sql", "error", txErr)
+			tx.Rollback()
+			return txErr
+		}
+
+		if txErr := tx.Commit(); txErr != nil {
+			log.Errorw("failed to commit db", "error", txErr)
+			return txErr
+		}
+		step = right
+		log.Infof("%d - %d commit", left, right)
 	}
 
-	if txErr := tx.Commit(); txErr != nil {
-		log.Errorw("failed to commit db", "error", txErr)
-		return txErr
-	}
 	metrics.BlocksyncerWriteDBTime.Set(float64(time.Since(dbStartTime).Milliseconds()))
 	log.Infof("height :%d tx count:%d sql count:%d", height, txCount, sqlCount)
 	metrics.BlockEventCount.Set(float64(sqlCount))
@@ -237,7 +246,6 @@ func (i *Impl) Process(height uint64) error {
 
 // SaveEpoch accept a block result data and persist basic info into db to record current sync progress
 func (i *Impl) SaveEpoch(block *coretypes.ResultBlock) (string, []interface{}) {
-	log.Infof(common.BytesToHash(block.BlockID.Hash).String())
 	return localDB.Cast(i.DB).SaveEpochToSQL(context.Background(), &models.Epoch{
 		OneRowId:    true,
 		BlockHeight: block.Block.Height,

--- a/modular/blocksyncer/blocksyncer_options.go
+++ b/modular/blocksyncer/blocksyncer_options.go
@@ -124,11 +124,15 @@ func (b *BlockSyncerModular) initClient(cfg *gfspconfig.GfSpConfig) error {
 	}
 	b.parserCtx = ctx
 	log.Infof("blocksyncer dsn : %s", config.Cfg.Database.DSN)
+	commitNumber := uint64(CommitNumber)
+	if cfg.BlockSyncer.CommitNumber != 0 {
+		commitNumber = cfg.BlockSyncer.CommitNumber
+	}
 	b.parserCtx.Indexer = NewIndexer(ctx.EncodingConfig.Marshaler,
 		ctx.Node,
 		ctx.Database,
 		ctx.Modules,
-		b.Name())
+		b.Name(), commitNumber)
 	return nil
 }
 

--- a/modular/blocksyncer/database/bucket.go
+++ b/modular/blocksyncer/database/bucket.go
@@ -10,7 +10,6 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
-	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
 	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
 )
 
@@ -112,6 +111,5 @@ func (db *DB) UpdateChargeSizeToSQL(ctx context.Context, objectID common.Hash, b
 	sql := `UPDATE buckets SET charge_size = charge_size %s CASE WHEN (CAST((SELECT payload_size FROM %s WHERE object_id = ?)AS DECIMAL(65,0)) < 128000) THEN CAST(128000 AS DECIMAL(65,0)) ELSE CAST((SELECT payload_size FROM %s WHERE object_id = ?) AS DECIMAL(65,0)) END WHERE bucket_name = ?`
 	vars := []interface{}{objectID, objectID, bucketName}
 	finalSql := fmt.Sprintf(sql, operation, tableName, tableName)
-	log.Infof("AddChargeSizeToSQL sql:%s", finalSql)
 	return finalSql, vars
 }

--- a/modular/manager/recover_scheduler.go
+++ b/modular/manager/recover_scheduler.go
@@ -23,17 +23,17 @@ import (
 )
 
 const (
-	recoverBatchSize = 10
+	recoverBatchSize = 30
 	maxRecoveryRetry = 5
 	MaxRecoveryTime  = 50
 
 	recoverInterval     = 10 * time.Second
-	verifyInterval      = 10 * time.Second
-	verifyGVGQueryLimit = uint32(100)
+	verifyInterval      = 3 * time.Second
+	verifyGVGQueryLimit = uint32(50)
 
-	recoverFailedObjectInterval = 30 * time.Second
+	recoverFailedObjectInterval = 20 * time.Second
 
-	monitorRecoverTimeOut = float64(5) // 10 minute
+	monitorRecoverTimeOut = float64(2) // 2 minute
 )
 
 type RecoverVGFScheduler struct {

--- a/modular/manager/recover_scheduler.go
+++ b/modular/manager/recover_scheduler.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	recoverBatchSize = 30
+	recoverBatchSize = 50
 	maxRecoveryRetry = 5
 	MaxRecoveryTime  = 50
 


### PR DESCRIPTION
### Description

blocksyncer sql is commit in batches

### Rationale

When dealing with large blocks, sql may exceed the limit length and cause an error

### Example

The number of sql committed each time is adjusted by the configuration

### Changes

Notable changes: 
* Add the configuration item commit number
* sql batch commit


### Potential Impacts
* sync speed