### PR TITLE
feat: specify some request's auth

### DIFF
--- a/modular/gater/request_context.go
+++ b/modular/gater/request_context.go
@@ -51,6 +51,8 @@ var skipAuthRouterNames = []string{
 	getBucketMetaRouterName,
 	listBucketsByIDsRouterName,
 	listObjectsByIDsRouterName,
+	listUserPaymentAccountsRouterName,
+	listPaymentAccountStreamsRouterName,
 }
 
 // NewRequestContext returns an instance of RequestContext, and verify the


### PR DESCRIPTION
### Description

Make payment metadata routes explicitly public to match on-chain public queries.

### Rationale

?user-payments / ?payment-buckets behaved as public due to ignored auth errors, but were not listed as public routes.
Since the underlying payment/bucket metadata is publicly queryable on-chain, we mark these routes as public in skipAuthRouterNames.
This removes intent-vs-behavior ambiguity (and keeps behavior consistent).

### Changes

Notable changes: 
* request_context.go
