### PR TITLE
fix: exclude timestamp from recover piece key

### DIFF
--- a/base/types/gfsptask/recovery.go
+++ b/base/types/gfsptask/recovery.go
@@ -35,7 +35,6 @@ func (m *GfSpRecoverPieceTask) Key() coretask.TKey {
 		m.GetObjectInfo().Id.String(),
 		m.GetSegmentIdx(),
 		m.GetEcIdx(),
-		m.GetCreateTime(),
 	)
 }
 

--- a/base/types/gfsptask/task_key.go
+++ b/base/types/gfsptask/task_key.go
@@ -83,13 +83,13 @@ func GfSpReplicatePieceTaskKey(bucket, object, id string) task.TKey {
 		CombineKey("bucket:"+bucket, "object:"+object, "id:"+id))
 }
 
-func GfSpRecoverPieceTaskKey(bucket, object, id string, pIdx uint32, replicateIdx int32, time int64) task.TKey {
+func GfSpRecoverPieceTaskKey(bucket, object, id string, pIdx uint32, replicateIdx int32) task.TKey {
 	if replicateIdx >= 0 {
 		return task.TKey(KeyPrefixGfSpRecoverPieceTask +
-			CombineKey("bucket:"+bucket, "object:"+object, "id:"+id, "segIdx:"+fmt.Sprint(pIdx), "ecIdx:"+fmt.Sprint(replicateIdx), "time"+fmt.Sprint(time)))
+			CombineKey("bucket:"+bucket, "object:"+object, "id:"+id, "segIdx:"+fmt.Sprint(pIdx), "ecIdx:"+fmt.Sprint(replicateIdx)))
 	}
 	return task.TKey(KeyPrefixGfSpRecoverPieceTask +
-		CombineKey("bucket:"+bucket, "object:"+object, "id:"+id, "segIdx:"+fmt.Sprint(pIdx), "time"+fmt.Sprint(time)))
+		CombineKey("bucket:"+bucket, "object:"+object, "id:"+id, "segIdx:"+fmt.Sprint(pIdx)))
 }
 
 func GfSpSealObjectTaskKey(bucket, object, id string) task.TKey {

--- a/base/types/gfsptask/task_key_test.go
+++ b/base/types/gfsptask/task_key_test.go
@@ -3,5 +3,5 @@ package gfsptask
 import "testing"
 
 func TestGfSpRecoverPieceTaskKey(t *testing.T) {
-	GfSpRecoverPieceTaskKey("1", "2", "3", 1, -1, 1)
+	GfSpRecoverPieceTaskKey("1", "2", "3", 1, -1)
 }

--- a/modular/manager/recover_scheduler.go
+++ b/modular/manager/recover_scheduler.go
@@ -350,6 +350,7 @@ func (s *RecoverGVGScheduler) Start() {
 						break out
 					}
 				}
+				log.Infow("pushed piece to recover queue", "object_id", objectInfo.Id, "segmentIdx", segmentIdx)
 			}
 			if !s.manager.recoverObjectStats.has(objectID) {
 				s.manager.recoverObjectStats.put(objectID, segmentCount)
@@ -575,7 +576,7 @@ func (s *RecoverFailedObjectScheduler) Start() {
 						break out
 					}
 				}
-				log.Errorw("pushed piece to recover queue", "object_id", objectInfo.Id, "segmentIdx", segmentIdx)
+				log.Infow("pushed piece to recover queue", "object_id", objectInfo.Id, "segmentIdx", segmentIdx)
 			}
 			o.RetryTime++
 			err = s.manager.baseApp.GfSpDB().UpdateRecoverFailedObject(o)


### PR DESCRIPTION
### Description

exclude timestamp from recover piece key to avoid duplicate request enqueued. 

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...