### PR TITLE
feat: add detailed logs for special customized logs

### DIFF
--- a/modular/gater/admin_handler.go
+++ b/modular/gater/admin_handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -318,7 +319,7 @@ func (g *GateModular) getChallengeInfoHandler(w http.ResponseWriter, r *http.Req
 		if strings.Contains(err.Error(), "No such object") {
 			err = ErrNoSuchObject
 		} else {
-			err = ErrConsensusWithDetail("failed to get object info from consensus, error: " + err.Error())
+			err = ErrConsensusWithDetail("failed to get object info from consensus, object_id: " + fmt.Sprint(objectID) + "error: " + err.Error())
 		}
 		return
 	}
@@ -342,7 +343,7 @@ func (g *GateModular) getChallengeInfoHandler(w http.ResponseWriter, r *http.Req
 	metrics.PerfChallengeTimeHistogram.WithLabelValues("challenge_get_bucket_time").Observe(time.Since(getBucketTime).Seconds())
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get bucket info from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get bucket info from consensus, error: " + err.Error())
+		err = ErrConsensusWithDetail("failed to get bucket info from consensus, bucket_name: " + objectInfo.GetBucketName() + ", error: " + err.Error())
 		return
 	}
 	redundancyIdx, err := util.StringToInt32(reqCtx.request.Header.Get(GnfdRedundancyIndexHeader))
@@ -459,7 +460,7 @@ func (g *GateModular) getChallengeInfoV2Handler(w http.ResponseWriter, r *http.R
 		if strings.Contains(err.Error(), "No such object") {
 			err = ErrNoSuchObject
 		} else {
-			err = ErrConsensusWithDetail("failed to get object info from consensus, error: " + err.Error())
+			err = ErrConsensusWithDetail("failed to get object info from consensus, object_id:" + reqCtx.request.Header.Get(GnfdObjectIDHeader) + ", error: " + err.Error())
 		}
 		return
 	}
@@ -483,7 +484,7 @@ func (g *GateModular) getChallengeInfoV2Handler(w http.ResponseWriter, r *http.R
 	metrics.PerfChallengeTimeHistogram.WithLabelValues("challenge_get_bucket_time").Observe(time.Since(getBucketTime).Seconds())
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get bucket info from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get bucket info from consensus, error: " + err.Error())
+		err = ErrConsensusWithDetail("failed to get bucket info from consensus, bucket_name: " + objectInfo.GetBucketName() + ", error: " + err.Error())
 		return
 	}
 	redundancyIdx, err := util.StringToInt32(reqCtx.request.Header.Get(GnfdRedundancyIndexHeader))
