### PR TITLE
feat: fix gc objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ install-go-test-coverage:
 	go install github.com/vladopajic/go-test-coverage/v2@latest
 
 install-tools:
-	go install go.uber.org/mock/mockgen@latest
+	go install go.uber.org/mock/mockgen@v0.1.0
 	go install github.com/bufbuild/buf/cmd/buf@v1.28.0
 	go install github.com/cosmos/gogoproto/protoc-gen-gocosmos@latest
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Failure: plugin gocosmos: could not find protoc plugin for name gocosmos - pleas
 GO111MODULE=on GOBIN=/usr/local/go/bin go install github.com/cosmos/gogoproto/protoc-gen-gocosmos@latest
 
 # if you want to execute unit test of sp, you should execute the following command, assumed that you installed golang in /usr/local/go/bin. Other OS are similar.
-GO111MODULE=on GOBIN=/usr/local/go/bin go install go.uber.org/mock/mockgen@latest
+GO111MODULE=on GOBIN=/usr/local/go/bin go install go.uber.org/mock/mockgen@v0.1.0
 ```
 
 Above error messages are due to users don't set go env correctly. More info users can search `GOROOT`, `GOPATH` and `GOBIN`.

--- a/cmd/command/bs_data_migration/v1.0.1/fix_payment.go
+++ b/cmd/command/bs_data_migration/v1.0.1/fix_payment.go
@@ -42,7 +42,7 @@ func FixPayment(endpoint string, db *gorm.DB) error {
 			}
 			defer resp.Body.Close()
 			if resp.StatusCode != 200 {
-				httpErr = fmt.Errorf(resp.Status)
+				httpErr = fmt.Errorf("%s", resp.Status)
 				return
 			}
 			err := json.NewDecoder(resp.Body).Decode(&paymentResult)

--- a/cmd/command/query.go
+++ b/cmd/command/query.go
@@ -218,7 +218,7 @@ func (w *CMDWrapper) queryTasksAction(ctx *cli.Context) error {
 		fmt.Printf("failed to query task due to no task, endpoint:%v, key:%v\n", endpoint, key)
 	}
 	for _, info := range infos {
-		fmt.Printf(info + "\n")
+		fmt.Printf("%s"+"\n", info)
 	}
 	return nil
 }

--- a/core/piecestore/piecestore.go
+++ b/core/piecestore/piecestore.go
@@ -48,4 +48,7 @@ type PieceStore interface {
 	// DeletePiece deletes the piece data from piece store, it can delete
 	// segment or ec piece data.
 	DeletePiece(ctx context.Context, key string) error
+	// DeletePiecesByPrefix deletes pieces data from piece store, it can delete
+	// segment or ec piece data.
+	DeletePiecesByPrefix(ctx context.Context, key string) error
 }

--- a/core/piecestore/piecestore_mock.go
+++ b/core/piecestore/piecestore_mock.go
@@ -205,6 +205,20 @@ func (mr *MockPieceStoreMockRecorder) DeletePiece(ctx, key any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePiece", reflect.TypeOf((*MockPieceStore)(nil).DeletePiece), ctx, key)
 }
 
+// DeletePiecesByPrefix mocks base method.
+func (m *MockPieceStore) DeletePiecesByPrefix(ctx context.Context, key string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeletePiecesByPrefix", ctx, key)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeletePiecesByPrefix indicates an expected call of DeletePiecesByPrefix.
+func (mr *MockPieceStoreMockRecorder) DeletePiecesByPrefix(ctx, key any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePiecesByPrefix", reflect.TypeOf((*MockPieceStore)(nil).DeletePiecesByPrefix), ctx, key)
+}
+
 // GetPiece mocks base method.
 func (m *MockPieceStore) GetPiece(ctx context.Context, key string, offset, limit int64) ([]byte, error) {
 	m.ctrl.T.Helper()

--- a/modular/executor/execute_gc.go
+++ b/modular/executor/execute_gc.go
@@ -201,7 +201,6 @@ func (e *ExecuteModular) HandleGCObjectTask(ctx context.Context, task coretask.G
 		currentGCBlockID   uint64
 		currentGCObjectID  uint64
 		responseEndBlockID uint64
-		storageParams      *storagetypes.Params
 		gcObjectNumber     int
 		tryAgainLater      bool
 		taskIsCanceled     bool
@@ -254,30 +253,18 @@ func (e *ExecuteModular) HandleGCObjectTask(ctx context.Context, task coretask.G
 	}
 
 	for _, object := range waitingGCObjects {
-		if storageParams, err = e.baseApp.Consensus().QueryStorageParamsByTimestamp(
-			context.Background(), object.GetObjectInfo().GetCreateAt()); err != nil {
-			log.Errorw("failed to query storage params", "task_info", task.Info(), "error", err)
-			return
-		}
-
 		currentGCBlockID = uint64(object.GetDeleteAt())
 		objectInfo := object.GetObjectInfo()
-		objectVersion := objectInfo.Version
 		currentGCObjectID = objectInfo.Id.Uint64()
 		if currentGCBlockID < task.GetCurrentBlockNumber() {
 			log.Errorw("skip gc object", "object_info", objectInfo,
 				"task_current_gc_block_id", task.GetCurrentBlockNumber())
 			continue
 		}
-		segmentCount := e.baseApp.PieceOp().SegmentPieceCount(objectInfo.GetPayloadSize(),
-			storageParams.VersionedParams.GetMaxSegmentSize())
-		for segIdx := uint32(0); segIdx < segmentCount; segIdx++ {
-			pieceKey := e.baseApp.PieceOp().SegmentPieceKey(currentGCObjectID, segIdx, objectVersion)
-			// ignore this delete api error, TODO: refine gc workflow by enrich metadata index.
-			deleteErr := e.baseApp.PieceStore().DeletePiece(ctx, pieceKey)
-			log.CtxDebugw(ctx, "delete the primary sp pieces", "object_info", objectInfo,
-				"piece_key", pieceKey, "error", deleteErr)
-		}
+		segmentPieceKeyPrefix := fmt.Sprintf("s%d_", currentGCObjectID)
+		deleteErr := e.baseApp.PieceStore().DeletePiecesByPrefix(ctx, segmentPieceKeyPrefix)
+		log.CtxDebugw(ctx, "delete the primary sp pieces", "object_info", objectInfo,
+			"piece_key_prefix", segmentPieceKeyPrefix, "error", deleteErr)
 		bucketInfo, err := e.baseApp.GfSpClient().GetBucketInfoByBucketName(ctx, objectInfo.BucketName)
 		if err != nil || bucketInfo == nil {
 			log.Errorw("failed to get bucket by bucket name", "bucket_name", objectInfo.BucketName, "error", err)
@@ -290,35 +277,30 @@ func (e *ExecuteModular) HandleGCObjectTask(ctx context.Context, task coretask.G
 		}
 
 		var redundancyIndex int32 = -1
+		// since in GC the object will be completely deleted, simply find all pieces with the piece key prefix and remove them
+		ECPieceKeyPrefix := fmt.Sprintf("e%d_", currentGCObjectID)
 		if len(gvg.GetSecondarySpIds()) != 0 {
 			for rIdx, sspId := range gvg.GetSecondarySpIds() {
 				if spId == sspId {
 					redundancyIndex = int32(rIdx)
-					for segIdx := uint32(0); segIdx < segmentCount; segIdx++ {
-						pieceKey := e.baseApp.PieceOp().ECPieceKey(currentGCObjectID, segIdx, uint32(rIdx), objectVersion)
-						if objectInfo.GetRedundancyType() == storagetypes.REDUNDANCY_REPLICA_TYPE {
-							pieceKey = e.baseApp.PieceOp().SegmentPieceKey(objectInfo.Id.Uint64(), segIdx, objectVersion)
-						}
-						// ignore this delete api error, TODO: refine gc workflow by enrich metadata index.
-						deleteErr := e.baseApp.PieceStore().DeletePiece(ctx, pieceKey)
-						log.CtxDebugw(ctx, "delete the secondary sp pieces",
-							"object_info", objectInfo, "piece_key", pieceKey, "error", deleteErr)
-					}
+					// ignore this delete api error, TODO: refine gc workflow by enrich metadata index.
+					deleteErr := e.baseApp.PieceStore().DeletePiecesByPrefix(ctx, ECPieceKeyPrefix)
+					log.CtxDebugw(ctx, "delete the secondary sp pieces by prefix",
+						"object_info", objectInfo, "piece_key_prefix", ECPieceKeyPrefix, "error", deleteErr)
 				}
 			}
 		} else {
-			// if failed to get secondary sps, iterate through all files with key prefix to delete possible files in storage and metadata in sp
-			pieceKeyPrefix := fmt.Sprintf("e%d_", currentGCObjectID)
-			deleteErr := e.baseApp.PieceStore().DeletePiecesByPrefix(ctx, pieceKeyPrefix)
-			log.CtxDebugw(ctx, "delete the secondary sp pieces by prefix",
-				"object_info", objectInfo, "piece_key_prefix", pieceKeyPrefix, "error", deleteErr)
+			// if failed to get secondary sps, check the current sp
+			deleteErr := e.baseApp.PieceStore().DeletePiecesByPrefix(ctx, ECPieceKeyPrefix)
+			log.CtxDebugw(ctx, "delete the sp pieces by prefix in current sp when secondary sp not found",
+				"object_info", objectInfo, "piece_key_prefix", ECPieceKeyPrefix, "error", deleteErr)
 
 			// signal as delete any integrity meta related with the object
 			redundancyIndex = math.MaxInt32
 		}
 
 		// ignore this delete api error, TODO: refine gc workflow by enrich metadata index
-		deleteErr := e.baseApp.GfSpDB().DeleteObjectIntegrity(objectInfo.Id.Uint64(), redundancyIndex)
+		deleteErr = e.baseApp.GfSpDB().DeleteObjectIntegrity(objectInfo.Id.Uint64(), redundancyIndex)
 		log.CtxDebugw(ctx, "delete the object integrity meta", "object_info", objectInfo, "error", deleteErr)
 		task.SetCurrentBlockNumber(currentGCBlockID)
 		task.SetLastDeletedObjectId(currentGCObjectID)

--- a/modular/executor/executor_task_test.go
+++ b/modular/executor/executor_task_test.go
@@ -521,32 +521,6 @@ func TestExecuteModular_HandleGCObjectTask(t *testing.T) {
 			},
 		},
 		{
-			name: "failed to query storage params",
-			task: &gfsptask.GfSpGCObjectTask{
-				Task: &gfsptask.GfSpTask{},
-			},
-			fn: func() *ExecuteModular {
-				e := setup(t)
-				ctrl := gomock.NewController(t)
-				m := gfspclient.NewMockGfSpClientAPI(ctrl)
-				waitingGCObjects := []*metadatatypes.Object{
-					{
-						ObjectInfo: &storagetypes.ObjectInfo{Id: sdkmath.NewUint(1)},
-					},
-				}
-				m.EXPECT().ListDeletedObjectsByBlockNumberRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-					gomock.Any()).Return(waitingGCObjects, uint64(0), nil).Times(1)
-				m.EXPECT().ReportTask(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-				e.baseApp.SetGfSpClient(m)
-
-				m1 := consensus.NewMockConsensus(ctrl)
-				m1.EXPECT().QueryStorageParamsByTimestamp(gomock.Any(), gomock.Any()).Return(nil, mockErr).Times(1)
-				m1.EXPECT().QuerySP(gomock.Any(), gomock.Any()).Return(&sptypes.StorageProvider{Id: 1}, nil).Times(1)
-				e.baseApp.SetConsensus(m1)
-				return e
-			},
-		},
-		{
 			name: "failed to get bucket by bucket name",
 			task: &gfsptask.GfSpGCObjectTask{
 				Task:               &gfsptask.GfSpTask{},
@@ -568,18 +542,14 @@ func TestExecuteModular_HandleGCObjectTask(t *testing.T) {
 				e.baseApp.SetGfSpClient(m)
 
 				m1 := consensus.NewMockConsensus(ctrl)
-				m1.EXPECT().QueryStorageParamsByTimestamp(gomock.Any(), gomock.Any()).Return(&storagetypes.Params{
-					VersionedParams: storagetypes.VersionedParams{MaxSegmentSize: 10}}, nil).Times(1)
 				m1.EXPECT().QuerySP(gomock.Any(), gomock.Any()).Return(&sptypes.StorageProvider{Id: 1}, nil).Times(1)
 				e.baseApp.SetConsensus(m1)
 
 				m2 := piecestore.NewMockPieceOp(ctrl)
-				m2.EXPECT().SegmentPieceCount(gomock.Any(), gomock.Any()).Return(uint32(1)).Times(1)
-				m2.EXPECT().SegmentPieceKey(gomock.Any(), gomock.Any(), gomock.Any()).Return("test").Times(1)
 				e.baseApp.SetPieceOp(m2)
 
 				m3 := piecestore.NewMockPieceStore(ctrl)
-				m3.EXPECT().DeletePiece(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				m3.EXPECT().DeletePiecesByPrefix(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				e.baseApp.SetPieceStore(m3)
 				return e
 			},
@@ -608,18 +578,14 @@ func TestExecuteModular_HandleGCObjectTask(t *testing.T) {
 				e.baseApp.SetGfSpClient(m)
 
 				m1 := consensus.NewMockConsensus(ctrl)
-				m1.EXPECT().QueryStorageParamsByTimestamp(gomock.Any(), gomock.Any()).Return(&storagetypes.Params{
-					VersionedParams: storagetypes.VersionedParams{MaxSegmentSize: 10}}, nil).Times(1)
 				m1.EXPECT().QuerySP(gomock.Any(), gomock.Any()).Return(&sptypes.StorageProvider{Id: 1}, nil).Times(1)
 				e.baseApp.SetConsensus(m1)
 
 				m2 := piecestore.NewMockPieceOp(ctrl)
-				m2.EXPECT().SegmentPieceCount(gomock.Any(), gomock.Any()).Return(uint32(1)).Times(1)
-				m2.EXPECT().SegmentPieceKey(gomock.Any(), gomock.Any(), gomock.Any()).Return("test").Times(1)
 				e.baseApp.SetPieceOp(m2)
 
 				m3 := piecestore.NewMockPieceStore(ctrl)
-				m3.EXPECT().DeletePiece(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				m3.EXPECT().DeletePiecesByPrefix(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				e.baseApp.SetPieceStore(m3)
 				return e
 			},
@@ -676,19 +642,14 @@ func TestExecuteModular_HandleGCObjectTask(t *testing.T) {
 				e.baseApp.SetGfSpClient(m)
 
 				m1 := consensus.NewMockConsensus(ctrl)
-				m1.EXPECT().QueryStorageParamsByTimestamp(gomock.Any(), gomock.Any()).Return(&storagetypes.Params{
-					VersionedParams: storagetypes.VersionedParams{MaxSegmentSize: 10}}, nil).Times(1)
 				m1.EXPECT().QuerySP(gomock.Any(), gomock.Any()).Return(&sptypes.StorageProvider{Id: 1}, nil).Times(1)
 				e.baseApp.SetConsensus(m1)
 
 				m2 := piecestore.NewMockPieceOp(ctrl)
-				m2.EXPECT().SegmentPieceCount(gomock.Any(), gomock.Any()).Return(uint32(1)).Times(1)
-				m2.EXPECT().SegmentPieceKey(gomock.Any(), gomock.Any(), gomock.Any()).Return("test").Times(1)
-				m2.EXPECT().ECPieceKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("test").Times(1)
 				e.baseApp.SetPieceOp(m2)
 
 				m3 := piecestore.NewMockPieceStore(ctrl)
-				m3.EXPECT().DeletePiece(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+				m3.EXPECT().DeletePiecesByPrefix(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 				e.baseApp.SetPieceStore(m3)
 
 				m4 := corespdb.NewMockSPDB(ctrl)

--- a/store/piecestore/piece/api.go
+++ b/store/piecestore/piece/api.go
@@ -14,6 +14,7 @@ type PieceAPI interface {
 	Get(ctx context.Context, key string, offset, limit int64) (io.ReadCloser, error)
 	Put(ctx context.Context, key string, reader io.Reader) error
 	Delete(ctx context.Context, key string) error
+	DeleteByPrefix(ctx context.Context, key string) (uint64, error)
 }
 
 type PieceStore struct {
@@ -33,6 +34,11 @@ func (p *PieceStore) Put(ctx context.Context, key string, reader io.Reader) erro
 // Delete one piece in PieceStore
 func (p *PieceStore) Delete(ctx context.Context, key string) error {
 	return p.storeAPI.DeleteObject(ctx, key)
+}
+
+// DeleteByPrefix deletes several pieces in PieceStore and returns deleted size
+func (p *PieceStore) DeleteByPrefix(ctx context.Context, key string) (uint64, error) {
+	return p.storeAPI.DeleteObjectsByPrefix(ctx, key)
 }
 
 // Head returns piece info in PieceStore

--- a/store/piecestore/piece/api_mock.go
+++ b/store/piecestore/piece/api_mock.go
@@ -54,6 +54,21 @@ func (mr *MockPieceAPIMockRecorder) Delete(ctx, key any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockPieceAPI)(nil).Delete), ctx, key)
 }
 
+// DeleteByPrefix mocks base method.
+func (m *MockPieceAPI) DeleteByPrefix(ctx context.Context, key string) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteByPrefix", ctx, key)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteByPrefix indicates an expected call of DeleteByPrefix.
+func (mr *MockPieceAPIMockRecorder) DeleteByPrefix(ctx, key any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByPrefix", reflect.TypeOf((*MockPieceAPI)(nil).DeleteByPrefix), ctx, key)
+}
+
 // Get mocks base method.
 func (m *MockPieceAPI) Get(ctx context.Context, key string, offset, limit int64) (io.ReadCloser, error) {
 	m.ctrl.T.Helper()

--- a/store/piecestore/storage/disk_file.go
+++ b/store/piecestore/storage/disk_file.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -140,6 +141,36 @@ func (d *diskFileStore) DeleteObject(ctx context.Context, key string) error {
 		err = nil
 	}
 	return err
+}
+
+func (d *diskFileStore) DeleteObjectsByPrefix(ctx context.Context, key string) (uint64, error) {
+	dirEntries, err := os.ReadDir(d.root)
+	if err != nil {
+		log.Errorw("DeleteObjectsByPrefix read directory error", "error", err)
+		return 0, err
+	}
+
+	var (
+		size uint64
+		info fs.FileInfo
+	)
+
+	for _, dirEntry := range dirEntries {
+		if strings.HasPrefix(dirEntry.Name(), key) {
+			err = d.DeleteObject(ctx, dirEntry.Name())
+			if err != nil {
+				log.Errorw("remove single file by prefix error", "error", err)
+			} else {
+				info, err = dirEntry.Info()
+				if err != nil {
+					log.Errorw("get dirEntry info error", "error", err)
+				}
+				size += uint64(info.Size())
+			}
+		}
+	}
+
+	return size, nil
 }
 
 func (d *diskFileStore) HeadBucket(ctx context.Context) error {

--- a/store/piecestore/storage/interface.go
+++ b/store/piecestore/storage/interface.go
@@ -21,6 +21,8 @@ type ObjectStorage interface {
 	PutObject(ctx context.Context, key string, reader io.Reader) error
 	// DeleteObject deletes an object
 	DeleteObject(ctx context.Context, key string) error
+	// DeleteObjectsByPrefix deletes objects by prefix
+	DeleteObjectsByPrefix(ctx context.Context, key string) (uint64, error)
 
 	// HeadBucket determines if a bucket exists and have permission to access it
 	HeadBucket(ctx context.Context) error

--- a/store/piecestore/storage/interface_mock.go
+++ b/store/piecestore/storage/interface_mock.go
@@ -69,6 +69,21 @@ func (mr *MockObjectStorageMockRecorder) DeleteObject(ctx, key any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteObject", reflect.TypeOf((*MockObjectStorage)(nil).DeleteObject), ctx, key)
 }
 
+// DeleteObjectsByPrefix mocks base method.
+func (m *MockObjectStorage) DeleteObjectsByPrefix(ctx context.Context, key string) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteObjectsByPrefix", ctx, key)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteObjectsByPrefix indicates an expected call of DeleteObjectsByPrefix.
+func (mr *MockObjectStorageMockRecorder) DeleteObjectsByPrefix(ctx, key any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteObjectsByPrefix", reflect.TypeOf((*MockObjectStorage)(nil).DeleteObjectsByPrefix), ctx, key)
+}
+
 // GetObject mocks base method.
 func (m *MockObjectStorage) GetObject(ctx context.Context, key string, offset, limit int64) (io.ReadCloser, error) {
 	m.ctrl.T.Helper()

--- a/store/piecestore/storage/s3.go
+++ b/store/piecestore/storage/s3.go
@@ -177,7 +177,7 @@ func (s *s3Store) DeleteObjectsByPrefix(ctx context.Context, key string) (uint64
 		}
 		if deleteObjectsOutput != nil {
 			for _, deletedObj := range deleteObjectsOutput.Deleted {
-				size += objectKeySizeMap[*deletedObj.Key]
+				size += objectKeySizeMap[*(deletedObj.Key)]
 			}
 		}
 	}

--- a/store/piecestore/storage/s3.go
+++ b/store/piecestore/storage/s3.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"math"
 	"math/rand"
 	"net"
 	"net/http"
@@ -142,38 +141,47 @@ func (s *s3Store) DeleteObject(ctx context.Context, key string) error {
 }
 
 func (s *s3Store) DeleteObjectsByPrefix(ctx context.Context, key string) (uint64, error) {
-	objs, err := s.ListObjects(ctx, key, "", "", math.MaxUint64)
-	if err != nil {
-		log.Errorw("DeleteObjectsByPrefix list objects error", "error", err)
-		return 0, err
-	}
-
 	var (
-		objectIdentifiers []*s3.ObjectIdentifier
-		objectKeySizeMap  map[string]uint64
-		size              uint64
+		objectIdentifiers    []*s3.ObjectIdentifier
+		objectKeySizeMap     map[string]uint64
+		continueDeleteObject = true
+		batchSize            = int64(1000)
+		size                 uint64
 	)
-	for _, obj := range objs {
-		objKey := obj.Key()
-		objectIdentifiers = append(objectIdentifiers, &s3.ObjectIdentifier{Key: &objKey})
-		objectKeySizeMap[obj.Key()] = uint64(obj.Size())
-	}
 
-	deleteParams := s3.Delete{Objects: make([]*s3.ObjectIdentifier, 0)}
-	param := &s3.DeleteObjectsInput{
-		Bucket: aws.String(s.bucketName),
-		Delete: &deleteParams,
-	}
-	deleteObjectsOutput, err := s.api.DeleteObjectsWithContext(ctx, param)
-	if err != nil {
-		log.Errorw("DeleteObjectsByPrefix delete objects with context error", "error", err)
-	}
-	if deleteObjectsOutput != nil {
-		for _, deletedObj := range deleteObjectsOutput.Deleted {
-			size += objectKeySizeMap[*deletedObj.Key]
+	for continueDeleteObject {
+		objs, err := s.ListObjects(ctx, key, "", "", batchSize)
+		if err != nil {
+			log.Errorw("DeleteObjectsByPrefix list objects error", "error", err)
+			return size, err
+		}
+
+		if int64(len(objs)) < batchSize {
+			continueDeleteObject = false
+		}
+
+		for _, obj := range objs {
+			objKey := obj.Key()
+			objectIdentifiers = append(objectIdentifiers, &s3.ObjectIdentifier{Key: &objKey})
+			objectKeySizeMap[obj.Key()] = uint64(obj.Size())
+		}
+
+		deleteParams := s3.Delete{Objects: make([]*s3.ObjectIdentifier, 0)}
+		param := &s3.DeleteObjectsInput{
+			Bucket: aws.String(s.bucketName),
+			Delete: &deleteParams,
+		}
+		deleteObjectsOutput, err := s.api.DeleteObjectsWithContext(ctx, param)
+		if err != nil {
+			log.Errorw("DeleteObjectsByPrefix delete objects with context error", "error", err)
+		}
+		if deleteObjectsOutput != nil {
+			for _, deletedObj := range deleteObjectsOutput.Deleted {
+				size += objectKeySizeMap[*deletedObj.Key]
+			}
 		}
 	}
-	return size, err
+	return size, nil
 }
 
 func (s *s3Store) HeadBucket(ctx context.Context) error {

--- a/store/sqldb/object_integrity.go
+++ b/store/sqldb/object_integrity.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"time"
 
@@ -232,10 +233,17 @@ func (s *SpDBImpl) DeleteObjectIntegrity(objectID uint64, redundancyIndex int32)
 	}()
 
 	shardTableName := GetIntegrityMetasTableName(objectID)
-	err = s.db.Table(shardTableName).Delete(&IntegrityMetaTable{
-		ObjectID:        objectID, // should be the primary key
-		RedundancyIndex: redundancyIndex,
-	}).Error
+	if redundancyIndex == math.MaxInt32 {
+		// delete any integrity meta related with object id
+		err = s.db.Table(shardTableName).Delete(&IntegrityMetaTable{
+			ObjectID: objectID, // should be the primary key
+		}).Error
+	} else {
+		err = s.db.Table(shardTableName).Delete(&IntegrityMetaTable{
+			ObjectID:        objectID, // should be the primary key
+			RedundancyIndex: redundancyIndex,
+		}).Error
+	}
 	return err
 }
 


### PR DESCRIPTION
### Description

Currently in sp, if an object is deleted within the same tx as its local virtual group (lvg), the async GC Task will have issue finding its secondary sps, as this info is only available by using logic objectId -> lvg -> gvg -> secondary sps.

In this case, it used to be that the data in secondary sp's data storage will not be removed. Now updating logic for all sps to check for files that have prefix related to the object (as "e{objectid}_"), and remove all related files.

### Rationale

Update logic of GC 

### Example
https://testnet.greenfieldscan.com/tx/0x2a34610146b15f60728e79b96181dc2af60825578822f70b913348b6cb8bed28
This link is an example of object & lvg in the same tx.

### Changes

Notable changes: 
* GC Task
* new data storage methods

### Potential Impacts
* GC Task