### PR TITLE
feat: update deps to stay with go 1.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ install-go-test-coverage:
 	go install github.com/vladopajic/go-test-coverage/v2@latest
 
 install-tools:
-	go install go.uber.org/mock/mockgen@latest
+	go install go.uber.org/mock/mockgen@v0.1.0
 	go install github.com/bufbuild/buf/cmd/buf@v1.28.0
 	go install github.com/cosmos/gogoproto/protoc-gen-gocosmos@latest
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Failure: plugin gocosmos: could not find protoc plugin for name gocosmos - pleas
 GO111MODULE=on GOBIN=/usr/local/go/bin go install github.com/cosmos/gogoproto/protoc-gen-gocosmos@latest
 
 # if you want to execute unit test of sp, you should execute the following command, assumed that you installed golang in /usr/local/go/bin. Other OS are similar.
-GO111MODULE=on GOBIN=/usr/local/go/bin go install go.uber.org/mock/mockgen@latest
+GO111MODULE=on GOBIN=/usr/local/go/bin go install go.uber.org/mock/mockgen@v0.1.0
 ```
 
 Above error messages are due to users don't set go env correctly. More info users can search `GOROOT`, `GOPATH` and `GOBIN`.


### PR DESCRIPTION
### Description

The current latest uber mockgen dependency require go 1.22, specify the version to stay with go 1.20.

### Rationale

tell us why we need these changes...

### Example

when running make install-tools:
go install go.uber.org/mock/mockgen@latest
go.uber.org/mock/mockgen
/root/go/pkg/mod/go.uber.org/mock@v0.5.0/mockgen/package_mode.go:93:21: undefined: types.Unalias
/root/go/pkg/mod/go.uber.org/mock@v0.5.0/mockgen/package_mode.go:147:17: cannot range over t.NumEmbeddeds() (value of type int)
/root/go/pkg/mod/go.uber.org/mock@v0.5.0/mockgen/package_mode.go:194:28: undefined: types.Alias
/root/go/pkg/mod/go.uber.org/mock@v0.5.0/mockgen/package_mode.go:211:18: cannot range over genericType.TypeArgs().Len() (value of type int)
/root/go/pkg/mod/go.uber.org/mock@v0.5.0/mockgen/package_mode.go:270:17: cannot range over sig.Params().Len() (value of type int)
/root/go/pkg/mod/go.uber.org/mock@v0.5.0/mockgen/package_mode.go:303:17: cannot range over sig.Results().Len() (value of type int)
note: module requires Go 1.22
make: *** [Makefile:43: install-tools] Error 1

### Changes

Notable changes: 
* dependency

### Potential Impacts
* build install tools