### PR TITLE
fix: recovery task setups

### DIFF
--- a/.github/workflows/code-lint.yml
+++ b/.github/workflows/code-lint.yml
@@ -33,7 +33,7 @@ jobs:
           version: 1.14.0
           buf_user: "${{ secrets.BUF_REGISTRY_USER }}"
           buf_api_token: "${{ secrets.BUF_REGISTRY_SECRET }}"
-      
+
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
 
@@ -56,7 +56,7 @@ jobs:
           # Required: the version of golangci-lint is required and
           # must be specified without patch version: we always use the
           # latest patch version.
-          version: latest
+          version: v1.54
           skip-pkg-cache: true
           skip-cache: true
           skip-build-cache: true

--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -43,7 +43,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: ${IMAGE_NAME}
+          tags: ${{ env.IMAGE_NAME }}
           file: ./Dockerfile
           labels: |
             org.opencontainers.image.source=${IMAGE_SOURCE}
@@ -53,7 +53,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: ${IMAGE_NAME}:distroless
+          tags: ${{ env.IMAGE_NAME }}:distroless
           file: Dockerfile.distroless
           labels: |
             org.opencontainers.image.source=${IMAGE_SOURCE}

--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -33,29 +33,29 @@ jobs:
           make install-tools
           make buf-gen
 
-      - name: Build image
-        run: |
-          docker build . \
-          --build-arg "GH_TOKEN=${{ secrets.GH_SECRET }}" \
-          --label "org.opencontainers.image.source=${IMAGE_SOURCE}" \
-          --label "org.opencontainers.image.revision=$(git rev-parse HEAD)" \
-          --label "org.opencontainers.image.licenses=LGPL-3.0,GPL-3.0" \
-          -f ./Dockerfile -t "${IMAGE_NAME}"
-          
-          docker build . \
-          --build-arg "GH_TOKEN=${{ secrets.GH_SECRET }}" \
-          --label "org.opencontainers.image.source=${IMAGE_SOURCE}" \
-          --label "org.opencontainers.image.revision=$(git rev-parse HEAD)" \
-          --label "org.opencontainers.image.licenses=LGPL-3.0,GPL-3.0" \
-          -f ./Dockerfile.distroless -t "${IMAGE_NAME}:distroless"
 
-      - name: Log into registry
-        run: echo "${{ secrets.GH_SECRET }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Push image
-        run: |
-          VERSION=$(echo "${{ github.sha }}" | sed -e 's,.*/\(.*\),\1,')
-          docker tag $IMAGE_NAME $IMAGE_NAME:$VERSION
-          docker tag ${IMAGE_NAME}:distroless $IMAGE_NAME:$VERSION-distroless
-          docker push $IMAGE_NAME:$VERSION
-          docker push $IMAGE_NAME:$VERSION-distroless
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${IMAGE_NAME}
+          file: ./Dockerfile
+          labels: |
+            org.opencontainers.image.source=${IMAGE_SOURCE}
+            org.opencontainers.image.revision=$(git rev-parse HEAD)
+            org.opencontainers.image.licenses=LGPL-3.0,GPL-3.0
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${IMAGE_NAME}:distroless
+          file: Dockerfile.distroless
+          labels: |
+            org.opencontainers.image.source=${IMAGE_SOURCE}
+            org.opencontainers.image.revision=$(git rev-parse HEAD)
+            org.opencontainers.image.licenses=LGPL-3.0,GPL-3.0

--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -2,7 +2,7 @@ name: Docker-CI
 
 on:
   push:
-    branches: [ develop, master]
+    branches: [ develop, master, ci-*]
 
 env:
   IMAGE_NAME: ghcr.io/bnb-chain/greenfield-storage-provider-invisible

--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -5,7 +5,7 @@ on:
     branches: [ develop, master, ci-*]
 
 env:
-  IMAGE_NAME: ghcr.io/bnb-chain/greenfield-storage-provider-invisible
+  IMAGE_NAME: ghcr.io/bnb-chain/greenfield-storage-provider
   IMAGE_SOURCE: https://github.com/bnb-chain/greenfield-storage-provider
 
 jobs:
@@ -53,7 +53,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          tags: ${{ env.IMAGE_NAME }}:invisible-${{ github.sha }}
 
           file: ./Dockerfile
           labels: |
@@ -64,7 +64,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: ${{ env.IMAGE_NAME }}:distroless-${{ github.sha }}
+          tags: ${{ env.IMAGE_NAME }}:invisible-distroless-${{ github.sha }}
           file: Dockerfile.distroless
           labels: |
             org.opencontainers.image.source=${IMAGE_SOURCE}

