### PR TITLE
fix: 500 error code when bucket is deleted

### DIFF
--- a/modular/metadata/metadata_object_service.go
+++ b/modular/metadata/metadata_object_service.go
@@ -419,6 +419,9 @@ func (r *MetadataModular) GfSpListObjectsByGVGAndBucketForGC(ctx context.Context
 	}
 	objects, bucket, err = r.baseApp.GfBsDB().ListObjectsByGVGAndBucketForGC(common.BigToHash(math.NewUint(req.BucketId).BigInt()), req.DstGvgId, common.BigToHash(math.NewUint(req.StartAfter).BigInt()), limit)
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNoSuchBucket
+		}
 		log.CtxErrorw(ctx, "failed to list objects by gvg and bucket for gc", "error", err)
 		return nil, err
 	}

--- a/modular/metadata/metadata_object_service_test.go
+++ b/modular/metadata/metadata_object_service_test.go
@@ -1183,6 +1183,25 @@ func TestMetadataModular_GfSpListObjectsByGVGAndBucketForGC_Failed2(t *testing.T
 	assert.NotNil(t, err)
 }
 
+func TestMetadataModular_GfSpListObjectsByGVGAndBucketForGC_Failed3(t *testing.T) {
+	a := setup(t)
+	ctrl := gomock.NewController(t)
+	m := bsdb.NewMockBSDB(ctrl)
+	a.baseApp.SetGfBsDB(m)
+	m.EXPECT().ListObjectsByGVGAndBucketForGC(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(common.Hash, uint32, common.Hash, int) ([]*bsdb.Object, *bsdb.Bucket, error) {
+			return nil, nil, gorm.ErrRecordNotFound
+		},
+	).Times(1)
+	_, err := a.GfSpListObjectsByGVGAndBucketForGC(context.Background(), &types.GfSpListObjectsByGVGAndBucketForGCRequest{
+		DstGvgId:   1,
+		BucketId:   1,
+		StartAfter: 0,
+		Limit:      11111,
+	})
+	assert.NotNil(t, err)
+}
+
 func TestMetadataModular_GfSpListObjectsInGVG_Success(t *testing.T) {
 	a := setup(t)
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
### Description

![image](https://github.com/bnb-chain/greenfield-storage-provider/assets/122767193/cfe49023-a16f-4b7c-824d-eae3e6ae8ef3)


### Rationale

return 500 when bucket is deleted

### Example

N/A

### Changes

Notable changes: 
* add UT
* fix error code

### Potential Impacts
* QA