### PR TITLE
 fix: refine error code for bucket migration

### DIFF
--- a/base/errors.md
+++ b/base/errors.md
@@ -31,6 +31,9 @@ It sorts from 50...
 * `53`: is used for Resource manager code.
 * `54`: is used for VirtualGroup manager code.
 
+### No Dependencies
+* `00`: no dependencies
+
 ### Modular Code
 It sorts from 0... to 49
 * `01`: is used for Approver modular code.

--- a/base/gfspclient/client.go
+++ b/base/gfspclient/client.go
@@ -30,9 +30,10 @@ const (
 )
 
 var (
-	ErrExceptionsStream = gfsperrors.Register(ClientCodeSpace, http.StatusBadRequest, 98002, "stream closed abnormally")
-	ErrTypeMismatch     = gfsperrors.Register(ClientCodeSpace, http.StatusBadRequest, 98101, "response type mismatch")
-	ErrNoSuchObject     = gfsperrors.Register(ClientCodeSpace, http.StatusBadRequest, 98093, "no such object from metadata")
+	ErrExceptionsStream = gfsperrors.Register(ClientCodeSpace, http.StatusBadRequest, 980001, "stream closed abnormally")
+	ErrTypeMismatch     = gfsperrors.Register(ClientCodeSpace, http.StatusBadRequest, 980002, "response type mismatch")
+	ErrNoSuchObject     = gfsperrors.Register(ClientCodeSpace, http.StatusBadRequest, 980901, "no such object from metadata")
+	ErrNoEnoughQuota    = gfsperrors.Register(ClientCodeSpace, http.StatusNotAcceptable, 980003, "the bucket does not have enough quota")
 )
 
 func ErrRPCUnknownWithDetail(detail string, err error) *gfsperrors.GfSpError {

--- a/base/gfspclient/gater.go
+++ b/base/gfspclient/gater.go
@@ -9,12 +9,13 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/cosmos/gogoproto/proto"
+
 	"github.com/bnb-chain/greenfield-storage-provider/base/types/gfsptask"
 	coretask "github.com/bnb-chain/greenfield-storage-provider/core/task"
 	"github.com/bnb-chain/greenfield-storage-provider/pkg/log"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 	virtualgrouptypes "github.com/bnb-chain/greenfield/x/virtualgroup/types"
-	"github.com/cosmos/gogoproto/proto"
 )
 
 // spilt server and client const definition avoids circular references
@@ -373,8 +374,9 @@ func (s *GfSpClient) QuerySPHasEnoughQuotaForMigrateBucket(ctx context.Context, 
 	if quotaResult.GetAllowMigrate() {
 		return nil
 	} else {
-		return fmt.Errorf("failed to check src sp has enough bucket quota, bucket(%d), status_code(%d), endpoint(%s), quota(%s)",
-			bucketID, resp.StatusCode, srcSPEndpoint, quotaResult.String())
+		log.CtxErrorw(ctx, "error", fmt.Errorf("failed to check src sp has enough bucket quota, bucket(%d), status_code(%d), endpoint(%s), quota(%s)",
+			bucketID, resp.StatusCode, srcSPEndpoint, quotaResult.String()))
+		return ErrNoEnoughQuota
 	}
 }
 

--- a/modular/approver/approve_task.go
+++ b/modular/approver/approve_task.go
@@ -17,9 +17,10 @@ import (
 )
 
 var (
-	ErrDanglingPointer     = gfsperrors.Register(module.ApprovalModularName, http.StatusBadRequest, 10001, "OoooH.... request lost")
-	ErrExceedBucketNumber  = gfsperrors.Register(module.ApprovalModularName, http.StatusNotAcceptable, 10002, "account buckets exceed the limit")
-	ErrExceedApprovalLimit = gfsperrors.Register(module.ApprovalModularName, http.StatusNotAcceptable, 10003, "SP is too busy to approve the request, please come back later")
+	ErrDanglingPointer       = gfsperrors.Register(module.ApprovalModularName, http.StatusBadRequest, 10001, "OoooH.... request lost")
+	ErrExceedBucketNumber    = gfsperrors.Register(module.ApprovalModularName, http.StatusNotAcceptable, 10002, "account buckets exceed the limit")
+	ErrExceedApprovalLimit   = gfsperrors.Register(module.ApprovalModularName, http.StatusNotAcceptable, 10003, "SP is too busy to approve the request, please come back later")
+	ErrBucketMigrationStatus = gfsperrors.Register(module.ApprovalModularName, http.StatusNotAcceptable, 10004, "the bucket is migrating or gc, try it after gc done")
 )
 
 const (
@@ -176,7 +177,7 @@ func (a *ApprovalModular) HandleMigrateBucketApprovalTask(ctx context.Context, t
 		}
 	} else if state != int(storetypes.BucketMigrationState_BUCKET_MIGRATION_STATE_INIT_UNSPECIFIED) {
 		log.CtxInfow(ctx, "the bucket is migrating or gc, migrated to this sp should be reject", "bucket_id", bucketID)
-		return false, fmt.Errorf("the bucket is migrating or gc, try it after gc done")
+		return false, ErrBucketMigrationStatus
 	}
 
 	// check src sp has enough quota


### PR DESCRIPTION
### Description

 fix: refine error code for bucket migration

### Rationale

During bucket migration, it could happens that users's buckets do not have enough quota or the bucket is still in gc or in migrating. So for such cases,  the current 500 error code is not reasonable. This pR changes the error cod to 406.
### Example

N/A
### Changes

N/A

### Potential Impacts
N/A