### PR TITLE
fix: pick new gvg when retry failed replicate piece task

### DIFF
--- a/modular/manager/manager_test.go
+++ b/modular/manager/manager_test.go
@@ -239,7 +239,10 @@ func TestManageModular_LoadTaskFromDB(t *testing.T) {
 	m3.EXPECT().GetBucketByBucketName(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&types.Bucket{BucketInfo: &types0.BucketInfo{
 			GlobalVirtualGroupFamilyId: 1,
-		}}, nil)
+		}}, nil).AnyTimes()
+
+	m1.EXPECT().UpdateUploadProgress(gomock.Any()).Return(
+		nil).AnyTimes()
 
 	vgm := vgmgr.NewMockVirtualGroupManager(ctrl)
 	manage.virtualGroupManager = vgm


### PR DESCRIPTION
### Description

fix: pick new gvg when retry failed replicate piece task

### Rationale

N/A

### Example

N/A

### Changes

Notable changes: 
* repick gvg for retryReplicateTask & LoadTaskFromDB

### Potential Impacts
* QA