### PR TITLE
 fix: bind SP task signing contexts

### DIFF
--- a/base/types/gfsptask/migrate_gvg.go
+++ b/base/types/gfsptask/migrate_gvg.go
@@ -191,10 +191,11 @@ func (m *GfSpMigrateGVGTask) SetFinished(finished bool) {
 
 func (m *GfSpMigrateGVGTask) GetSignBytes() []byte {
 	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&GfSpMigrateGVGTask{
-		BucketId:      m.GetBucketID(),
-		SrcGvg:        m.GetSrcGvg(),
-		RedundancyIdx: m.GetRedundancyIdx(),
-		ExpireTime:    m.GetExpireTime(),
+		BucketId:             m.GetBucketID(),
+		SrcGvg:               m.GetSrcGvg(),
+		RedundancyIdx:        m.GetRedundancyIdx(),
+		LastMigratedObjectId: m.GetLastMigratedObjectID(),
+		ExpireTime:           m.GetExpireTime(),
 	}))
 }
 

--- a/base/types/gfsptask/migrate_gvg_test.go
+++ b/base/types/gfsptask/migrate_gvg_test.go
@@ -460,13 +460,16 @@ func TestGfSpMigrateGVGTask_SetFinished(t *testing.T) {
 
 func TestGfSpMigrateGVGTask_GetSignBytes(t *testing.T) {
 	m := &GfSpMigrateGVGTask{
-		Task:     &GfSpTask{},
-		BucketId: 1,
-		SrcGvg:   mockGVG,
-		DestGvg:  mockGVG,
-		SrcSp:    mockSP,
+		Task:                 &GfSpTask{},
+		BucketId:             1,
+		SrcGvg:               mockGVG,
+		DestGvg:              mockGVG,
+		SrcSp:                mockSP,
+		LastMigratedObjectId: 1,
 	}
-	m.GetSignBytes()
+	signBytes := m.GetSignBytes()
+	m.SetLastMigratedObjectID(2)
+	assert.NotEqual(t, signBytes, m.GetSignBytes())
 }
 
 func TestGfSpMigratePieceTask_Key(t *testing.T) {

--- a/base/types/gfsptask/recovery.go
+++ b/base/types/gfsptask/recovery.go
@@ -206,7 +206,9 @@ func (m *GfSpRecoverPieceTask) GetSignBytes() []byte {
 		PieceSize:     m.GetPieceSize(),
 		SegmentIdx:    m.GetSegmentIdx(),
 		// TODO rename EcIdx to ReplicateIdx
-		EcIdx: m.GetEcIdx(),
+		EcIdx:         m.GetEcIdx(),
+		BySuccessorSp: m.GetBySuccessorSp(),
+		GvgId:         m.GetGVGID(),
 	}
 	bz := ModuleCdc.MustMarshalJSON(fakeMsg)
 	return sdk.MustSortJSON(bz)

--- a/base/types/gfsptask/recovery_test.go
+++ b/base/types/gfsptask/recovery_test.go
@@ -325,6 +325,14 @@ func TestGfSpRecoverPieceTask_GetSignBytes(t *testing.T) {
 		Task:          &GfSpTask{},
 		ObjectInfo:    mockObjectInfo,
 		StorageParams: mockStorageParams,
+		BySuccessorSp: false,
+		GvgId:         1,
 	}
-	m.GetSignBytes()
+	signBytes := m.GetSignBytes()
+	m.SetBySuccessorSP(true)
+	assert.NotEqual(t, signBytes, m.GetSignBytes())
+
+	signBytes = m.GetSignBytes()
+	m.SetGVGID(2)
+	assert.NotEqual(t, signBytes, m.GetSignBytes())
 }

--- a/base/types/gfsptask/upload.go
+++ b/base/types/gfsptask/upload.go
@@ -698,13 +698,14 @@ func (m *GfSpReceivePieceTask) InitReceivePieceTask(gvgID uint32, object *storag
 
 func (m *GfSpReceivePieceTask) GetSignBytes() []byte {
 	fakeMsg := &GfSpReceivePieceTask{
-		ObjectInfo:    m.GetObjectInfo(),
-		StorageParams: m.GetStorageParams(),
-		Task:          &GfSpTask{CreateTime: m.GetCreateTime(), UpdateTime: m.GetUpdateTime()},
-		SegmentIdx:    m.GetSegmentIdx(),
-		RedundancyIdx: m.GetRedundancyIdx(),
-		PieceSize:     m.GetPieceSize(),
-		PieceChecksum: m.GetPieceChecksum(),
+		ObjectInfo:           m.GetObjectInfo(),
+		StorageParams:        m.GetStorageParams(),
+		Task:                 &GfSpTask{CreateTime: m.GetCreateTime(), UpdateTime: m.GetUpdateTime()},
+		SegmentIdx:           m.GetSegmentIdx(),
+		RedundancyIdx:        m.GetRedundancyIdx(),
+		PieceSize:            m.GetPieceSize(),
+		PieceChecksum:        m.GetPieceChecksum(),
+		GlobalVirtualGroupId: m.GetGlobalVirtualGroupId(),
 	}
 	bz := ModuleCdc.MustMarshalJSON(fakeMsg)
 	return sdk.MustSortJSON(bz)

--- a/base/types/gfsptask/upload_test.go
+++ b/base/types/gfsptask/upload_test.go
@@ -1295,11 +1295,14 @@ func TestInitReceivePieceTask(t *testing.T) {
 
 func TestGfSpReceivePieceTask_GetSignBytes(t *testing.T) {
 	m := &GfSpReceivePieceTask{
-		Task:          &GfSpTask{},
-		ObjectInfo:    mockObjectInfo,
-		StorageParams: mockStorageParams,
+		Task:                 &GfSpTask{},
+		ObjectInfo:           mockObjectInfo,
+		StorageParams:        mockStorageParams,
+		GlobalVirtualGroupId: 1,
 	}
-	m.GetSignBytes()
+	signBytes := m.GetSignBytes()
+	m.SetGlobalVirtualGroupID(2)
+	assert.NotEqual(t, signBytes, m.GetSignBytes())
 }
 
 func TestGfSpReceivePieceTask_Key(t *testing.T) {

--- a/modular/executor/migrate_task.go
+++ b/modular/executor/migrate_task.go
@@ -91,6 +91,10 @@ func (e *ExecuteModular) HandleMigrateGVGTask(ctx context.Context, gvgTask coret
 					"current_migrated_object_number", migratedObjectNumberInGVG,
 					"last_migrated_object_id", object.GetObject().GetObjectInfo().Id.Uint64())
 				gvgTask.SetLastMigratedObjectID(object.GetObject().GetObjectInfo().Id.Uint64())
+				if err = e.signMigrateGVGTask(ctx, gvgTask); err != nil {
+					log.CtxErrorw(ctx, "failed to sign migrate gvg task progress", "task_info", gvgTask, "error", err)
+					return
+				}
 				if err = e.ReportTask(ctx, gvgTask); err != nil { // report task is already automatically triggered.
 					log.CtxErrorw(ctx, "failed to report migrate gvg task progress", "task_info", gvgTask, "error", err)
 					return
@@ -106,6 +110,19 @@ func (e *ExecuteModular) HandleMigrateGVGTask(ctx context.Context, gvgTask coret
 			return
 		}
 	}
+}
+
+func (e *ExecuteModular) signMigrateGVGTask(ctx context.Context, gvgTask coretask.MigrateGVGTask) error {
+	task, ok := gvgTask.(*gfsptask.GfSpMigrateGVGTask)
+	if !ok {
+		return fmt.Errorf("invalid migrate gvg task type")
+	}
+	signature, err := e.baseApp.GfSpClient().SignMigrateGVG(ctx, task)
+	if err != nil {
+		return err
+	}
+	task.SetSignature(signature)
+	return nil
 }
 
 func (e *ExecuteModular) checkAndTryRenewSig(gvgTask *gfsptask.GfSpMigrateGVGTask) error {


### PR DESCRIPTION
### Description

Bind security-sensitive task fields to their signatures in `greenfield-storage-provider`

All three reports concern incomplete signature coverage for security-relevant SP task context. They are treated as P4 security hardening because exploitation requires an SP-side participant or task mutation context, with no demonstrated direct fund loss or unrestricted external attack path.

- [SRC-910](<SRC-910 bug link>): `ReceivePieceTask.GetSignBytes()` does not include `GlobalVirtualGroupId`, allowing the GVG context to be modified without invalidating the signature.
- [SRC-911](<SRC-911 bug link>): `RecoverPieceTask.GetSignBytes()` does not include `BySuccessorSp` or `GvgId`, allowing the recovery mode and GVG context to be modified without invalidating the signature.
- [SRC-913](<SRC-913 bug link>): `MigrateGVGTask.GetSignBytes()` does not include `LastMigratedObjectId`, allowing the migration cursor to be modified without invalidating the signature.


- Include `GlobalVirtualGroupId` in `ReceivePieceTask` sign bytes.
- Include `BySuccessorSp` and `GvgId` in `RecoverPieceTask` sign bytes.
- Include `LastMigratedObjectId` in `MigrateGVGTask` sign bytes.
- Re-sign migration tasks after updating `LastMigratedObjectId`.
- Add regression tests verifying these fields affect sign bytes.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...