### PR TITLE
feat: print str cleanup

### DIFF
--- a/base/gfspconfig/config.go
+++ b/base/gfspconfig/config.go
@@ -74,16 +74,40 @@ func (cfg *GfSpConfig) Apply(opts ...Option) error {
 	return nil
 }
 
-// String returns the detail GfSp configuration.
+const redactedPlaceholder = "[REDACTED]"
+
+// String returns the detail GfSp configuration with secrets redacted.
 func (cfg *GfSpConfig) String() string {
-	customize := cfg.Customize
-	cfg.Customize = nil
-	bz, err := toml.Marshal(cfg)
+	redacted := *cfg
+	redacted.Customize = nil
+
+	redacted.SpAccount = SpAccountConfig{
+		SpOperatorAddress:  cfg.SpAccount.SpOperatorAddress,
+		OperatorPrivateKey: redactIfSet(cfg.SpAccount.OperatorPrivateKey),
+		FundingPrivateKey:  redactIfSet(cfg.SpAccount.FundingPrivateKey),
+		SealPrivateKey:     redactIfSet(cfg.SpAccount.SealPrivateKey),
+		ApprovalPrivateKey: redactIfSet(cfg.SpAccount.ApprovalPrivateKey),
+		GcPrivateKey:       redactIfSet(cfg.SpAccount.GcPrivateKey),
+		BlsPrivateKey:      redactIfSet(cfg.SpAccount.BlsPrivateKey),
+	}
+
+	redacted.P2P.P2PPrivateKey = redactIfSet(cfg.P2P.P2PPrivateKey)
+
+	redacted.SpDB.Passwd = redactIfSet(cfg.SpDB.Passwd)
+	redacted.BsDB.Passwd = redactIfSet(cfg.BsDB.Passwd)
+
+	bz, err := toml.Marshal(&redacted)
 	if err != nil {
 		return ""
 	}
-	cfg.Customize = customize
 	return string(bz)
+}
+
+func redactIfSet(v string) string {
+	if v != "" {
+		return redactedPlaceholder
+	}
+	return ""
 }
 
 type ChainConfig struct {

--- a/base/gfspconfig/config_test.go
+++ b/base/gfspconfig/config_test.go
@@ -2,9 +2,12 @@ package gfspconfig
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	storeconfig "github.com/bnb-chain/greenfield-storage-provider/store/config"
 )
 
 var mockErr = errors.New("mock error")
@@ -27,4 +30,65 @@ func TestGfSpConfig_StringSuccess(t *testing.T) {
 	cfg := &GfSpConfig{Env: "mainnet"}
 	result := cfg.String()
 	assert.NotNil(t, result)
+}
+
+func TestGfSpConfig_StringRedactsSecrets(t *testing.T) {
+	cfg := &GfSpConfig{
+		Env: "mainnet",
+		SpAccount: SpAccountConfig{
+			SpOperatorAddress:  "0xABCD",
+			OperatorPrivateKey: "secret_operator",
+			FundingPrivateKey:  "secret_funding",
+			SealPrivateKey:     "secret_seal",
+			ApprovalPrivateKey: "secret_approval",
+			GcPrivateKey:       "secret_gc",
+			BlsPrivateKey:      "secret_bls",
+		},
+		P2P: P2PConfig{
+			P2PPrivateKey: "secret_p2p",
+		},
+		SpDB: storeconfig.SQLDBConfig{Passwd: "secret_spdb"},
+		BsDB: storeconfig.SQLDBConfig{Passwd: "secret_bsdb"},
+	}
+
+	result := cfg.String()
+
+	secrets := []string{
+		"secret_operator", "secret_funding", "secret_seal",
+		"secret_approval", "secret_gc", "secret_bls",
+		"secret_p2p", "secret_spdb", "secret_bsdb",
+	}
+	for _, s := range secrets {
+		assert.False(t, strings.Contains(result, s), "output must not contain plaintext secret: %s", s)
+	}
+
+	// 9 sensitive fields should each appear as [REDACTED]
+	assert.Equal(t, 9, strings.Count(result, redactedPlaceholder),
+		"output must contain exactly 9 [REDACTED] placeholders")
+
+	assert.Contains(t, result, "0xABCD", "non-secret fields must still be present")
+}
+
+func TestGfSpConfig_StringDoesNotMutateOriginal(t *testing.T) {
+	cfg := &GfSpConfig{
+		Env: "mainnet",
+		SpAccount: SpAccountConfig{
+			OperatorPrivateKey: "original_key",
+		},
+		P2P: P2PConfig{
+			P2PPrivateKey: "original_p2p",
+		},
+	}
+
+	_ = cfg.String()
+
+	assert.Equal(t, "original_key", cfg.SpAccount.OperatorPrivateKey, "String() must not mutate original config")
+	assert.Equal(t, "original_p2p", cfg.P2P.P2PPrivateKey, "String() must not mutate original config")
+}
+
+func TestGfSpConfig_StringEmptySecretsNotRedacted(t *testing.T) {
+	cfg := &GfSpConfig{Env: "mainnet"}
+	result := cfg.String()
+	assert.False(t, strings.Contains(result, redactedPlaceholder),
+		"empty secret fields should not produce [REDACTED]")
 }


### PR DESCRIPTION
### Description

Redact sensitive info from SP startup config logs.

### Rationale

GfSpConfig.String() serialized the live config into INFO logs, which could include sensitive information.
In production these logs are often centrally collected, expanding exposure.
We now serialize a shallow-copied config with non-empty secrets replaced by [REDACTED] (plus tests).

Notable changes: 
* config.go

### Potential Impacts
* stop print sensitive information