### PR TITLE
fix: let bucket migration be able to start without a pre-read of bucket content

### DIFF
--- a/modular/manager/migrate_service.go
+++ b/modular/manager/migrate_service.go
@@ -143,7 +143,7 @@ func (m *ManageModular) NotifyPostMigrateBucketAndRecoupQuota(ctx context.Contex
 				log.CtxErrorw(ctx, "failed to update bucket migrate progress recoup quota", "error", err)
 			}
 		}
-		log.CtxDebugw(ctx, "succeed to recoup extra quota to user", "extra_quote", extraQuota)
+		log.CtxDebugw(ctx, "succeed to recoup extra quota to user", "extra_quote", extraQuota, "bucket_id", bucketID)
 	}
 
 	return latestQuota, nil

--- a/modular/metadata/metadata_bucket_service.go
+++ b/modular/metadata/metadata_bucket_service.go
@@ -417,13 +417,9 @@ func (r *MetadataModular) GfSpGetLatestBucketReadQuota(
 				freeQuotaSize = 0
 			}
 			quota := &gfsptask.GfSpBucketQuotaInfo{
-				BucketName:            bucketTraffic.BucketName,
-				BucketId:              bucketTraffic.BucketID,
-				Month:                 bucketTraffic.YearMonth,
-				ReadConsumedSize:      bucketTraffic.ReadConsumedSize,
-				FreeQuotaConsumedSize: bucketTraffic.FreeQuotaConsumedSize,
-				FreeQuotaSize:         freeQuotaSize,
-				ChargedQuotaSize:      bucketTraffic.ChargedQuotaSize,
+				BucketId:         req.BucketId,
+				FreeQuotaSize:    freeQuotaSize,
+				ChargedQuotaSize: 0,
 			}
 
 			return &types.GfSpGetLatestBucketReadQuotaResponse{

--- a/modular/metadata/metadata_test.go
+++ b/modular/metadata/metadata_test.go
@@ -5,17 +5,28 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/bnb-chain/greenfield-storage-provider/base/gfspapp"
-	"github.com/bnb-chain/greenfield-storage-provider/core/module"
-	"github.com/bnb-chain/greenfield-storage-provider/core/rcmgr"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+
+	"github.com/bnb-chain/greenfield-storage-provider/base/gfspapp"
+	"github.com/bnb-chain/greenfield-storage-provider/base/gfspconfig"
+	"github.com/bnb-chain/greenfield-storage-provider/core/module"
+	"github.com/bnb-chain/greenfield-storage-provider/core/rcmgr"
 )
 
 var mockErr = errors.New("mock error")
 
 func setup(t *testing.T) *MetadataModular {
-	return &MetadataModular{baseApp: &gfspapp.GfSpBaseApp{}}
+	cfg := &gfspconfig.GfSpConfig{
+		Parallel:    gfspconfig.ParallelConfig{},
+		BlockSyncer: gfspconfig.BlockSyncerConfig{},
+		Chain:       gfspconfig.ChainConfig{},
+		SpAccount:   gfspconfig.SpAccountConfig{},
+		Gateway:     gfspconfig.GatewayConfig{},
+	}
+	metadata := &MetadataModular{baseApp: &gfspapp.GfSpBaseApp{}}
+	DefaultMetadataOptions(metadata, cfg)
+	return metadata
 }
 
 func TestMetadataModular_Name(t *testing.T) {


### PR DESCRIPTION

### Description

fix: let bucket migration be able to start without a pre-read of bucket content

### Rationale

Previously, the bucket migration could not be started as long as the bucket objects have never been read before, due to defect happens during GfSpGetLatestBucketReadQuota

### Example

N/A
### Changes

Notable changes: 
* Make it be able to return gorm.ErrRecordNotFound when reading traffic table if there is no corresponding record.
* Backfill the GfSpBucketQuotaInfo object when no record is found when reading traffic
* ut

### Potential Impacts
N/A