### PR TITLE
fix: Not allow to upload piece/object for a fully-uploaded object

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -124,7 +124,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.3.0 // indirect
 	github.com/golang/glog v1.1.0 // indirect
-	github.com/golang/mock v1.6.0 // indirect
+	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.1.2 // indirect

--- a/modular/gater/object_handler_test.go
+++ b/modular/gater/object_handler_test.go
@@ -9,18 +9,20 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bnb-chain/greenfield-storage-provider/modular/downloader"
-	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 
+	"github.com/bnb-chain/greenfield-storage-provider/modular/downloader"
+	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
+
 	sdkmath "cosmossdk.io/math"
-	metadatatypes "github.com/bnb-chain/greenfield-storage-provider/modular/metadata/types"
-	virtualgrouptypes "github.com/bnb-chain/greenfield/x/virtualgroup/types"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+
+	metadatatypes "github.com/bnb-chain/greenfield-storage-provider/modular/metadata/types"
+	virtualgrouptypes "github.com/bnb-chain/greenfield/x/virtualgroup/types"
 
 	commonhttp "github.com/bnb-chain/greenfield-common/go/http"
 	"github.com/bnb-chain/greenfield-storage-provider/base/gfspclient"

--- a/modular/metadata/metadata_query_service.go
+++ b/modular/metadata/metadata_query_service.go
@@ -8,14 +8,18 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/bnb-chain/greenfield-storage-provider/modular/metadata/types"
+	storetypes "github.com/bnb-chain/greenfield-storage-provider/store/types"
 )
 
 func (r *MetadataModular) GfSpQueryUploadProgress(ctx context.Context, req *types.GfSpQueryUploadProgressRequest) (
 	*types.GfSpQueryUploadProgressResponse, error) {
 	state, errDescription, err := r.baseApp.GfSpDB().GetUploadState(req.GetObjectId())
 	if err != nil {
-		if strings.Contains(err.Error(), gorm.ErrRecordNotFound.Error()) {
-			return &types.GfSpQueryUploadProgressResponse{Err: ErrNoRecord}, nil
+		if strings.Contains(err.Error(), gorm.ErrRecordNotFound.Error()) { // ErrRecordNotFound is not an actual error
+			return &types.GfSpQueryUploadProgressResponse{
+				State:          storetypes.TaskState_TASK_STATE_INIT_UNSPECIFIED,
+				ErrDescription: errDescription,
+			}, nil
 		}
 		return &types.GfSpQueryUploadProgressResponse{
 			Err: ErrGfSpDBWithDetail("GfSpQueryUploadProgress error:" + err.Error()),

--- a/modular/metadata/metadata_query_service_test.go
+++ b/modular/metadata/metadata_query_service_test.go
@@ -5,11 +5,12 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/bnb-chain/greenfield-storage-provider/core/spdb"
-	storetypes "github.com/bnb-chain/greenfield-storage-provider/store/types"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"gorm.io/gorm"
+
+	"github.com/bnb-chain/greenfield-storage-provider/core/spdb"
+	storetypes "github.com/bnb-chain/greenfield-storage-provider/store/types"
 
 	"github.com/bnb-chain/greenfield-storage-provider/modular/metadata/types"
 )
@@ -41,7 +42,8 @@ func TestMetadataModular_GfSpQueryUploadProgress_ErrRecordNotFound(t *testing.T)
 	).Times(1)
 	state, err := a.GfSpQueryUploadProgress(context.Background(), &types.GfSpQueryUploadProgressRequest{ObjectId: 1})
 	assert.Nil(t, err)
-	assert.Equal(t, "no uploading record", state.Err.Description)
+	assert.Nil(t, state.Err)
+	assert.Equal(t, "record not found", state.ErrDescription)
 }
 
 func TestMetadataModular_GfSpQueryUploadProgress_Err(t *testing.T) {

--- a/modular/uploader/upload_task.go
+++ b/modular/uploader/upload_task.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/avast/retry-go/v4"
+
 	"github.com/bnb-chain/greenfield-common/go/hash"
 	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsperrors"
 	"github.com/bnb-chain/greenfield-storage-provider/core/module"
@@ -31,11 +32,13 @@ var (
 )
 
 var (
-	ErrDanglingUploadTask = gfsperrors.Register(module.UploadModularName, http.StatusBadRequest, 110001, "OoooH... request lost, try again later")
-	ErrNotCreatedState    = gfsperrors.Register(module.UploadModularName, http.StatusForbidden, 110002, "object not created state")
-	ErrRepeatedTask       = gfsperrors.Register(module.UploadModularName, http.StatusNotAcceptable, 110003, "put object request repeated")
-	ErrInvalidIntegrity   = gfsperrors.Register(module.UploadModularName, http.StatusNotAcceptable, 110004, "invalid payload data integrity hash")
-	ErrClosedStream       = gfsperrors.Register(module.UploadModularName, http.StatusBadRequest, 110005, "upload payload data stream exception")
+	ErrDanglingUploadTask   = gfsperrors.Register(module.UploadModularName, http.StatusBadRequest, 110001, "OoooH... request lost, try again later")
+	ErrNotCreatedState      = gfsperrors.Register(module.UploadModularName, http.StatusForbidden, 110002, "object not created state")
+	ErrRepeatedTask         = gfsperrors.Register(module.UploadModularName, http.StatusNotAcceptable, 110003, "put object request repeated")
+	ErrInvalidIntegrity     = gfsperrors.Register(module.UploadModularName, http.StatusNotAcceptable, 110004, "invalid payload data integrity hash")
+	ErrClosedStream         = gfsperrors.Register(module.UploadModularName, http.StatusBadRequest, 110005, "upload payload data stream exception")
+	ErrInvalidUploadRequest = gfsperrors.Register(module.UploadModularName, http.StatusConflict, 110006, "the object had already been fully uploaded and any further uploading attempt is not allowed")
+	ErrGetObjectUploadState = gfsperrors.Register(module.UploadModularName, http.StatusInternalServerError, 110007, "failed to get upload object state")
 )
 
 func ErrPieceStoreWithDetail(detail string) *gfsperrors.GfSpError {
@@ -55,6 +58,7 @@ func (u *UploadModular) PreUploadObject(ctx context.Context, uploadObjectTask co
 		log.CtxErrorw(ctx, "failed to pre upload object, object not create")
 		return ErrNotCreatedState
 	}
+
 	startTime := time.Now()
 	has := u.uploadQueue.Has(uploadObjectTask.Key())
 	metrics.PerfPutObjectTime.WithLabelValues("uploader_put_object_check_repeat_cost").Observe(time.Since(startTime).Seconds())
@@ -70,6 +74,18 @@ func (u *UploadModular) PreUploadObject(ctx context.Context, uploadObjectTask co
 		log.CtxErrorw(ctx, "failed to begin upload object task")
 		return err
 	}
+
+	taskState, _, errGetUploadObjectState := u.baseApp.GfSpClient().GetUploadObjectState(ctx, uploadObjectTask.GetObjectInfo().Id.Uint64())
+	if errGetUploadObjectState != nil {
+		log.CtxErrorw(ctx, "failed to get upload object state")
+		return ErrGetObjectUploadState
+	}
+	if !types.CheckAllowUploadStatus(types.TaskState(taskState)) {
+		// It is not allowed to upload piece or object for an object id which had already been fully uploaded.
+		log.CtxErrorw(ctx, "failed to put object as the target object had already fully uploaded")
+		return ErrInvalidUploadRequest
+	}
+
 	return nil
 }
 
@@ -219,6 +235,18 @@ func (u *UploadModular) PreResumableUploadObject(ctx context.Context, task coret
 	if err := u.baseApp.GfSpClient().CreateResumableUploadObject(ctx, task); err != nil {
 		log.CtxErrorw(ctx, "failed to begin upload object task")
 		return err
+	}
+
+	taskState, _, errGetUploadObjectState := u.baseApp.GfSpClient().GetUploadObjectState(ctx, task.GetObjectInfo().Id.Uint64())
+	if errGetUploadObjectState != nil {
+		log.CtxErrorw(ctx, "failed to get upload object state")
+		return ErrGetObjectUploadState
+	}
+	log.CtxInfo(ctx, "taskState is ", taskState, "task is ", task)
+	if !types.CheckAllowUploadStatus(types.TaskState(taskState)) {
+		// It is not allowed to upload piece or object for an object id which had already been fully uploaded.
+		log.CtxErrorw(ctx, "failed to put object as the target object had already fully uploaded")
+		return ErrInvalidUploadRequest
 	}
 	return nil
 }

--- a/modular/uploader/uploader_task_test.go
+++ b/modular/uploader/uploader_task_test.go
@@ -17,6 +17,7 @@ import (
 	corespdb "github.com/bnb-chain/greenfield-storage-provider/core/spdb"
 	coretask "github.com/bnb-chain/greenfield-storage-provider/core/task"
 	"github.com/bnb-chain/greenfield-storage-provider/core/taskqueue"
+	servicetypes "github.com/bnb-chain/greenfield-storage-provider/store/types"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 )
 
@@ -59,10 +60,12 @@ func TestUploadModular_PreUploadObjectSuccess(t *testing.T) {
 
 	m1 := gfspclient.NewMockGfSpClientAPI(ctrl)
 	u.baseApp.SetGfSpClient(m1)
+	m1.EXPECT().GetUploadObjectState(gomock.Any(), gomock.Any()).Return(int32(servicetypes.TaskState_TASK_STATE_UPLOAD_OBJECT_DOING), "", nil).Times(1)
+
 	m1.EXPECT().CreateUploadObject(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 	uploadObjectTask := &gfsptask.GfSpUploadObjectTask{
-		ObjectInfo:    &storagetypes.ObjectInfo{ObjectStatus: storagetypes.OBJECT_STATUS_CREATED},
+		ObjectInfo:    &storagetypes.ObjectInfo{ObjectStatus: storagetypes.OBJECT_STATUS_CREATED, Id: sdkmath.NewUint(1)},
 		StorageParams: &storagetypes.Params{MaxPayloadSize: 1},
 	}
 	err := u.PreUploadObject(context.TODO(), uploadObjectTask)
@@ -79,7 +82,7 @@ func TestUploadModular_PreUploadObjectFailure1(t *testing.T) {
 	m.EXPECT().Has(gomock.Any()).Return(true).Times(1)
 
 	uploadObjectTask := &gfsptask.GfSpUploadObjectTask{
-		ObjectInfo:    &storagetypes.ObjectInfo{ObjectStatus: storagetypes.OBJECT_STATUS_CREATED},
+		ObjectInfo:    &storagetypes.ObjectInfo{ObjectStatus: storagetypes.OBJECT_STATUS_CREATED, Id: sdkmath.NewUint(1)},
 		StorageParams: &storagetypes.Params{MaxPayloadSize: 1},
 	}
 	err := u.PreUploadObject(context.TODO(), uploadObjectTask)
@@ -100,11 +103,74 @@ func TestUploadModular_PreUploadObjectFailure2(t *testing.T) {
 	m1.EXPECT().CreateUploadObject(gomock.Any(), gomock.Any()).Return(mockErr).Times(1)
 
 	uploadObjectTask := &gfsptask.GfSpUploadObjectTask{
-		ObjectInfo:    &storagetypes.ObjectInfo{ObjectStatus: storagetypes.OBJECT_STATUS_CREATED},
+		ObjectInfo:    &storagetypes.ObjectInfo{ObjectStatus: storagetypes.OBJECT_STATUS_CREATED, Id: sdkmath.NewUint(1)},
 		StorageParams: &storagetypes.Params{MaxPayloadSize: 1},
 	}
 	err := u.PreUploadObject(context.TODO(), uploadObjectTask)
 	assert.Equal(t, mockErr, err)
+}
+
+func TestUploadModular_PreUploadObjectFailure3(t *testing.T) {
+	t.Log("Can't proceed for object which had been fully uploaded")
+	u := setup(t)
+	ctrl := gomock.NewController(t)
+	m := taskqueue.NewMockTQueueOnStrategy(ctrl)
+	u.uploadQueue = m
+	m.EXPECT().Has(gomock.Any()).Return(false).Times(1)
+
+	m1 := gfspclient.NewMockGfSpClientAPI(ctrl)
+	u.baseApp.SetGfSpClient(m1)
+	m1.EXPECT().GetUploadObjectState(gomock.Any(), gomock.Any()).Return(int32(servicetypes.TaskState_TASK_STATE_UPLOAD_OBJECT_DONE), "", nil).Times(1)
+	m1.EXPECT().CreateUploadObject(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+	uploadObjectTask := &gfsptask.GfSpUploadObjectTask{
+		ObjectInfo:    &storagetypes.ObjectInfo{ObjectStatus: storagetypes.OBJECT_STATUS_CREATED, Id: sdkmath.NewUint(1)},
+		StorageParams: &storagetypes.Params{MaxPayloadSize: 1},
+	}
+	err := u.PreUploadObject(context.TODO(), uploadObjectTask)
+	assert.Equal(t, ErrInvalidUploadRequest, err)
+}
+
+func TestUploadModular_PreUploadObjectFailure4(t *testing.T) {
+	t.Log("failed to get upload object state")
+	u := setup(t)
+	ctrl := gomock.NewController(t)
+	m := taskqueue.NewMockTQueueOnStrategy(ctrl)
+	u.uploadQueue = m
+	m.EXPECT().Has(gomock.Any()).Return(false).Times(1)
+
+	m1 := gfspclient.NewMockGfSpClientAPI(ctrl)
+	u.baseApp.SetGfSpClient(m1)
+	m1.EXPECT().GetUploadObjectState(gomock.Any(), gomock.Any()).Return(int32(servicetypes.TaskState_TASK_STATE_INIT_UNSPECIFIED), "", mockErr).Times(1)
+	m1.EXPECT().CreateUploadObject(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+	uploadObjectTask := &gfsptask.GfSpUploadObjectTask{
+		ObjectInfo:    &storagetypes.ObjectInfo{ObjectStatus: storagetypes.OBJECT_STATUS_CREATED, Id: sdkmath.NewUint(1)},
+		StorageParams: &storagetypes.Params{MaxPayloadSize: 1},
+	}
+	err := u.PreUploadObject(context.TODO(), uploadObjectTask)
+	assert.Equal(t, ErrGetObjectUploadState, err)
+}
+
+func TestUploadModular_PreUploadObjectFailure5(t *testing.T) {
+	t.Log("Can't proceed for object which had been fully uploaded")
+	u := setup(t)
+	ctrl := gomock.NewController(t)
+	m := taskqueue.NewMockTQueueOnStrategy(ctrl)
+	u.uploadQueue = m
+	m.EXPECT().Has(gomock.Any()).Return(false).Times(1)
+
+	m1 := gfspclient.NewMockGfSpClientAPI(ctrl)
+	u.baseApp.SetGfSpClient(m1)
+	m1.EXPECT().GetUploadObjectState(gomock.Any(), gomock.Any()).Return(int32(servicetypes.TaskState_TASK_STATE_REPLICATE_OBJECT_DOING), "", nil).Times(1)
+	m1.EXPECT().CreateUploadObject(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+	uploadObjectTask := &gfsptask.GfSpUploadObjectTask{
+		ObjectInfo:    &storagetypes.ObjectInfo{ObjectStatus: storagetypes.OBJECT_STATUS_CREATED, Id: sdkmath.NewUint(1)},
+		StorageParams: &storagetypes.Params{MaxPayloadSize: 1},
+	}
+	err := u.PreUploadObject(context.TODO(), uploadObjectTask)
+	assert.Equal(t, ErrInvalidUploadRequest, err)
 }
 
 func TestUploadModular_HandleUploadObjectTaskSuccess1(t *testing.T) {
@@ -373,9 +439,10 @@ func TestUploadModular_PreResumableUploadObjectSuccess(t *testing.T) {
 	m1 := gfspclient.NewMockGfSpClientAPI(ctrl)
 	u.baseApp.SetGfSpClient(m1)
 	m1.EXPECT().CreateResumableUploadObject(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	m1.EXPECT().GetUploadObjectState(gomock.Any(), gomock.Any()).Return(int32(servicetypes.TaskState_TASK_STATE_UPLOAD_OBJECT_DOING), "", nil).Times(1)
 
 	uploadObjectTask := &gfsptask.GfSpResumableUploadObjectTask{
-		ObjectInfo:    &storagetypes.ObjectInfo{ObjectStatus: storagetypes.OBJECT_STATUS_CREATED},
+		ObjectInfo:    &storagetypes.ObjectInfo{ObjectStatus: storagetypes.OBJECT_STATUS_CREATED, Id: sdkmath.NewUint(1)},
 		StorageParams: &storagetypes.Params{MaxPayloadSize: 1},
 	}
 	err := u.PreResumableUploadObject(context.TODO(), uploadObjectTask)
@@ -392,7 +459,7 @@ func TestUploadModular_PreResumableUploadObjectFailure1(t *testing.T) {
 	m.EXPECT().Has(gomock.Any()).Return(true).Times(1)
 
 	uploadObjectTask := &gfsptask.GfSpResumableUploadObjectTask{
-		ObjectInfo:    &storagetypes.ObjectInfo{ObjectStatus: storagetypes.OBJECT_STATUS_CREATED},
+		ObjectInfo:    &storagetypes.ObjectInfo{ObjectStatus: storagetypes.OBJECT_STATUS_CREATED, Id: sdkmath.NewUint(1)},
 		StorageParams: &storagetypes.Params{MaxPayloadSize: 1},
 	}
 	err := u.PreResumableUploadObject(context.TODO(), uploadObjectTask)
@@ -413,11 +480,80 @@ func TestUploadModular_PreResumableUploadObjectFailure2(t *testing.T) {
 	m1.EXPECT().CreateResumableUploadObject(gomock.Any(), gomock.Any()).Return(mockErr).Times(1)
 
 	uploadObjectTask := &gfsptask.GfSpResumableUploadObjectTask{
-		ObjectInfo:    &storagetypes.ObjectInfo{ObjectStatus: storagetypes.OBJECT_STATUS_CREATED},
+		ObjectInfo:    &storagetypes.ObjectInfo{ObjectStatus: storagetypes.OBJECT_STATUS_CREATED, Id: sdkmath.NewUint(1)},
 		StorageParams: &storagetypes.Params{MaxPayloadSize: 1},
 	}
 	err := u.PreResumableUploadObject(context.TODO(), uploadObjectTask)
 	assert.Equal(t, mockErr, err)
+}
+
+func TestUploadModular_PreResumableUploadObjectFailure3(t *testing.T) {
+	t.Log("Can't proceed for object which had been fully uploaded")
+	u := setup(t)
+	ctrl := gomock.NewController(t)
+
+	m := taskqueue.NewMockTQueueOnStrategy(ctrl)
+	u.resumeableUploadQueue = m
+	m.EXPECT().Has(gomock.Any()).Return(false).Times(1)
+
+	m1 := gfspclient.NewMockGfSpClientAPI(ctrl)
+	u.baseApp.SetGfSpClient(m1)
+	m1.EXPECT().GetUploadObjectState(gomock.Any(), gomock.Any()).Return(int32(servicetypes.TaskState_TASK_STATE_UPLOAD_OBJECT_DONE), "", nil).Times(1)
+
+	m1.EXPECT().CreateResumableUploadObject(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+	uploadObjectTask := &gfsptask.GfSpResumableUploadObjectTask{
+		ObjectInfo:    &storagetypes.ObjectInfo{ObjectStatus: storagetypes.OBJECT_STATUS_CREATED, Id: sdkmath.NewUint(1)},
+		StorageParams: &storagetypes.Params{MaxPayloadSize: 1},
+	}
+	err := u.PreResumableUploadObject(context.TODO(), uploadObjectTask)
+	assert.Equal(t, ErrInvalidUploadRequest, err)
+}
+
+func TestUploadModular_PreResumableUploadObjectFailure4(t *testing.T) {
+	t.Log("failed to get upload object state")
+	u := setup(t)
+	ctrl := gomock.NewController(t)
+
+	m := taskqueue.NewMockTQueueOnStrategy(ctrl)
+	u.resumeableUploadQueue = m
+	m.EXPECT().Has(gomock.Any()).Return(false).Times(1)
+
+	m1 := gfspclient.NewMockGfSpClientAPI(ctrl)
+	u.baseApp.SetGfSpClient(m1)
+	m1.EXPECT().GetUploadObjectState(gomock.Any(), gomock.Any()).Return(int32(servicetypes.TaskState_TASK_STATE_INIT_UNSPECIFIED), "", mockErr).Times(1)
+
+	m1.EXPECT().CreateResumableUploadObject(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+	uploadObjectTask := &gfsptask.GfSpResumableUploadObjectTask{
+		ObjectInfo:    &storagetypes.ObjectInfo{ObjectStatus: storagetypes.OBJECT_STATUS_CREATED, Id: sdkmath.NewUint(1)},
+		StorageParams: &storagetypes.Params{MaxPayloadSize: 1},
+	}
+	err := u.PreResumableUploadObject(context.TODO(), uploadObjectTask)
+	assert.Equal(t, ErrGetObjectUploadState, err)
+}
+
+func TestUploadModular_PreResumableUploadObjectFailure5(t *testing.T) {
+	t.Log("Can't proceed for object which had been fully uploaded")
+	u := setup(t)
+	ctrl := gomock.NewController(t)
+
+	m := taskqueue.NewMockTQueueOnStrategy(ctrl)
+	u.resumeableUploadQueue = m
+	m.EXPECT().Has(gomock.Any()).Return(false).Times(1)
+
+	m1 := gfspclient.NewMockGfSpClientAPI(ctrl)
+	u.baseApp.SetGfSpClient(m1)
+	m1.EXPECT().GetUploadObjectState(gomock.Any(), gomock.Any()).Return(int32(servicetypes.TaskState_TASK_STATE_REPLICATE_OBJECT_DOING), "", nil).Times(1)
+
+	m1.EXPECT().CreateResumableUploadObject(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+	uploadObjectTask := &gfsptask.GfSpResumableUploadObjectTask{
+		ObjectInfo:    &storagetypes.ObjectInfo{ObjectStatus: storagetypes.OBJECT_STATUS_CREATED, Id: sdkmath.NewUint(1)},
+		StorageParams: &storagetypes.Params{MaxPayloadSize: 1},
+	}
+	err := u.PreResumableUploadObject(context.TODO(), uploadObjectTask)
+	assert.Equal(t, ErrInvalidUploadRequest, err)
 }
 
 func TestUploadModular_HandleResumableUploadObjectTaskSuccess(t *testing.T) {

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -64,3 +64,15 @@ func StateToDescription(state TaskState) string {
 	}
 	return description
 }
+
+// CheckAllowUploadStatus helps check if the user upload request is allowed based on current state.
+// If a given TaskState is TaskState_TASK_STATE_UPLOAD_OBJECT_DONE or TaskState_TASK_STATE_REPLICATE_OBJECT_DOING,
+// we DO NOT accept any further uploading request for the same object id.
+func CheckAllowUploadStatus(state TaskState) bool {
+	switch state {
+	case TaskState_TASK_STATE_UPLOAD_OBJECT_DONE,
+		TaskState_TASK_STATE_REPLICATE_OBJECT_DOING:
+		return false
+	}
+	return true
+}

--- a/store/types/store_test.go
+++ b/store/types/store_test.go
@@ -31,3 +31,38 @@ func TestStateToDescription(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckAllowUploadStatus(t *testing.T) {
+	cases := []struct {
+		name         string
+		state        TaskState
+		wantedResult bool
+	}{
+		{
+			name:         "1",
+			state:        TaskState_TASK_STATE_INIT_UNSPECIFIED,
+			wantedResult: true,
+		},
+		{
+			name:         "2",
+			state:        TaskState_TASK_STATE_UPLOAD_OBJECT_DONE,
+			wantedResult: false,
+		},
+		{
+			name:         "3",
+			state:        TaskState_TASK_STATE_REPLICATE_OBJECT_DOING,
+			wantedResult: false,
+		},
+		{
+			name:         "4",
+			state:        TaskState_TASK_STATE_UPLOAD_OBJECT_ERROR,
+			wantedResult: true,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckAllowUploadStatus(tt.state)
+			assert.Equal(t, tt.wantedResult, result)
+		})
+	}
+}


### PR DESCRIPTION
### Description

Not allowed to upload piece or object for an object id which had already been fully uploaded before
### Rationale

Users might repeatedly upload pieces for a given object which had already been fully uploaded before. This might be due to some kinds of user code issues. But in sp side we should not allow this. 

Before this fix, sp will override the file content in piece store, which might cause "integrity check" not matching.

### Example

N/A
### Changes

Notable changes: 
* uploadTask: PreUploadObject
* uploadTask: PreResumableUploadObject

### Potential Impacts
N/A