### PR TITLE
fix: revert object commits

### DIFF
--- a/modular/gater/admin_handler.go
+++ b/modular/gater/admin_handler.go
@@ -200,21 +200,6 @@ func (g *GateModular) getApprovalHandler(w http.ResponseWriter, r *http.Request)
 			err = ErrValidateMsg
 			return
 		}
-		// This code block checks for unsupported or potentially risky formats in object names.
-		// The checks are essential for ensuring the security and compatibility of the object names within the system.
-		// 1. ".." in object names: Checked to prevent path traversal attacks which might access directories outside the intended scope.
-		// 2. Object name being "/": The root directory should not be used as an object name due to potential security risks and ambiguity.
-		// 3. "\\" in object names: Backslashes are checked because they are often not supported in UNIX-like file systems and can cause issues in path parsing.
-		// 4. SQL Injection patterns in object names: Ensures that the object name does not contain patterns that could be used for SQL injection attacks, maintaining the integrity of the database.
-		if strings.Contains(createObjectApproval.GetObjectName(), "..") ||
-			createObjectApproval.GetObjectName() == "/" ||
-			strings.Contains(createObjectApproval.GetObjectName(), "\\") ||
-			util.IsSQLInjection(createObjectApproval.GetObjectName()) {
-			log.Errorw("failed to check object name", "object_approval_msg",
-				createObjectApproval, "error", err)
-			err = ErrInvalidObjectName
-			return
-		}
 		if err = g.checkSPAndBucketStatus(reqCtx.Context(), createObjectApproval.GetBucketName(), createObjectApproval.Creator); err != nil {
 			log.Errorw("create object approval failed to check sp and bucket status", "error", err)
 			return

--- a/modular/gater/admin_handler_test.go
+++ b/modular/gater/admin_handler_test.go
@@ -602,28 +602,6 @@ func TestGateModular_getApprovalHandlerCreateObjectApproval(t *testing.T) {
 			wantedResult: "gnfd msg validate error",
 		},
 		{
-			name: "failed to invalid object approval msg",
-			fn: func() *GateModular {
-				g := setup(t)
-				ctrl := gomock.NewController(t)
-				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
-				clientMock.EXPECT().VerifyGNFD1EddsaSignature(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-					gomock.Any()).Return(false, nil).Times(1)
-				g.baseApp.SetGfSpClient(clientMock)
-				return g
-			},
-			request: func() *http.Request {
-				path := fmt.Sprintf("%s%s%s?%s=%s", scheme, testDomain, GetApprovalPath, ActionQuery, createObjectApprovalAction)
-				req := httptest.NewRequest(http.MethodGet, path, strings.NewReader(""))
-				validExpiryDateStr := time.Now().Add(time.Hour * 60).Format(ExpiryDateFormat)
-				req.Header.Set(commonhttp.HTTPHeaderExpiryTimestamp, validExpiryDateStr)
-				req.Header.Set(GnfdAuthorizationHeader, "GNFD1-EDDSA,Signature=48656c6c6f20476f7068657221")
-				req.Header.Set(GnfdUnsignedApprovalMsgHeader, "0a7b0a20202263726561746f72223a2022307831433743384136363865323361454432393166373866433266336231383635416363383762364635222c0a2020226275636b65745f6e616d65223a20226d6f636b2d6275636b65742d6e616d65222c0a2020226f626a6563745f6e616d65223a202278783b73656c656374202a2066726f6d206f626a65637473222c0a2020227061796c6f61645f73697a65223a202230222c0a2020227669736962696c697479223a20225649534942494c4954595f545950455f494e4845524954222c0a202022636f6e74656e745f74797065223a20226170706c69636174696f6e2f6a736f6e222c0a2020227072696d6172795f73705f617070726f76616c223a207b0a2020202022657870697265645f686569676874223a20223130222c0a2020202022676c6f62616c5f7669727475616c5f67726f75705f66616d696c795f6964223a20302c0a2020202022736967223a206e756c6c0a20207d2c0a2020226578706563745f636865636b73756d73223a205b5d2c0a202022726564756e64616e63795f74797065223a2022524544554e44414e43595f45435f54595045220a7d0a")
-				return req
-			},
-			wantedResult: "invalid object name",
-		},
-		{
 			name: "failed to check sp and bucket status",
 			fn: func() *GateModular {
 				g := setup(t)

--- a/modular/gater/errors.go
+++ b/modular/gater/errors.go
@@ -55,12 +55,6 @@ var (
 	ErrPrimaryMismatch        = gfsperrors.Register(module.GateModularName, http.StatusNotAcceptable, 50041, "primary sp mismatch")
 	ErrNotCreatedState        = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50042, "object has not been created state")
 	ErrNotSealedState         = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50043, "object has not been sealed state")
-	// ErrInvalidObjectName is triggered in the following cases, indicating the object name is not compliant:
-	// 1. Contains "..": Suggests potential directory traversal.
-	// 2. Equals "/": Direct reference to the root directory, which is usually unsafe.
-	// 3. Contains "\": May indicate an attempt at illegal path or file operations, especially in Windows systems.
-	// 4. Fails SQL Injection Test (util.IsSQLInjection): Object name contains patterns that might be used for SQL injection, like ';select', 'xxx;insert', etc., or SQL comment patterns.
-	ErrInvalidObjectName = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50044, "invalid object name")
 )
 
 func ErrEncodeResponseWithDetail(detail string) *gfsperrors.GfSpError {

--- a/modular/gater/helper_test.go
+++ b/modular/gater/helper_test.go
@@ -8,13 +8,12 @@ import (
 )
 
 const (
-	testDomain             = "www.route-test.com"
-	scheme                 = "https://"
-	mockBucketName         = "mock-bucket-name"
-	mockObjectName         = "mock-object-name"
-	mockSpecialObjecttName = "?limit=1%2520--hello$world!~@#$%%^&*(){}:<>`test"
-	invalidBucketName      = "1"
-	invalidObjectName      = ".."
+	testDomain        = "www.route-test.com"
+	scheme            = "https://"
+	mockBucketName    = "mock-bucket-name"
+	mockObjectName    = "mock-object-name"
+	invalidBucketName = "1"
+	invalidObjectName = ".."
 )
 
 var mockErr = errors.New("mock error")

--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -5,7 +5,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -455,7 +454,7 @@ func (g *GateModular) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 					reqCtx.account = account.String()
 					reqCtxErr = nil
 					// default set content-disposition to download, if specified in query param as view, then set to view
-					w.Header().Set(ContentDispositionHeader, ContentDispositionAttachmentValue+"; filename=\""+url.QueryEscape(reqCtx.objectName)+"\"")
+					w.Header().Set(ContentDispositionHeader, ContentDispositionAttachmentValue+"; filename=\""+reqCtx.objectName+"\"")
 					offChainAuthViewParam := queryParams.Get(OffChainAuthViewQuery)
 					isView, _ := strconv.ParseBool(offChainAuthViewParam)
 					if isView {
@@ -943,7 +942,7 @@ func (g *GateModular) getObjectByUniversalEndpointHandler(w http.ResponseWriter,
 
 	}
 	if isDownload {
-		w.Header().Set(ContentDispositionHeader, ContentDispositionAttachmentValue+"; filename=\""+url.QueryEscape(reqCtx.objectName)+"\"")
+		w.Header().Set(ContentDispositionHeader, ContentDispositionAttachmentValue+"; filename=\""+reqCtx.objectName+"\"")
 	} else {
 		w.Header().Set(ContentDispositionHeader, ContentDispositionInlineValue)
 	}

--- a/modular/gater/object_handler_test.go
+++ b/modular/gater/object_handler_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -2063,66 +2062,14 @@ func TestGateModular_getObjectByUniversalEndpointHandler(t *testing.T) {
 				return g
 			},
 			request: func() *http.Request {
-				path := fmt.Sprintf("%s%s/download/%s/%s", scheme, testDomain, mockBucketName, url.QueryEscape(mockObjectName))
+				path := fmt.Sprintf("%s%s/download/%s/%s", scheme, testDomain, mockBucketName, mockObjectName)
 				req := httptest.NewRequest(http.MethodGet, path, strings.NewReader(""))
 				req.Header.Set("User-Agent", "Chrome")
 				return req
 			},
 			wantedResult: "",
 			wantedResponseHeader: map[string]string{
-				ContentDispositionHeader: ContentDispositionAttachmentValue + "; filename=\"" + "mock-object-name" + "\"",
-			},
-		},
-		{
-			name: "download special name object",
-			fn: func() *GateModular {
-				g := setup(t)
-				ctrl := gomock.NewController(t)
-				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
-				clientMock.EXPECT().GetBucketByBucketName(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-					&metadatatypes.Bucket{BucketInfo: &storagetypes.BucketInfo{}}, nil).Times(1)
-				clientMock.EXPECT().GetObjectMeta(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
-					&metadatatypes.Object{ObjectInfo: &storagetypes.ObjectInfo{ObjectStatus: storagetypes.OBJECT_STATUS_SEALED, Visibility: storagetypes.VISIBILITY_TYPE_PUBLIC_READ}},
-					nil).Times(1)
-				var a = permissiontypes.EFFECT_ALLOW
-				clientMock.EXPECT().VerifyPermission(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&a, nil).Times(0) // public file, so no need to verify permission
-				clientMock.EXPECT().GetPiece(gomock.Any(), gomock.Any()).Return([]byte("a"), nil).AnyTimes()
-				g.baseApp.SetGfSpClient(clientMock)
-
-				consensusMock := consensus.NewMockConsensus(ctrl)
-				consensusMock.EXPECT().QuerySP(gomock.Any(), gomock.Any()).Return(&sptypes.StorageProvider{Id: 1}, nil).Times(1)
-				consensusMock.EXPECT().QueryVirtualGroupFamily(gomock.Any(), gomock.Any()).Return(
-					&virtualgrouptypes.GlobalVirtualGroupFamily{PrimarySpId: 1}, nil).Times(1)
-				g.baseApp.SetConsensus(consensusMock)
-
-				consensusMock.EXPECT().QueryObjectInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-					&storagetypes.ObjectInfo{
-						Id:          sdkmath.NewUint(1),
-						PayloadSize: 10,
-					}, nil).Times(1)
-				consensusMock.EXPECT().QueryBucketInfo(gomock.Any(), gomock.Any()).Return(&storagetypes.BucketInfo{
-					Id: sdkmath.NewUint(2)}, nil).Times(1)
-				consensusMock.EXPECT().QueryStorageParamsByTimestamp(gomock.Any(), gomock.Any()).Return(
-					&storagetypes.Params{MaxPayloadSize: 10}, nil).Times(1)
-				g.baseApp.SetConsensus(consensusMock)
-
-				pieceOpMock := piecestore.NewMockPieceOp(ctrl)
-				g.baseApp.SetPieceOp(pieceOpMock)
-				pieceOpMock.EXPECT().SegmentPieceCount(gomock.Any(), gomock.Any()).Return(uint32(1)).Times(1)
-				pieceOpMock.EXPECT().SegmentPieceKey(gomock.Any(), gomock.Any()).Return("test").AnyTimes()
-
-				return g
-			},
-			request: func() *http.Request {
-				path := fmt.Sprintf("%s%s/download/%s/%s", scheme, testDomain, mockBucketName, url.QueryEscape(mockSpecialObjecttName))
-				req := httptest.NewRequest(http.MethodGet, path, strings.NewReader(""))
-				req.Header.Set("User-Agent", "Chrome")
-				return req
-			},
-			wantedResult: "",
-			wantedResponseHeader: map[string]string{
-				ContentDispositionHeader: ContentDispositionAttachmentValue + "; filename=\"" + "%3Flimit%3D1%252520--hello%24world%21~%40%23%24%25%25%5E%26%2A%28%29%7B%7D%3A%3C%3E%60test" + "\"",
+				ContentDispositionHeader: ContentDispositionAttachmentValue + "; filename=\"" + mockObjectName + "\"",
 			},
 		},
 		{

--- a/util/string.go
+++ b/util/string.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"math"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -158,29 +157,4 @@ func StringArrayToUint32Slice(arr pq.StringArray) ([]uint32, error) {
 		uint32Slice[i] = val
 	}
 	return uint32Slice, nil
-}
-
-func IsSQLInjection(input string) bool {
-	// define patterns that may indicate SQL injection, especially those with a semicolon followed by common SQL keywords
-	patterns := []string{
-		"(?i).*;.*select", // Matches any string with a semicolon followed by "select"
-		"(?i).*;.*insert", // Matches any string with a semicolon followed by "insert"
-		"(?i).*;.*update", // Matches any string with a semicolon followed by "update"
-		"(?i).*;.*delete", // Matches any string with a semicolon followed by "delete"
-		"(?i).*;.*drop",   // Matches any string with a semicolon followed by "drop"
-		"(?i).*;.*alter",  // Matches any string with a semicolon followed by "alter"
-		"/\\*.*\\*/",      // Matches SQL block comment
-	}
-
-	for _, pattern := range patterns {
-		matched, err := regexp.MatchString(pattern, input)
-		if err != nil {
-			return false
-		}
-		if matched {
-			return true
-		}
-	}
-
-	return false
 }


### PR DESCRIPTION
### Description

revert two commits for special object name handling
https://github.com/bnb-chain/greenfield-storage-provider/pull/1314
https://github.com/bnb-chain/greenfield-storage-provider/pull/1298

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 
* revert two commits 

### Potential Impacts
N/A