### PR TITLE
fix: no such object error code

### DIFF
--- a/modular/gater/errors.go
+++ b/modular/gater/errors.go
@@ -80,5 +80,5 @@ func ErrConsensusWithDetail(detail string) *gfsperrors.GfSpError {
 }
 
 func ErrConsensusNotFoundWithDetail(detail string) *gfsperrors.GfSpError {
-	return gfsperrors.Register(module.GateModularName, http.StatusNotFound, 55001, detail)
+	return gfsperrors.Register(module.GateModularName, http.StatusNotFound, 55002, detail)
 }

--- a/modular/gater/errors.go
+++ b/modular/gater/errors.go
@@ -78,3 +78,7 @@ func ErrNotifySwapOutWithDetail(detail string) *gfsperrors.GfSpError {
 func ErrConsensusWithDetail(detail string) *gfsperrors.GfSpError {
 	return gfsperrors.Register(module.GateModularName, http.StatusInternalServerError, 55001, detail)
 }
+
+func ErrConsensusNotFoundWithDetail(detail string) *gfsperrors.GfSpError {
+	return gfsperrors.Register(module.GateModularName, http.StatusNotFound, 55001, detail)
+}

--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -583,7 +583,7 @@ func (g *GateModular) downloadObject(w http.ResponseWriter, reqCtx *RequestConte
 	metrics.PerfGetObjectTimeHistogram.WithLabelValues("get_object_get_object_info_time").Observe(time.Since(getObjectTime).Seconds())
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get object info from consensus", "error", err)
-		err = ErrConsensusWithDetail("failed to get object info from consensus, object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + ", error:" + err.Error())
+		err = ErrConsensusNotFoundWithDetail("failed to get object info from consensus, object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + ", error:" + err.Error())
 		return err
 	}
 

--- a/modular/gater/object_handler.go
+++ b/modular/gater/object_handler.go
@@ -583,7 +583,11 @@ func (g *GateModular) downloadObject(w http.ResponseWriter, reqCtx *RequestConte
 	metrics.PerfGetObjectTimeHistogram.WithLabelValues("get_object_get_object_info_time").Observe(time.Since(getObjectTime).Seconds())
 	if err != nil {
 		log.CtxErrorw(reqCtx.Context(), "failed to get object info from consensus", "error", err)
-		err = ErrConsensusNotFoundWithDetail("failed to get object info from consensus, object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + ", error:" + err.Error())
+		if strings.Contains(err.Error(), "No such object") {
+			err = ErrConsensusNotFoundWithDetail("failed to get object info from consensus, the object may be deleted. object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + ", error:" + err.Error())
+		} else {
+			err = ErrConsensusWithDetail("failed to get object info from consensus, object_name: " + reqCtx.objectName + ", bucket_name: " + reqCtx.bucketName + ", error:" + err.Error())
+		}
 		return err
 	}
 


### PR DESCRIPTION
### Description

replace error code from 500 to 404 when object is not found

### Rationale

```
"gater/object_handler.go:437","msg":"HttpStatusCode[500] action[GetObject] 
\"inner_code\":55001,\"description\":\"failed to get object info from consensus, 
error:rpc error: code = Unknown desc = No such object: unknown request\"
```

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* replace error code from 500 to 404 when object is not found

### Potential Impacts
* QA