--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -53,9 +53,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: ｜
-            ${{ env.IMAGE_NAME }}:${{ github.sha }}
-            ${{ env.IMAGE_NAME }}:latest
+          tags: ${{ env.IMAGE_NAME }}:${{ github.sha }}
 
           file: ./Dockerfile
           labels: |

--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -64,7 +64,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: ${{ env.IMAGE_NAME }}:distroless:${{ github.sha }}
+          tags: ${{ env.IMAGE_NAME }}:distroless-${{ github.sha }}
           file: Dockerfile.distroless
           labels: |
             org.opencontainers.image.source=${IMAGE_SOURCE}

--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -14,6 +14,10 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
+    permissions:
+      contents: read
+      packages: write
+
     runs-on: ${{ matrix.os }}
     if: github.event_name == 'push'
 

--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -53,7 +53,10 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: ${{ env.IMAGE_NAME }}
+          tags: ｜
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.IMAGE_NAME }}:latest
+
           file: ./Dockerfile
           labels: |
             org.opencontainers.image.source=${IMAGE_SOURCE}
@@ -63,7 +66,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: ${{ env.IMAGE_NAME }}:distroless
+          tags: ${{ env.IMAGE_NAME }}:distroless:${{ github.sha }}
           file: Dockerfile.distroless
           labels: |
             org.opencontainers.image.source=${IMAGE_SOURCE}

--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -36,6 +36,12 @@ jobs:
       - run: |
           make install-tools
           make buf-gen
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
 
       - name: Set up QEMU
@@ -53,7 +59,7 @@ jobs:
             org.opencontainers.image.source=${IMAGE_SOURCE}
             org.opencontainers.image.revision=$(git rev-parse HEAD)
             org.opencontainers.image.licenses=LGPL-3.0,GPL-3.0
-      - name: Build and push
+      - name: Build and push distroless
         uses: docker/build-push-action@v6
         with:
           push: true

--- a/base/types/gfsptask/recovery.go
+++ b/base/types/gfsptask/recovery.go
@@ -165,7 +165,7 @@ func (m *GfSpRecoverPieceTask) SetError(err error) {
 }
 
 func (m *GfSpRecoverPieceTask) EstimateLimit() corercmgr.Limit {
-	l := &gfsplimit.GfSpLimit{Memory: 2 * int64(m.GetObjectInfo().PayloadSize)}
+	l := &gfsplimit.GfSpLimit{Memory: 2 * int64(m.GetPieceSize())}
 	l.Add(LimitEstimateByPriority(m.GetPriority()))
 	return l
 }

--- a/modular/manager/recover_scheduler.go
+++ b/modular/manager/recover_scheduler.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	recoverBatchSize = 50
-	maxRecoveryRetry = 5
+	maxRecoveryRetry = 20
 	MaxRecoveryTime  = 50
 
 	recoverInterval     = 10 * time.Second

--- a/modular/manager/recover_scheduler.go
+++ b/modular/manager/recover_scheduler.go
@@ -31,7 +31,7 @@ const (
 	verifyInterval      = 3 * time.Second
 	verifyGVGQueryLimit = uint32(50)
 
-	recoverFailedObjectInterval = 20 * time.Second
+	recoverFailedObjectInterval = 5 * time.Minute
 
 	monitorRecoverTimeOut = float64(2) // 2 minute
 )

--- a/store/bsdb/object.go
+++ b/store/bsdb/object.go
@@ -481,7 +481,7 @@ func (b *BsDBImpl) ListObjectsInGVG(gvgID uint32, startAfter common.Hash, limit 
 
 		// Apply the filter
 		query += fmt.Sprintf(filterQuery, startAfter)
-		finalQuery := fmt.Sprintf("select * from( %s", query)
+		finalQuery := fmt.Sprintf("select /*+ MAX_EXECUTION_TIME(10000) */ * from( %s", query)
 		err = b.db.Table((&Object{}).TableName()).Raw(finalQuery).Find(&objects).Error
 		if err != nil {
 			// Handle error


### PR DESCRIPTION
### Description
This pr tunes the recovery task setups:
1. Update retry allowance from 5 to 20, to tolerate network connection instability when recovering files for a long continuous period of time (e.g. when executing sp exit).
2. Update logic of recover piece task memory limit from considering the whole object payload size to piece size (since the the task itself only recovers the piece, not object).

### Rationale
To have better user experience when recover files on SP.

### Example
N/A

### Changes

Notable changes: 
* recover task

### Potential Impacts
* recover task