### PR TITLE
fix: correct the bucket quota formula when pre-check in bucket migration

### DIFF
--- a/modular/gater/migrate_handler.go
+++ b/modular/gater/migrate_handler.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 	"time"
 
-	permissiontypes "github.com/bnb-chain/greenfield/x/permission/types"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
+
+	permissiontypes "github.com/bnb-chain/greenfield/x/permission/types"
 
 	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsperrors"
 	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsptask"
@@ -579,7 +580,7 @@ func (g *GateModular) sufficientQuotaForBucketMigrationHandler(w http.ResponseWr
 	}
 
 	// empty bucket will approval
-	if quota.FreeQuotaSize > bucketSize || bucketSize == 0 {
+	if quota.FreeQuotaSize+quota.ChargedQuotaSize-quota.ReadConsumedSize > bucketSize || bucketSize == 0 {
 		quota.AllowMigrate = true
 	} else {
 		quota.AllowMigrate = false

--- a/modular/metadata/metadata_bucket_service.go
+++ b/modular/metadata/metadata_bucket_service.go
@@ -416,10 +416,20 @@ func (r *MetadataModular) GfSpGetLatestBucketReadQuota(
 					"bucket_id", req.GetBucketId(), "error", err)
 				freeQuotaSize = 0
 			}
+			var chargedQuotaSize uint64
+			bucketInfo, queryBucketInfoErr := r.baseApp.Consensus().QueryBucketInfoById(ctx, req.BucketId)
+			if queryBucketInfoErr != nil {
+				log.Errorw("failed to get bucketInfo on chain",
+					"bucket_id", req.GetBucketId(), "error", err)
+				chargedQuotaSize = 0
+			} else {
+				chargedQuotaSize = bucketInfo.ChargedReadQuota
+			}
 			quota := &gfsptask.GfSpBucketQuotaInfo{
 				BucketId:         req.BucketId,
 				FreeQuotaSize:    freeQuotaSize,
-				ChargedQuotaSize: 0,
+				ChargedQuotaSize: chargedQuotaSize,
+				ReadConsumedSize: 0, //  because we can't get bucketTraffic record
 			}
 
 			return &types.GfSpGetLatestBucketReadQuotaResponse{

--- a/modular/metadata/metadata_bucket_service_test.go
+++ b/modular/metadata/metadata_bucket_service_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/bnb-chain/greenfield-storage-provider/core/spdb"
 	"github.com/bnb-chain/greenfield-storage-provider/modular/metadata/types"
 	"github.com/bnb-chain/greenfield-storage-provider/store/bsdb"
+	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 )
 
 func TestErrGfSpDBWithDetail(t *testing.T) {
@@ -597,6 +598,8 @@ func TestMetadataModular_GfSpGetLatestBucketReadQuota_Failure1(t *testing.T) {
 
 	consensusMock := consensus.NewMockConsensus(ctrl)
 	consensusMock.EXPECT().QuerySPFreeQuota(gomock.Any(), gomock.Any()).Return(uint64(0), mockErr).Times(1)
+	consensusMock.EXPECT().QueryBucketInfoById(gomock.Any(), gomock.Any()).Return(&storagetypes.BucketInfo{
+		BucketName: "testBucketName", ChargedReadQuota: 10000000}, nil).Times(1)
 	a.baseApp.SetConsensus(consensusMock)
 
 	resp, err := a.GfSpGetLatestBucketReadQuota(context.Background(), &types.GfSpGetLatestBucketReadQuotaRequest{
@@ -607,7 +610,7 @@ func TestMetadataModular_GfSpGetLatestBucketReadQuota_Failure1(t *testing.T) {
 		Quota: &gfsptask.GfSpBucketQuotaInfo{
 			BucketId:         1,
 			FreeQuotaSize:    0,
-			ChargedQuotaSize: 0,
+			ChargedQuotaSize: 10000000,
 		},
 	}, resp)
 }
@@ -625,7 +628,7 @@ func TestMetadataModular_GfSpGetLatestBucketReadQuota_Failure2(t *testing.T) {
 	consensusMock := consensus.NewMockConsensus(ctrl)
 	consensusMock.EXPECT().QuerySPFreeQuota(gomock.Any(), gomock.Any()).Return(uint64(10000), nil).Times(1)
 	a.baseApp.SetConsensus(consensusMock)
-
+	consensusMock.EXPECT().QueryBucketInfoById(gomock.Any(), gomock.Any()).Return(nil, mockErr).Times(1)
 	resp, err := a.GfSpGetLatestBucketReadQuota(context.Background(), &types.GfSpGetLatestBucketReadQuotaRequest{
 		BucketId: 1,
 	})


### PR DESCRIPTION
### Description

fix: correct the bucket quota formula when pre-check in bucket migration
### Rationale

The original comparison expression did not take the "ChargedQuotaSize" and "ReadConsumedSize" into account

### Example

N/A
### Changes
N/A

### Potential Impacts
N/A