### PR TITLE
fix: re-apply object commits

### DIFF
--- a/modular/gater/admin_handler_test.go
+++ b/modular/gater/admin_handler_test.go
@@ -602,6 +602,28 @@ func TestGateModular_getApprovalHandlerCreateObjectApproval(t *testing.T) {
 			wantedResult: "gnfd msg validate error",
 		},
 		{
+			name: "failed to invalid object approval msg",
+			fn: func() *GateModular {
+				g := setup(t)
+				ctrl := gomock.NewController(t)
+				clientMock := gfspclient.NewMockGfSpClientAPI(ctrl)
+				clientMock.EXPECT().VerifyGNFD1EddsaSignature(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any()).Return(false, nil).Times(1)
+				g.baseApp.SetGfSpClient(clientMock)
+				return g
+			},
+			request: func() *http.Request {
+				path := fmt.Sprintf("%s%s%s?%s=%s", scheme, testDomain, GetApprovalPath, ActionQuery, createObjectApprovalAction)
+				req := httptest.NewRequest(http.MethodGet, path, strings.NewReader(""))
+				validExpiryDateStr := time.Now().Add(time.Hour * 60).Format(ExpiryDateFormat)
+				req.Header.Set(commonhttp.HTTPHeaderExpiryTimestamp, validExpiryDateStr)
+				req.Header.Set(GnfdAuthorizationHeader, "GNFD1-EDDSA,Signature=48656c6c6f20476f7068657221")
+				req.Header.Set(GnfdUnsignedApprovalMsgHeader, "0a7b0a20202263726561746f72223a2022307831433743384136363865323361454432393166373866433266336231383635416363383762364635222c0a2020226275636b65745f6e616d65223a20226d6f636b2d6275636b65742d6e616d65222c0a2020226f626a6563745f6e616d65223a202278783b73656c656374202a2066726f6d206f626a65637473222c0a2020227061796c6f61645f73697a65223a202230222c0a2020227669736962696c697479223a20225649534942494c4954595f545950455f494e4845524954222c0a202022636f6e74656e745f74797065223a20226170706c69636174696f6e2f6a736f6e222c0a2020227072696d6172795f73705f617070726f76616c223a207b0a2020202022657870697265645f686569676874223a20223130222c0a2020202022676c6f62616c5f7669727475616c5f67726f75705f66616d696c795f6964223a20302c0a2020202022736967223a206e756c6c0a20207d2c0a2020226578706563745f636865636b73756d73223a205b5d2c0a202022726564756e64616e63795f74797065223a2022524544554e44414e43595f45435f54595045220a7d0a")
+				return req
+			},
+			wantedResult: "invalid object name",
+		},
+		{
 			name: "failed to check sp and bucket status",
 			fn: func() *GateModular {
 				g := setup(t)

--- a/modular/gater/errors.go
+++ b/modular/gater/errors.go
@@ -55,6 +55,12 @@ var (
 	ErrPrimaryMismatch        = gfsperrors.Register(module.GateModularName, http.StatusNotAcceptable, 50041, "primary sp mismatch")
 	ErrNotCreatedState        = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50042, "object has not been created state")
 	ErrNotSealedState         = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50043, "object has not been sealed state")
+	// ErrInvalidObjectName is triggered in the following cases, indicating the object name is not compliant:
+	// 1. Contains "..": Suggests potential directory traversal.
+	// 2. Equals "/": Direct reference to the root directory, which is usually unsafe.
+	// 3. Contains "\": May indicate an attempt at illegal path or file operations, especially in Windows systems.
+	// 4. Fails SQL Injection Test (util.IsSQLInjection): Object name contains patterns that might be used for SQL injection, like ';select', 'xxx;insert', etc., or SQL comment patterns.
+	ErrInvalidObjectName = gfsperrors.Register(module.GateModularName, http.StatusBadRequest, 50044, "invalid object name")
 )
 
 func ErrEncodeResponseWithDetail(detail string) *gfsperrors.GfSpError {

--- a/modular/gater/helper_test.go
+++ b/modular/gater/helper_test.go
@@ -8,12 +8,13 @@ import (
 )
 
 const (
-	testDomain        = "www.route-test.com"
-	scheme            = "https://"
-	mockBucketName    = "mock-bucket-name"
-	mockObjectName    = "mock-object-name"
-	invalidBucketName = "1"
-	invalidObjectName = ".."
+	testDomain             = "www.route-test.com"
+	scheme                 = "https://"
+	mockBucketName         = "mock-bucket-name"
+	mockObjectName         = "mock-object-name"
+	mockSpecialObjecttName = "?limit=1%2520--hello$world!~@#$%%^&*(){}:<>`test"
+	invalidBucketName      = "1"
+	invalidObjectName      = ".."
 )
 
 var mockErr = errors.New("mock error")

--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -454,7 +455,7 @@ func (g *GateModular) getObjectHandler(w http.ResponseWriter, r *http.Request) {
 					reqCtx.account = account.String()
 					reqCtxErr = nil
 					// default set content-disposition to download, if specified in query param as view, then set to view
-					w.Header().Set(ContentDispositionHeader, ContentDispositionAttachmentValue+"; filename=\""+reqCtx.objectName+"\"")
+					w.Header().Set(ContentDispositionHeader, ContentDispositionAttachmentValue+"; filename=\""+url.QueryEscape(reqCtx.objectName)+"\"")
 					offChainAuthViewParam := queryParams.Get(OffChainAuthViewQuery)
 					isView, _ := strconv.ParseBool(offChainAuthViewParam)
 					if isView {
@@ -942,7 +943,7 @@ func (g *GateModular) getObjectByUniversalEndpointHandler(w http.ResponseWriter,
 
 	}
 	if isDownload {
-		w.Header().Set(ContentDispositionHeader, ContentDispositionAttachmentValue+"; filename=\""+reqCtx.objectName+"\"")
+		w.Header().Set(ContentDispositionHeader, ContentDispositionAttachmentValue+"; filename=\""+url.QueryEscape(reqCtx.objectName)+"\"")
 	} else {
 		w.Header().Set(ContentDispositionHeader, ContentDispositionInlineValue)
 	}

--- a/util/string.go
+++ b/util/string.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"math"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -157,4 +158,29 @@ func StringArrayToUint32Slice(arr pq.StringArray) ([]uint32, error) {
 		uint32Slice[i] = val
 	}
 	return uint32Slice, nil
+}
+
+func IsSQLInjection(input string) bool {
+	// define patterns that may indicate SQL injection, especially those with a semicolon followed by common SQL keywords
+	patterns := []string{
+		"(?i).*;.*select", // Matches any string with a semicolon followed by "select"
+		"(?i).*;.*insert", // Matches any string with a semicolon followed by "insert"
+		"(?i).*;.*update", // Matches any string with a semicolon followed by "update"
+		"(?i).*;.*delete", // Matches any string with a semicolon followed by "delete"
+		"(?i).*;.*drop",   // Matches any string with a semicolon followed by "drop"
+		"(?i).*;.*alter",  // Matches any string with a semicolon followed by "alter"
+		"/\\*.*\\*/",      // Matches SQL block comment
+	}
+
+	for _, pattern := range patterns {
+		matched, err := regexp.MatchString(pattern, input)
+		if err != nil {
+			return false
+		}
+		if matched {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
### Description

re-apply two commits for special object name handling
https://github.com/bnb-chain/greenfield-storage-provider/pull/1314
https://github.com/bnb-chain/greenfield-storage-provider/pull/1298

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 
* re-apply two commits 

### Potential Impacts
N/A