@@ -549,7 +550,7 @@ func (g *GateModular) getChallengeInfoV2Handler(w http.ResponseWriter, r *http.R
 	xmlBody, err := xml.Marshal(&xmlInfo)
 	if err != nil {
 		log.Errorw("failed to marshal xml", "error", err)
-		err = ErrEncodeResponseWithDetail("failed to marshal xml, error: " + err.Error())
+		err = ErrEncodeResponseWithDetail("failed to marshal xml, object_id: " + reqCtx.request.Header.Get(GnfdObjectIDHeader) + "error: " + err.Error())
 		return
 	}
 	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
@@ -695,7 +696,7 @@ func (g *GateModular) checkReplicatePermission(ctx context.Context, receiveTask 
 	for retry := 0; retry < checkPermissionRetry; retry++ {
 		objectInfo, err = g.baseApp.Consensus().QueryObjectInfo(ctx, receiveTask.ObjectInfo.BucketName, receiveTask.ObjectInfo.ObjectName)
 		if err != nil {
-			err = ErrConsensusWithDetail("failed to get object info from consensus, error:" + err.Error())
+			err = ErrConsensusWithDetail("failed to get object info from consensus, object_name: " + receiveTask.ObjectInfo.ObjectName + "bucket_name: " + receiveTask.ObjectInfo.BucketName + ", error:" + err.Error())
 			time.Sleep(checkPermissionSleepTime)
 			continue
 		}
@@ -722,17 +723,17 @@ func (g *GateModular) checkReplicatePermission(ctx context.Context, receiveTask 
 	// check if the request account is the primary SP of the object of the receiving task
 	gvg, err := g.baseApp.GfSpClient().GetGlobalVirtualGroupByGvgID(ctx, receiveTask.GetGlobalVirtualGroupID())
 	if err != nil {
-		return ErrConsensusWithDetail("QueryGVGInfo error: " + err.Error())
+		return ErrConsensusWithDetail("failed to get queryGVGInfo, gvg id: " + fmt.Sprint(receiveTask.GetGlobalVirtualGroupID()) + ", error: " + err.Error())
 	}
 
 	if gvg == nil {
-		return ErrConsensusWithDetail("QueryGVGInfo nil")
+		return ErrConsensusWithDetail("QueryGVGInfo nil, with gvg id: " + fmt.Sprint(receiveTask.GetGlobalVirtualGroupID()))
 	}
 
 	// judge if sender is the primary sp of the gvg
 	primarySp, err := g.baseApp.Consensus().QuerySPByID(ctx, gvg.PrimarySpId)
 	if err != nil {
-		return ErrConsensusWithDetail("QuerySPInfo error: " + err.Error())
+		return ErrConsensusWithDetail("failed to querySPInfo, primarySpId: " + fmt.Sprint(gvg.PrimarySpId) + ", error: " + err.Error())
 	}
 
 	if primarySp.GetOperatorAccAddress().String() != signatureAddr {
@@ -744,7 +745,7 @@ func (g *GateModular) checkReplicatePermission(ctx context.Context, receiveTask 
 	// judge if myself is the right secondary sp of the gvg
 	spID, err := g.getSPID()
 	if err != nil {
-		return ErrConsensusWithDetail("getSPID error: " + err.Error())
+		return ErrConsensusWithDetail("failed to getSPID, gvg info:" + gvg.String() + ", error: " + err.Error())
 	}
 
 	expectSecondarySPID := gvg.GetSecondarySpIds()[int(receiveTask.GetRedundancyIdx())]
@@ -858,12 +859,12 @@ func (g *GateModular) getRecoverDataHandler(w http.ResponseWriter, r *http.Reque
 
 	spID, err := g.getSPID()
 	if err != nil {
-		err = ErrConsensusWithDetail("getSPID error: " + err.Error())
+		err = ErrConsensusWithDetail("failed to getSPID, operator_address: " + g.baseApp.OperatorAddress() + ", error: " + err.Error())
 		return
 	}
 	bucketSPID, err := util.GetBucketPrimarySPID(reqCtx.Context(), g.baseApp.Consensus(), bucketInfo)
 	if err != nil {
-		err = ErrConsensusWithDetail("GetBucketPrimarySPID error: " + err.Error())
+		err = ErrConsensusWithDetail("failed to getBucketPrimarySPID, bucket_name: " + bucketInfo.GetBucketName() + ", error: " + err.Error())
 		return
 	}
 
@@ -930,7 +931,7 @@ func (g *GateModular) getRecoverPiece(ctx context.Context, objectInfo *storagety
 		if err == nil {
 			successorSP, err = g.baseApp.Consensus().QuerySPByID(ctx, swapInInfo.SuccessorSpId)
 			if err != nil {
-				return nil, ErrConsensusWithDetail("query sp err: " + err.Error())
+				return nil, ErrConsensusWithDetail("failed to query sp, SuccessorSpId: " + fmt.Sprint(swapInInfo.SuccessorSpId) + ", err: " + err.Error())
 			}
 			if primarySp.Id == swapInInfo.TargetSpId && successorSP.OperatorAddress == signatureAddr.String() {
 				isSuccessorPrimary = true
@@ -938,11 +939,11 @@ func (g *GateModular) getRecoverPiece(ctx context.Context, objectInfo *storagety
 		} else {
 			swapInInfo, err = g.baseApp.Consensus().QuerySwapInInfo(ctx, virtualgrouptypes.NoSpecifiedFamilyId, gvg.Id)
 			if err != nil {
-				return nil, ErrConsensusWithDetail("query swapInInfo err: " + err.Error())
+				return nil, ErrConsensusWithDetail("failed to query swapInInfo, gvg_id: " + fmt.Sprint(gvg.Id) + ", err: " + err.Error())
 			}
 			successorSP, err = g.baseApp.Consensus().QuerySPByID(ctx, swapInInfo.SuccessorSpId)
 			if err != nil {
-				return nil, ErrConsensusWithDetail("query sp err: " + err.Error())
+				return nil, ErrConsensusWithDetail("failed to query sp, SuccessorSpId: " + fmt.Sprint(swapInInfo.SuccessorSpId) + ", err: " + err.Error())
 			}
 			for _, sspID := range gvg.SecondarySpIds {
 				if sspID == swapInInfo.TargetSpId && successorSP.OperatorAddress == signatureAddr.String() {
@@ -1015,11 +1016,11 @@ func (g *GateModular) getRecoverSegment(ctx context.Context, objectInfo *storage
 	// if the handler is not the primary SP of the object, return error
 	spID, err := g.getSPID()
 	if err != nil {
-		return nil, ErrConsensusWithDetail("getSPID error: " + err.Error())
+		return nil, ErrConsensusWithDetail("failed to getSPID , object_name: " + objectInfo.GetObjectName() + "bucket_name:" + bucketInfo.GetBucketName() + ", error: " + err.Error())
 	}
 	bucketSPID, err := util.GetBucketPrimarySPID(ctx, g.baseApp.Consensus(), bucketInfo)
 	if err != nil {
-		return nil, ErrConsensusWithDetail("GetBucketPrimarySPID error: " + err.Error())
+		return nil, ErrConsensusWithDetail("GetBucketPrimarySPID, bucket_name: " + bucketInfo.GetBucketName() + ",  error: " + err.Error())
 	}
 
 	if bucketSPID != spID {
@@ -1042,11 +1043,11 @@ func (g *GateModular) getRecoverSegment(ctx context.Context, objectInfo *storage
 	if recoveryTask.GetBySuccessorSp() {
 		swapInInfo, err = g.baseApp.Consensus().QuerySwapInInfo(ctx, 0, gvg.Id)
 		if err != nil {
-			return nil, ErrConsensusWithDetail("query swapInInfo err: " + err.Error())
+			return nil, ErrConsensusWithDetail("failed to query swapInInfo, gvg_id: " + fmt.Sprint(gvg.Id) + ", err: " + err.Error())
 		}
 		successorSP, err = g.baseApp.Consensus().QuerySPByID(ctx, swapInInfo.SuccessorSpId)
 		if err != nil {
-			return nil, ErrConsensusWithDetail("query sp err: " + err.Error())
+			return nil, ErrConsensusWithDetail("failed to query sp, swapInInfo.SuccessorSpId: " + fmt.Sprint(swapInInfo.SuccessorSpId) + ", err: " + err.Error())
 		}
 	}
 
@@ -1054,7 +1055,7 @@ func (g *GateModular) getRecoverSegment(ctx context.Context, objectInfo *storage
 		ssp, err := g.baseApp.Consensus().QuerySPByID(ctx, sspId)
 		if err != nil {
 			log.CtxErrorw(ctx, "failed to query SP by ID", "sp_id", sspId, "error", err)
-			return nil, ErrConsensusWithDetail("QuerySPByID error: " + err.Error())
+			return nil, ErrConsensusWithDetail("failed to querySPByID, sp_id : " + fmt.Sprint(sspId) + ", error: " + err.Error())
 		}
 
 		if ssp.OperatorAddress == signatureAddr.String() {

--- a/modular/gater/bucket_handler.go
+++ b/modular/gater/bucket_handler.go
@@ -49,8 +49,8 @@ func (g *GateModular) getBucketReadQuotaHandler(w http.ResponseWriter, r *http.R
 
 	bucketInfo, err = g.baseApp.Consensus().QueryBucketInfo(ctx, bucketName)
 	if err != nil {
-		log.CtxErrorw(ctx, "failed to get bucket info from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get bucket info from consensus, error: " + err.Error())
+		log.CtxErrorw(ctx, "failed to get bucket info from consensus", "bucket_name", bucketName, "error", err)
+		err = ErrConsensusWithDetail("failed to get bucket info from consensus,bucket_name: " + bucketName + ", error: " + err.Error())
 		return
 	}
 	spID, err := g.getSPID()
@@ -100,13 +100,13 @@ func (g *GateModular) getBucketReadQuotaHandler(w http.ResponseWriter, r *http.R
 	xmlBody, err := xml.Marshal(&xmlInfo)
 	if err != nil {
 		log.Errorw("failed to marshal xml", "error", err)
-		err = ErrEncodeResponseWithDetail("failed to marshal xml, error: " + err.Error())
+		err = ErrEncodeResponseWithDetail("failed to marshal xml, bucket_name: " + bucketInfo.GetBucketName() + ", error: " + err.Error())
 		return
 	}
 	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
 	if _, err = w.Write(xmlBody); err != nil {
 		log.Errorw("failed to write body", "error", err)
-		err = ErrEncodeResponseWithDetail("failed to write body, error: " + err.Error())
+		err = ErrEncodeResponseWithDetail("failed to write body, bucket_name: " + bucketInfo.GetBucketName() + " ,error: " + err.Error())
 		return
 	}
 	log.CtxDebugw(ctx, "succeed to get bucket quota", "xml_info", xmlInfo)
@@ -140,8 +140,8 @@ func (g *GateModular) listBucketReadRecordHandler(w http.ResponseWriter, r *http
 
 	bucketInfo, err := g.baseApp.Consensus().QueryBucketInfo(ctx, bucketName)
 	if err != nil {
-		log.CtxErrorw(ctx, "failed to get bucket info from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get bucket info from consensus, error: " + err.Error())
+		log.CtxErrorw(ctx, "failed to get bucket info from consensus", "bucketName", bucketName, "error", err)
+		err = ErrConsensusWithDetail("failed to get bucket info from consensus, bucket_name: " + bucketName + ", error: " + err.Error())
 		return
 	}
 	spID, err := g.getSPID()
@@ -219,14 +219,14 @@ func (g *GateModular) listBucketReadRecordHandler(w http.ResponseWriter, r *http
 	xmlBody, err := xml.Marshal(&xmlInfo)
 	if err != nil {
 		log.Errorw("failed to marshal xml", "error", err)
-		err = ErrEncodeResponseWithDetail("failed to marshal xml, error: " + err.Error())
+		err = ErrEncodeResponseWithDetail("failed to marshal xml for bucket read records, bucket_name: " + bucketName + " ,error: " + err.Error())
 		return
 	}
 
 	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
 	if _, err = w.Write(xmlBody); err != nil {
 		log.Errorw("failed to write body", "error", err)
-		err = ErrEncodeResponseWithDetail("failed to write body, error: " + err.Error())
+		err = ErrEncodeResponseWithDetail("failed to write body for bucket read records, bucket_name: " + bucketName + " ,error: " + err.Error())
 		return
 	}
 	log.Debugw("succeed to list bucket read records", "xml_info", xmlInfo)
@@ -277,8 +277,8 @@ func (g *GateModular) queryBucketMigrationProgressHandler(w http.ResponseWriter,
 	}
 
 	if bucketInfo, err = g.baseApp.Consensus().QueryBucketInfo(reqCtx.Context(), reqCtx.bucketName); err != nil {
-		log.CtxErrorw(reqCtx.Context(), "failed to get bucket info from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get bucket info from consensus, error: " + err.Error())
+		log.CtxErrorw(reqCtx.Context(), "failed to get bucket info from consensus", "bucket_name", reqCtx.bucketName, "error", err)
+		err = ErrConsensusWithDetail("failed to get bucket info from consensus, bucket_name: " + reqCtx.bucketName + " ,error: " + err.Error())
 		return
 	}
 
@@ -308,13 +308,13 @@ func (g *GateModular) queryBucketMigrationProgressHandler(w http.ResponseWriter,
 	xmlBody, err := xml.Marshal(&xmlInfo)
 	if err != nil {
 		log.Errorw("failed to marshal xml", "error", err)
-		err = ErrEncodeResponseWithDetail("failed to marshal xml, error: " + err.Error())
+		err = ErrEncodeResponseWithDetail("failed to marshal xml for query bucket migration progress, bucket_name: " + reqCtx.bucketName + " ,error: " + err.Error())
 		return
 	}
 	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
 	if _, err = w.Write(xmlBody); err != nil {
 		log.Errorw("failed to write body", "error", err)
-		err = ErrEncodeResponseWithDetail("failed to write body, error: " + err.Error())
+		err = ErrEncodeResponseWithDetail("failed to write body for query bucket migration progress, bucket_name: " + reqCtx.bucketName + " ,error: " + err.Error())
 		return
 	}
 	log.Debugw("succeed to query bucket migration progress", "xml_info", xmlInfo)
@@ -381,13 +381,13 @@ func (g *GateModular) listBucketReadQuotaHandler(w http.ResponseWriter, r *http.
 	xmlBody, err := xml.Marshal(&xmlInfo)
 	if err != nil {
 		log.Errorw("failed to marshal xml", "error", err)
-		err = ErrEncodeResponseWithDetail("failed to marshal xml, error: " + err.Error())
+		err = ErrEncodeResponseWithDetail("failed to marshal xml for list bucket read quota, error: " + err.Error())
 		return
 	}
 	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
 	if _, err = w.Write(xmlBody); err != nil {
 		log.Errorw("failed to write body", "error", err)
-		err = ErrEncodeResponseWithDetail("failed to write body, error: " + err.Error())
+		err = ErrEncodeResponseWithDetail("failed to write body for list bucket read quota, error: " + err.Error())
 		return
 	}
 	log.CtxDebugw(ctx, "succeed to get bucket quota", "xml_info", xmlInfo)
@@ -434,13 +434,13 @@ func (g *GateModular) getBucketReadQuotaCountHandler(w http.ResponseWriter, r *h
 	xmlBody, err := xml.Marshal(&xmlInfo)
 	if err != nil {
 		log.Errorw("failed to marshal xml", "error", err)
-		err = ErrEncodeResponseWithDetail("failed to marshal xml, error: " + err.Error())
+		err = ErrEncodeResponseWithDetail("failed to marshal xml for get bucket read quota count, error: " + err.Error())
 		return
 	}
 	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
 	if _, err = w.Write(xmlBody); err != nil {
 		log.Errorw("failed to write body", "error", err)
-		err = ErrEncodeResponseWithDetail("failed to write body, error: " + err.Error())
+		err = ErrEncodeResponseWithDetail("failed to write body for get bucket read quota count, error: " + err.Error())
 		return
 	}
 	log.CtxDebugw(ctx, "succeed to get bucket quota count", "xml_info", xmlInfo)
@@ -493,14 +493,14 @@ func (g *GateModular) getRecommendedVGFIDHandler(w http.ResponseWriter, r *http.
 	xmlBody, err := xml.Marshal(&xmlInfo)
 	if err != nil {
 		log.Errorw("failed to marshal xml", "error", err)
-		err = ErrEncodeResponseWithDetail("failed to marshal xml, error: " + err.Error())
+		err = ErrEncodeResponseWithDetail("failed to marshal xml for get recommended vgf id, error: " + err.Error())
 		return
 	}
 	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
 
 	if _, err = w.Write(xmlBody); err != nil {
 		log.Errorw("failed to write body", "error", err)
-		err = ErrEncodeResponseWithDetail("failed to write body, error: " + err.Error())
+		err = ErrEncodeResponseWithDetail("failed to write body for get recommended vgf id, error: " + err.Error())
 		return
 	}
 	log.CtxDebugw(reqCtx.Context(), "succeed to get recommended virtual group family", "xml_info", xmlInfo)

--- a/modular/gater/migrate_handler.go
+++ b/modular/gater/migrate_handler.go
@@ -301,7 +301,7 @@ func (g *GateModular) getSecondaryBlsMigrationBucketApprovalHandler(w http.Respo
 	signature, err := g.baseApp.GfSpClient().SignSecondarySPMigrationBucket(reqCtx.Context(), signDoc)
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to sign secondary sp migration bucket", "error", err)
-		err = ErrMigrateApprovalWithDetail("failed to sign secondary sp migration bucket, error: " + err.Error())
+		err = ErrMigrateApprovalWithDetail("failed to sign secondary sp migration bucket, bucket_id: " + signDoc.BucketId.String() + " ,error: " + err.Error())
 		return
 	}
 	w.Header().Set(GnfdSecondarySPMigrationBucketApprovalHeader, hex.EncodeToString(signature))
@@ -354,7 +354,7 @@ func (g *GateModular) getSwapOutApproval(w http.ResponseWriter, r *http.Request)
 	signature, err := g.baseApp.GfSpClient().SignSwapOut(reqCtx.Context(), swapOutApproval)
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to sign swap out", "error", err)
-		err = ErrMigrateApprovalWithDetail("failed to sign swap out, error: " + err.Error())
+		err = ErrMigrateApprovalWithDetail("failed to sign swap out, context:" + reqCtx.String() + ", error: " + err.Error())
 		return
 	}
 	swapOutApproval.SuccessorSpApproval.Sig = signature

--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -97,13 +97,13 @@ func (g *GateModular) putObjectHandler(w http.ResponseWriter, r *http.Request) {
 	metrics.PerfPutObjectTime.WithLabelValues("gateway_put_object_query_object_end").Observe(time.Since(uploadPrimaryStartTime).Seconds())
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get object info from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get object info from consensus, error: " + err.Error())
+		err = ErrConsensusWithDetail("failed to get object info from consensus, object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + ", error: " + err.Error())
 		return
 	}
 	err = g.checkAndAssignShadowObjectInfo(reqCtx, objectInfo)
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get object info from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get object info from consensus, error: " + err.Error())
+		err = ErrConsensusWithDetail("failed to get object info from consensus, object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + ",  error: " + err.Error())
 		return
 	}
 	if objectInfo.GetPayloadSize() == 0 || objectInfo.GetPayloadSize() > g.maxPayloadSize {
@@ -117,7 +117,7 @@ func (g *GateModular) putObjectHandler(w http.ResponseWriter, r *http.Request) {
 	metrics.PerfPutObjectTime.WithLabelValues("gateway_put_object_query_params_end").Observe(time.Since(uploadPrimaryStartTime).Seconds())
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get storage params from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get storage params from consensus, error" + err.Error())
+		err = ErrConsensusWithDetail("failed to get storage params from consensus, object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + ", error: " + err.Error())
 		return
 	}
 	task := &gfsptask.GfSpUploadObjectTask{}
@@ -242,7 +242,7 @@ func (g *GateModular) resumablePutObjectHandler(w http.ResponseWriter, r *http.R
 	metrics.PerfPutObjectTime.WithLabelValues("gateway_resumable_put_object_query_object_end").Observe(time.Since(uploadPrimaryStartTime).Seconds())
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get object info from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get object info from consensus, error: " + err.Error())
+		err = ErrConsensusWithDetail("failed to get object info from consensus, object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + ",error: " + err.Error())
 		return
 	}
 
@@ -252,13 +252,13 @@ func (g *GateModular) resumablePutObjectHandler(w http.ResponseWriter, r *http.R
 	metrics.PerfPutObjectTime.WithLabelValues("gateway_resumable_put_object_query_params_end").Observe(time.Since(uploadPrimaryStartTime).Seconds())
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get storage params from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get storage params from consensus, error: " + err.Error())
+		err = ErrConsensusWithDetail("failed to get storage params from consensus, object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + ", error: " + err.Error())
 		return
 	}
 	err = g.checkAndAssignShadowObjectInfo(reqCtx, objectInfo)
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get object info from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get object info from consensus, error: " + err.Error())
+		err = ErrConsensusWithDetail("failed to get object info from consensus, object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + ",error: " + err.Error())
 		return
 	}
 	// the resumable upload utilizes the on-chain MaxPayloadSize as the maximum file size
@@ -365,14 +365,14 @@ func (g *GateModular) queryResumeOffsetHandler(w http.ResponseWriter, r *http.Re
 	objectInfo, err = g.baseApp.Consensus().QueryObjectInfo(reqCtx.Context(), reqCtx.bucketName, reqCtx.objectName)
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get object info from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get object info from consensus, error: " + err.Error())
+		err = ErrConsensusWithDetail("failed to get object info from consensus, object_name: " + reqCtx.objectName + "bucket_name: " + reqCtx.bucketName + " ,error: " + err.Error())
 		return
 	}
 
 	params, err := g.baseApp.Consensus().QueryStorageParamsByTimestamp(reqCtx.Context(), objectInfo.GetLatestUpdatedTime())
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get storage params from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get storage params from consensus, error: " + err.Error())
+		err = ErrConsensusWithDetail("failed to get storage params from consensus, object_name: " + reqCtx.objectName + "bucket_name: " + reqCtx.bucketName + " ,error: " + err.Error())
 		return
 	}
 
@@ -396,13 +396,13 @@ func (g *GateModular) queryResumeOffsetHandler(w http.ResponseWriter, r *http.Re
 	xmlBody, err := xml.Marshal(&xmlInfo)
 	if err != nil {
 		log.Errorw("failed to marshal xml", "error", err)
-		err = ErrEncodeResponseWithDetail("failed to marshal xml, error: " + err.Error())
+		err = ErrEncodeResponseWithDetail("failed to marshal xml， object_name: " + reqCtx.objectName + "bucket_name: " + reqCtx.bucketName + " ,error: " + err.Error())
 		return
 	}
 	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
 	if _, err = w.Write(xmlBody); err != nil {
 		log.Errorw("failed to write body", "error", err)
-		err = ErrEncodeResponseWithDetail("failed to write body, error: " + err.Error())
+		err = ErrEncodeResponseWithDetail("failed to write body, object_name: " + reqCtx.objectName + "bucket_name: " + reqCtx.bucketName + " , error: " + err.Error())
 		return
 	}
 	log.Debugw("succeed to query resumable offset", "xml_info", xmlInfo)
@@ -583,7 +583,7 @@ func (g *GateModular) downloadObject(w http.ResponseWriter, reqCtx *RequestConte
 	metrics.PerfGetObjectTimeHistogram.WithLabelValues("get_object_get_object_info_time").Observe(time.Since(getObjectTime).Seconds())
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get object info from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get object info from consensus, error:" + err.Error())
+		err = ErrConsensusWithDetail("failed to get object info from consensus, object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + ", error:" + err.Error())
 		return err
 	}
 
@@ -592,7 +592,7 @@ func (g *GateModular) downloadObject(w http.ResponseWriter, reqCtx *RequestConte
 	metrics.PerfGetObjectTimeHistogram.WithLabelValues("get_object_get_bucket_info_time").Observe(time.Since(getBucketTime).Seconds())
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get bucket info from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get bucket info from consensus, error: " + err.Error())
+		err = ErrConsensusWithDetail("failed to get bucket info from consensus, object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + ", error: " + err.Error())
 		return err
 	}
 
@@ -601,7 +601,7 @@ func (g *GateModular) downloadObject(w http.ResponseWriter, reqCtx *RequestConte
 	metrics.PerfGetObjectTimeHistogram.WithLabelValues("get_object_get_storage_param_time").Observe(time.Since(getParamTime).Seconds())
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get storage params from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get storage params from consensus, error: " + err.Error())
+		err = ErrConsensusWithDetail("failed to get storage params from consensus, object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + ", error: " + err.Error())
 		return err
 	}
 
@@ -731,7 +731,7 @@ func (g *GateModular) queryUploadProgressHandler(w http.ResponseWriter, r *http.
 	objectInfo, err = g.baseApp.Consensus().QueryObjectInfo(reqCtx.Context(), reqCtx.bucketName, reqCtx.objectName)
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get object info from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get object info from consensus, error: " + err.Error())
+		err = ErrConsensusWithDetail("failed to get object info from consensus, object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + " ,error: " + err.Error())
 		return
 	}
 	if objectInfo.GetObjectStatus() == storagetypes.OBJECT_STATUS_CREATED {
@@ -768,13 +768,13 @@ func (g *GateModular) queryUploadProgressHandler(w http.ResponseWriter, r *http.
 	xmlBody, err := xml.Marshal(&xmlInfo)
 	if err != nil {
 		log.Errorw("failed to marshal xml", "error", err)
-		err = ErrEncodeResponseWithDetail("failed to marshal xml, error: " + err.Error())
+		err = ErrEncodeResponseWithDetail("failed to marshal xml for query upload progress, object_name: " + reqCtx.objectName + "bucket_name: " + reqCtx.bucketName + ", error: " + err.Error())
 		return
 	}
 	w.Header().Set(ContentTypeHeader, ContentTypeXMLHeaderValue)
 	if _, err = w.Write(xmlBody); err != nil {
 		log.Errorw("failed to write body", "error", err)
-		err = ErrEncodeResponseWithDetail("failed to write body, error: " + err.Error())
+		err = ErrEncodeResponseWithDetail("failed to write body, object_name: " + reqCtx.objectName + "bucket_name: " + reqCtx.bucketName + ",error: " + err.Error())
 		return
 	}
 	log.Debugw("succeed to query upload progress", "xml_info", xmlInfo)
@@ -858,12 +858,12 @@ func (g *GateModular) getObjectByUniversalEndpointHandler(w http.ResponseWriter,
 	// TODO get from config
 	spID, err := g.getSPID()
 	if err != nil {
-		err = ErrConsensusWithDetail("getSPID error: " + err.Error())
+		err = ErrConsensusWithDetail("failed to getSPID, object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + " ,error: " + err.Error())
 		return
 	}
 	bucketSPID, err := util.GetBucketPrimarySPID(reqCtx.Context(), g.baseApp.Consensus(), getBucketInfoRes.GetBucketInfo())
 	if err != nil {
-		err = ErrConsensusWithDetail("GetBucketPrimarySPID error: " + err.Error())
+		err = ErrConsensusWithDetail("failed to GetBucketPrimarySPID, object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + ",error: " + err.Error())
 		return
 	}
 	if spID != bucketSPID {
@@ -1104,7 +1104,7 @@ func (g *GateModular) delegatePutObjectHandler(w http.ResponseWriter, r *http.Re
 	metrics.PerfPutObjectTime.WithLabelValues("gateway_agent_put_object_query_params_end").Observe(time.Since(uploadPrimaryStartTime).Seconds())
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get storage params from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get storage params from consensus, error" + err.Error())
+		err = ErrConsensusWithDetail("failed to get storage params from consensus, object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + ", error" + err.Error())
 		return
 	}
 
@@ -1218,13 +1218,13 @@ func (g *GateModular) delegatePutObjectHandler(w http.ResponseWriter, r *http.Re
 	metrics.PerfPutObjectTime.WithLabelValues("gateway_agent_put_object_query_object_end").Observe(time.Since(uploadPrimaryStartTime).Seconds())
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get object info from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get object info from consensus, error: " + err.Error())
+		err = ErrConsensusWithDetail("failed to get object info from consensus, object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + ", error: " + err.Error())
 		return
 	}
 	err = g.checkAndAssignShadowObjectInfo(reqCtx, objectInfo)
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get object info from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get object info from consensus, error: " + err.Error())
+		err = ErrConsensusWithDetail("failed to get object info from consensus, object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + ", error: " + err.Error())
 		return
 	}
 
@@ -1325,7 +1325,7 @@ func (g *GateModular) delegateResumablePutObjectHandler(w http.ResponseWriter, r
 	metrics.PerfPutObjectTime.WithLabelValues("gateway_resumable_put_object_query_params_end").Observe(time.Since(uploadPrimaryStartTime).Seconds())
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get storage params from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get storage params from consensus, error: " + err.Error())
+		err = ErrConsensusWithDetail("failed to get storage params from consensus, object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + ", error: " + err.Error())
 		return
 	}
 	if payloadSize == 0 || payloadSize > params.GetMaxPayloadSize() {
@@ -1365,7 +1365,7 @@ func (g *GateModular) delegateResumablePutObjectHandler(w http.ResponseWriter, r
 		objectInfo, err = g.baseApp.Consensus().QueryObjectInfo(reqCtx.ctx, reqCtx.bucketName, reqCtx.objectName)
 		if err != nil {
 			log.CtxErrorw(reqCtx.Context(), "failed to get object info from consensus", "error", err)
-			err = ErrConsensusWithDetail("failed to get object info from consensus, error: " + err.Error())
+			err = ErrConsensusWithDetail("failed to get object info from consensus, object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + ", error: " + err.Error())
 			return
 		}
 
@@ -1452,14 +1452,14 @@ func (g *GateModular) delegateResumablePutObjectHandler(w http.ResponseWriter, r
 	metrics.PerfPutObjectTime.WithLabelValues("gateway_resumable_put_object_query_object_end").Observe(time.Since(uploadPrimaryStartTime).Seconds())
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get object info from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get object info from consensus, error: " + err.Error())
+		err = ErrConsensusWithDetail("failed to get object info from consensus, object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + ", error: " + err.Error())
 		return
 	}
 
 	err = g.checkAndAssignShadowObjectInfo(reqCtx, objectInfo)
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get object info from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get object info from consensus, error: " + err.Error())
+		err = ErrConsensusWithDetail("failed to get object info from consensus, object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + ", error: " + err.Error())
 		return
 	}
 
@@ -1675,7 +1675,7 @@ func (g *GateModular) delegateCreateFolderHandler(w http.ResponseWriter, r *http
 
 	if _, err = w.Write(respBytes); err != nil {
 		log.Errorw("failed to write body", "error", err)
-		err = ErrEncodeResponseWithDetail("failed to write body, error: " + err.Error())
+		err = ErrEncodeResponseWithDetail("failed to write body, object_name: " + reqCtx.objectName + "bucket_name: " + reqCtx.bucketName + ", error: " + err.Error())
 		return
 	}
 	log.Debugw("succeed to delegate create folder", "xml_info", respBytes)

--- a/modular/gater/query_util.go
+++ b/modular/gater/query_util.go
@@ -2,6 +2,7 @@ package gater
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -64,19 +65,19 @@ func (g *GateModular) getObjectChainMeta(ctx context.Context, objectName, bucket
 	objectInfo, err := g.baseApp.Consensus().QueryObjectInfo(ctx, bucketName, objectName)
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get object info from consensus", "error", err)
-		return nil, nil, nil, ErrConsensusWithDetail("failed to get object info from consensus, error: " + err.Error())
+		return nil, nil, nil, ErrConsensusWithDetail("failed to get object info from consensus, object_name: " + objectName + ", bucket_name: " + bucketName + ", error: " + err.Error())
 	}
 
 	bucketInfo, err := g.baseApp.Consensus().QueryBucketInfo(ctx, objectInfo.GetBucketName())
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get bucket info from consensus", "error", err)
-		return nil, nil, nil, ErrConsensusWithDetail("failed to get bucket info from consensus, error: " + err.Error())
+		return nil, nil, nil, ErrConsensusWithDetail("failed to get bucket info from consensus, object_name: " + objectName + ", bucket_name: " + bucketName + ", error: " + err.Error())
 	}
 
 	params, err := g.baseApp.Consensus().QueryStorageParamsByTimestamp(ctx, objectInfo.GetLatestUpdatedTime())
 	if err != nil {
 		log.CtxErrorw(ctx, "failed to get storage params", "error", err)
-		return nil, nil, nil, ErrConsensusWithDetail("failed to get storage params, error: " + err.Error())
+		return nil, nil, nil, ErrConsensusWithDetail("failed to get storage params, object_name: " + objectName + ", bucket_name: " + bucketName + "GetLatestUpdatedTime: " + fmt.Sprint(objectInfo.GetLatestUpdatedTime()) + ", error: " + err.Error())
 	}
 
 	return objectInfo, bucketInfo, params, nil


### PR DESCRIPTION
### Description

Add detailed logs including bucket_name, obejct_name etc. to 4 kinds of special logs that does not have context.

### Rationale

There are 4 special kinds of logs that need to record the detail, therefore had to register the log in gfsperrors at the time of invocation. These logs does not have context come with them, making debug difficult. Additional logs about bucket name and object names can provide more details.

### Example
original:
err = ErrConsensusWithDetail("failed to get object info from consensus,  error: " + err.Error())

updated:
err = ErrConsensusWithDetail("failed to get object info from consensus, object_name: " +objectInfo.objectName + ", bucket_name: " + objectInfo.bucketName + ",  error: " + err.Error())

### Changes

Notable changes: 
* adding more logs to gater module

### Potential Impacts
