### PR TITLE
fix: pick new gvg when retry failed replicate piece task

### DIFF
--- a/modular/manager/manager_test.go
+++ b/modular/manager/manager_test.go
@@ -239,7 +239,10 @@ func TestManageModular_LoadTaskFromDB(t *testing.T) {
 	m3.EXPECT().GetBucketByBucketName(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&types.Bucket{BucketInfo: &types0.BucketInfo{
 			GlobalVirtualGroupFamilyId: 1,
-		}}, nil)
+		}}, nil).AnyTimes()
+
+	m1.EXPECT().UpdateUploadProgress(gomock.Any()).Return(
+		nil).AnyTimes()
 
 	vgm := vgmgr.NewMockVirtualGroupManager(ctrl)
 	manage.virtualGroupManager = vgm

--- a/modular/manager/task_retry_scheduler.go
+++ b/modular/manager/task_retry_scheduler.go
@@ -8,11 +8,10 @@ import (
 	"time"
 
 	"github.com/bnb-chain/greenfield-common/go/hash"
-	"github.com/bnb-chain/greenfield-storage-provider/core/piecestore"
-
 	"github.com/bnb-chain/greenfield-storage-provider/base/gfspapp"
 	"github.com/bnb-chain/greenfield-storage-provider/base/gfsptqueue"
 	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsptask"
+	"github.com/bnb-chain/greenfield-storage-provider/core/piecestore"
 	"github.com/bnb-chain/greenfield-storage-provider/core/spdb"
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
 	"github.com/bnb-chain/greenfield-storage-provider/store/sqldb"
@@ -212,24 +211,23 @@ func (s *TaskRetryScheduler) retryReplicateTask(meta *spdb.UploadObjectMeta) err
 	replicateTask.InitReplicatePieceTask(objectInfo, storageParams, s.manager.baseApp.TaskPriority(replicateTask),
 		s.manager.baseApp.TaskTimeout(replicateTask, objectInfo.GetPayloadSize()), s.manager.baseApp.TaskMaxRetry(replicateTask), meta.IsAgentUpload)
 
-	// for objects that have been uploaded but not starting the replication yet, it doesn't have the GVG info the UploadObjectMeta,
-	// so it needs to pick one to start the replicate task.
-	if meta.GlobalVirtualGroupID == 0 {
-		bucketInfo, err := s.manager.baseApp.GfSpClient().GetBucketByBucketName(context.Background(), objectInfo.BucketName, true)
-		if err != nil || bucketInfo == nil {
-			log.Errorw("failed to get bucket by bucket name", "bucket", bucketInfo, "error", err)
-			return err
-		}
-		gvgMeta, err := s.manager.pickGlobalVirtualGroup(context.Background(), bucketInfo.BucketInfo.GlobalVirtualGroupFamilyId, storageParams)
-		log.Infow("pick global virtual group", "gvg_meta", gvgMeta, "error", err)
-		if err != nil {
-			return err
-		}
-		replicateTask.GlobalVirtualGroupId = gvgMeta.ID
-		replicateTask.SecondaryEndpoints = gvgMeta.SecondarySPEndpoints
-	} else {
-		replicateTask.GlobalVirtualGroupId = meta.GlobalVirtualGroupID
-		replicateTask.SecondaryEndpoints = meta.SecondaryEndpoints
+	//retrieve objects from the database that have not completed the replicate piece, reselect gvg, and then add them to the replicate queue
+	bucketInfo, err := s.manager.baseApp.GfSpClient().GetBucketByBucketName(context.Background(), objectInfo.BucketName, true)
+	if err != nil || bucketInfo == nil {
+		log.Errorw("failed to get bucket by bucket name", "bucket", bucketInfo, "error", err)
+		return err
+	}
+	gvgMeta, err := s.manager.pickGlobalVirtualGroup(context.Background(), bucketInfo.BucketInfo.GlobalVirtualGroupFamilyId, storageParams)
+	log.Infow("pick global virtual group", "gvg_meta", gvgMeta, "error", err)
+	if err != nil {
+		return err
+	}
+	replicateTask.GlobalVirtualGroupId = gvgMeta.ID
+	replicateTask.SecondaryEndpoints = gvgMeta.SecondarySPEndpoints
+	meta.GlobalVirtualGroupID = gvgMeta.ID
+	meta.SecondaryEndpoints = gvgMeta.SecondarySPEndpoints
+	if err = s.manager.baseApp.GfSpDB().UpdateUploadProgress(meta); err != nil {
+		log.Errorw("failed to update object task state", "task_info", replicateTask.Info(), "error", err)
 	}
 
 	err = s.manager.replicateQueue.Push(replicateTask)


### PR DESCRIPTION
### Description

fix: pick new gvg when retry failed replicate piece task

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 
* repick gvg for retryReplicateTask & LoadTaskFromDB

### Potential Impacts
* QA